### PR TITLE
Add release drafter

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -1,0 +1,23 @@
+name-template: 'v$RESOLVED_VERSION 🤖'
+tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'skip-changelog'
+version-resolver:
+  minor:
+    labels:
+      - 'breaking-change'
+  default: patch
+categories:
+  - title: 'Breaking changes'
+    label: 'breaking-change'
+template: |
+  ## Changes
+
+  $CHANGES
+
+  Thanks again to $CONTRIBUTORS! 🎉
+no-changes-template: 'Changes are coming soon 😎'
+sort-direction: 'ascending'
+replacers:
+  - search: '/(?:and )?@dependabot-preview(?:\[bot\])?,?/g'
+    replace: ''

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+      - bump-meilisearch-v*
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-draft-template.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DRAFTER_TOKEN }}


### PR DESCRIPTION
Will automatically create/update a release draft.

How it works:
- The release description is generated and corresponds to all the PRs titles since the previous release.
- As the description is generated on every push on `master`, don't change it manually until the final release publishment.
- If you don't want a PR to appear in the release: set the label `skip-changelog`
- If the changes you are doing on the PR are breaking: set the label `breaking change`. The minor instead of the patch will be increased. (The major will not change because MeiliSearch is not stable yet)
- If you forgot to add a label or if you want to change the title of a PR but the PR is already closed, don't panic: change what you want on the closed PR and run the job again.

More information about [release drafter](https://github.com/release-drafter/release-drafter).

NB: the secret `RELEASE_DRAFTER_TOKEN` is set 🙂