### PR TITLE
Add GHA to publish to Nuget

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to Nuget
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+publish:
+    name: Build, pack & publish
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Publish
+        uses: rohith/publish-nuget@v2
+        with:
+        PROJECT_FILE_PATH: src/Meilisearch/Meilisearch.csproj
+        NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,5 +18,5 @@ publish:
     - name: Publish
         uses: rohith/publish-nuget@v2
         with:
-        PROJECT_FILE_PATH: src/Meilisearch/Meilisearch.csproj
-        NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          PROJECT_FILE_PATH: src/Meilisearch/Meilisearch.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/README.md
+++ b/README.md
@@ -147,11 +147,17 @@ dotnet test
 
 ### Release
 
-TODO 
+MeiliSearch tools follow the [Semantic Versioning Convention](https://semver.org/).
+
+You must do a PR modifying the file [`src/Meilisearch/Meilisearch.csproj`](https://github.com/meilisearch/meilisearch-dotnet/blob/master/src/Meilisearch/Meilisearch.csproj) with the right version.
 
 ```xml
-<Version>x.x.x</Version>
+<Version>X.X.X</Version>
 ```
+
+Once the changes are merged on `master`, you can publish the current draft release via the [GitHub interface](https://github.com/meilisearch/meilisearch-dotnet/releases).
+
+A GitHub Action will be triggered and push the new package to [Nuget](https://www.nuget.org/packages/MeiliSearch/).
 
 ## 🤖 Compatibility with MeiliSearch
 

--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -2,6 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <OutputType>Library</OutputType>
+        <PackageId>MeiliSearch</PackageId>
+        <Version>0.1.0</Version>
+        <Description>.NET wrapper for MeiliSearch</Description>
+        <RepositoryUrl>https://github.com/meilisearch/meilisearch-dotnet</RepositoryUrl>
+        <PackageTags>meilisearch;dotnet;sdk</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Add GHA to publish to Nuget on each matched tag `v*` (= each new release)
- Update the `Release` part of the README (closes #5)

NB: the secret token for Nuget is added to the repo so this GHA is ready to be used!