### PR TITLE
Update Document Methods to accept Ints or strings for document ids

### DIFF
--- a/Meilisearch.sln.DotSettings.user
+++ b/Meilisearch.sln.DotSettings.user
@@ -1,12 +1,13 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=7f061c9d_002D61b5_002D43b1_002D9fc4_002Dacb521cb3f64/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Should_be_Able_to_Get_One_Document_With_Int_Id" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=3016812d_002D3355_002D4357_002D9434_002Dac001d85aa2b/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Should_Be_to_Search_A_Index_Document" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::CDAACB2F-0197-4266-B40C-D51F61136ABF::.NETCoreApp,Version=v3.1::Meilisearch.Tests.DocumentTest.Should_be_Able_to_Get_One_Document_With_Int_Id&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::CDAACB2F-0197-4266-B40C-D51F61136ABF::.NETCoreApp,Version=v3.1::Meilisearch.Tests.SearchTests.Should_Be_to_Search_A_Index_Document&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	
-	
-	
-	
-	
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=4631f27e_002Dc2b6_002D4d12_002D8d70_002D0944164e8ce7/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="All tests from Solution #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Solution /&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=f825195d_002D16f6_002D4838_002Da70e_002D75e2b801d643/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Solution /&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Meilisearch/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Meilisearch.sln.DotSettings.user
+++ b/Meilisearch.sln.DotSettings.user
@@ -1,13 +1,12 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=3016812d_002D3355_002D4357_002D9434_002Dac001d85aa2b/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Should_Be_to_Search_A_Index_Document" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=7f061c9d_002D61b5_002D43b1_002D9fc4_002Dacb521cb3f64/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Should_be_Able_to_Get_One_Document_With_Int_Id" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::CDAACB2F-0197-4266-B40C-D51F61136ABF::.NETCoreApp,Version=v3.1::Meilisearch.Tests.SearchTests.Should_Be_to_Search_A_Index_Document&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;xUnit::CDAACB2F-0197-4266-B40C-D51F61136ABF::.NETCoreApp,Version=v3.1::Meilisearch.Tests.DocumentTest.Should_be_Able_to_Get_One_Document_With_Int_Id&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=4631f27e_002Dc2b6_002D4d12_002D8d70_002D0944164e8ce7/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="All tests from Solution #2" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;Solution /&gt;&#xD;
-&lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=f825195d_002D16f6_002D4838_002Da70e_002D75e2b801d643/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;Solution /&gt;&#xD;
-&lt;/SessionState&gt;</s:String>
+	
+	
+	
+	
+	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Meilisearch/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -107,6 +107,11 @@ namespace Meilisearch
            return await this._client.GetFromJsonAsync<T>($"/indexes/{Uid}/documents/{documentId}");
         }
 
+        public async Task<T> GetDocument<T>(int documentId)
+        {
+            return await this._client.GetFromJsonAsync<T>($"/indexes/{Uid}/documents/{documentId}");
+        }
+
         /// <summary>
         /// Get documents with the allowed Query Parameters.
         /// </summary>

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -174,12 +174,8 @@ namespace Meilisearch
         /// <returns>Update status with ID to look for progress of update.</returns>
         public async Task<UpdateStatus> DeleteDocuments(IEnumerable<int> documentIds)
         {
-            // We could do
-            // var docIds = documentIds.Select(id => id.ToString())
-            // await this.DeleteDocuments(docIds)
-            // which would keep keep the code more DRY, but at the cost of casting all to a strings
-            var httpresponse = await this._client.PostAsJsonAsync($"/indexes/{Uid}/documents/delete-batch", documentIds);
-            return await httpresponse.Content.ReadFromJsonAsync<UpdateStatus>();
+            var docIds = documentIds.Select(id => id.ToString());
+            return await this.DeleteDocuments(docIds);
         }
 
         /// <summary>

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -107,6 +108,12 @@ namespace Meilisearch
            return await this._client.GetFromJsonAsync<T>($"/indexes/{Uid}/documents/{documentId}");
         }
 
+        /// <summary>
+        /// Get document by its ID
+        /// </summary>
+        /// <param name="documentId">Document Id for query</param>
+        /// <typeparam name="T">Type to return for document</typeparam>
+        /// <returns>Type if the object is availble.</returns>
         public async Task<T> GetDocument<T>(int documentId)
         {
             return await this.GetDocument<T>(documentId.ToString());
@@ -139,6 +146,11 @@ namespace Meilisearch
             return await httpresponse.Content.ReadFromJsonAsync<UpdateStatus>();
         }
 
+        /// <summary>
+        /// Delete one document by its ID
+        /// </summary>
+        /// <param name="documentId">document ID</param>
+        /// <returns>Update Status with ID to look for document.</returns>
         public async Task<UpdateStatus> DeleteOneDocument(int documentId)
         {
             return await DeleteOneDocument(documentId.ToString());
@@ -151,6 +163,21 @@ namespace Meilisearch
         /// <returns>Update status with ID to look for progress of update.</returns>
         public async Task<UpdateStatus> DeleteDocuments(IEnumerable<string> documentIds)
         {
+            var httpresponse = await this._client.PostAsJsonAsync($"/indexes/{Uid}/documents/delete-batch", documentIds);
+            return await httpresponse.Content.ReadFromJsonAsync<UpdateStatus>();
+        }
+
+        /// <summary>
+        /// Delete documents in batch.
+        /// </summary>
+        /// <param name="documentIds">List of document Id</param>
+        /// <returns>Update status with ID to look for progress of update.</returns>
+        public async Task<UpdateStatus> DeleteDocuments(IEnumerable<int> documentIds)
+        {
+            // We could do
+            // var docIds = documentIds.Select(id => id.ToString())
+            // await this.DeleteDocuments(docIds)
+            // which would keep keep the code more DRY, but at the cost of casting all to a strings
             var httpresponse = await this._client.PostAsJsonAsync($"/indexes/{Uid}/documents/delete-batch", documentIds);
             return await httpresponse.Content.ReadFromJsonAsync<UpdateStatus>();
         }

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -109,7 +109,7 @@ namespace Meilisearch
 
         public async Task<T> GetDocument<T>(int documentId)
         {
-            return await this._client.GetFromJsonAsync<T>($"/indexes/{Uid}/documents/{documentId}");
+            return await this.GetDocument<T>(documentId.ToString());
         }
 
         /// <summary>
@@ -137,6 +137,11 @@ namespace Meilisearch
         {
             var httpresponse = await this._client.DeleteAsync($"/indexes/{Uid}/documents/{documentId}");
             return await httpresponse.Content.ReadFromJsonAsync<UpdateStatus>();
+        }
+
+        public async Task<UpdateStatus> DeleteOneDocument(int documentId)
+        {
+            return await DeleteOneDocument(documentId.ToString());
         }
 
         /// <summary>

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -63,9 +63,23 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task Should_be_Able_to_Delete_one_document_with_int_id()
+        {
+            var updateStatus = await index.DeleteOneDocument(11);
+            updateStatus.UpdateId.Should().BeGreaterOrEqualTo(0);
+        }
+
+        [Fact]
         public async Task Should_be_Able_to_Delete_documents_by_ids()
         {
             var updateStatus = await index.DeleteDocuments(new[] {"12", "13", "14"});
+            updateStatus.UpdateId.Should().BeGreaterOrEqualTo(0);
+        }
+
+        [Fact]
+        public async Task Should_be_Able_to_Delete_documents_by_int_ids()
+        {
+            var updateStatus = await index.DeleteDocuments(new[] {12, 13, 14});
             updateStatus.UpdateId.Should().BeGreaterOrEqualTo(0);
         }
 

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -42,6 +42,13 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task Should_be_Able_to_Get_One_Document_With_Int_Id()
+        {
+            var documents = await index.GetDocument<Movie>(10);
+            documents.Id.Should().Be("10");
+        }
+
+        [Fact]
         public async Task Should_Be_able_to_get_Many_documents_By_Limit()
         {
             var documents = await index.GetDocuments<Movie>(new DocumentQuery {Limit = 1});


### PR DESCRIPTION
Updates the following methods to have an overload for int documentId(s)
- `GetDocument<T>`
- `DeleteOneDocument`
- `DeleteDocuments`

These methods call the string variant in order to be DRY. 
Tests added in fashion of the string variant method call.

closes #25

