### PR TITLE
Add WaitForPendingUpdate method

### DIFF
--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -224,25 +224,29 @@ namespace Meilisearch
         /// <summary>
         /// Waits until the asynchronous task was done.
         /// </summary>
+        /// <param name="updateId">Unique identifier of the asynchronous task.</param>
+        /// <param name="timeoutMs">Timeout in millisecond.</param>
+        /// <param name="intervalMs">Interval in millisecond between each check.</param>
         /// <returns>Returns the status of asynchronous task.</returns>
         public async Task<UpdateStatus> WaitForPendingUpdate(
             int updateId,
             double timeoutMs = 5000.0,
-            int intervalMs = 50
-        )
+            int intervalMs = 50)
         {
             DateTime endingTime = DateTime.Now.AddMilliseconds(timeoutMs);
 
             while (DateTime.Now < endingTime)
             {
-                var response = await GetUpdateStatus(updateId);
+                var response = await this.GetUpdateStatus(updateId);
 
                 if (response.Status != "enqueued")
                 {
                     return response;
                 }
+
                 await Task.Delay(intervalMs);
             }
+
             throw new Exception("The task " + updateId.ToString() + " timed out.");
         }
 

--- a/tests/Meilisearch.Tests/StatusTests.cs
+++ b/tests/Meilisearch.Tests/StatusTests.cs
@@ -8,32 +8,57 @@ namespace Meilisearch.Tests
 
     [Collection("Sequential")]
 
-    public class StatusTests
+    public class StatusTests : IClassFixture<DocumentFixture>
     {
-        public StatusTests()
+        private readonly Meilisearch.Index index;
+
+        public StatusTests(DocumentFixture fixture)
         {
+            this.index = fixture.DocumentsIndex;
         }
 
         [Fact]
         public async Task GetAllUpdateStatus()
         {
-            var client = new MeilisearchClient("http://localhost:7700", "masterKey");
-            var indexName = "MoviesStatus" + new Random().Next();
-            var index = await client.CreateIndex(indexName);
-            await index.AddDocuments(new[] { new Movie { Id = "1" } });
-            var status = await index.GetAllUpdateStatus();
-            status.Count().Should().BeGreaterOrEqualTo(1);
+            await this.index.AddDocuments(new[] { new Movie { Id = "1" } });
+            var allUpdates = await this.index.GetAllUpdateStatus();
+            allUpdates.Count().Should().BeGreaterOrEqualTo(1);
         }
 
         [Fact]
         public async Task GetOneUpdateStatus()
         {
-            var client = new MeilisearchClient("http://localhost:7700", "masterKey");
-            var indexName = "MoviesStatus" + new Random().Next();
-            var index = await client.CreateIndex(indexName);
-            var status = await index.AddDocuments(new[] { new Movie { Id = "2" } });
-            UpdateStatus individualStatus = await index.GetUpdateStatus(status.UpdateId);
+            var status = await this.index.AddDocuments(new[] { new Movie { Id = "2" } });
+            UpdateStatus individualStatus = await this.index.GetUpdateStatus(status.UpdateId);
             individualStatus.Should().NotBeNull();
+            individualStatus.UpdateId.Should().BeGreaterOrEqualTo(0);
+            individualStatus.Status.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task DefaultWaitForPendingUpdate()
+        {
+            var status = await this.index.AddDocuments(new[] { new Movie { Id = "3" } });
+            var response = await this.index.WaitForPendingUpdate(status.UpdateId);
+            Assert.Equal(response.UpdateId, status.UpdateId);
+            Assert.Equal(response.Status, "processed");
+        }
+
+        [Fact]
+        public async Task CustomWaitForPendingUpdate()
+        {
+            var status = await this.index.AddDocuments(new[] { new Movie { Id = "4" } });
+            var response = await this.index.WaitForPendingUpdate(status.UpdateId, 10000.0, 20);
+            Assert.Equal(response.UpdateId, status.UpdateId);
+            Assert.Equal(response.Status, "processed");
+        }
+
+        [Fact]
+        public async Task WaitForPendingUpdateWithException()
+        {
+            var status = await this.index.AddDocuments(new[] { new Movie { Id = "5" } });
+            await Assert.ThrowsAsync<Exception>(() => index.WaitForPendingUpdate(status.UpdateId, 0.0, 20));
+
         }
     }
 }

--- a/tests/Meilisearch.Tests/StatusTests.cs
+++ b/tests/Meilisearch.Tests/StatusTests.cs
@@ -7,7 +7,6 @@ namespace Meilisearch.Tests
     using Xunit;
 
     [Collection("Sequential")]
-
     public class StatusTests : IClassFixture<DocumentFixture>
     {
         private readonly Meilisearch.Index index;
@@ -41,7 +40,7 @@ namespace Meilisearch.Tests
             var status = await this.index.AddDocuments(new[] { new Movie { Id = "3" } });
             var response = await this.index.WaitForPendingUpdate(status.UpdateId);
             Assert.Equal(response.UpdateId, status.UpdateId);
-            Assert.Equal(response.Status, "processed");
+            Assert.Equal("processed", response.Status);
         }
 
         [Fact]
@@ -50,15 +49,14 @@ namespace Meilisearch.Tests
             var status = await this.index.AddDocuments(new[] { new Movie { Id = "4" } });
             var response = await this.index.WaitForPendingUpdate(status.UpdateId, 10000.0, 20);
             Assert.Equal(response.UpdateId, status.UpdateId);
-            Assert.Equal(response.Status, "processed");
+            Assert.Equal("processed", response.Status);
         }
 
         [Fact]
         public async Task WaitForPendingUpdateWithException()
         {
             var status = await this.index.AddDocuments(new[] { new Movie { Id = "5" } });
-            await Assert.ThrowsAsync<Exception>(() => index.WaitForPendingUpdate(status.UpdateId, 0.0, 20));
-
+            await Assert.ThrowsAsync<Exception>(() => this.index.WaitForPendingUpdate(status.UpdateId, 0.0, 20));
         }
     }
 }


### PR DESCRIPTION
Add the `WaitForPendingUpdate` method that waits until the [asynchronous task](https://docs.meilisearch.com/guides/advanced_guides/asynchronous_updates.html#asynchronous-updates) was processed by MeiliSearch.