### PR TITLE
Update tests for MeiliSearch v0.15.0

### DIFF
--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -39,7 +39,9 @@ namespace Meilisearch.Tests
         public async Task BasicSearchWithEmptyQuery()
         {
             var movies = await this.index.Search<Movie>(string.Empty);
-            movies.Hits.Should().BeEmpty();
+            movies.Hits.Should().NotBeEmpty();
+            movies.Hits.First().Id.Should().NotBeNull();
+            movies.Hits.First().Name.Should().NotBeNull();
         }
 
         [Fact]
@@ -87,7 +89,11 @@ namespace Meilisearch.Tests
             var movies = await this.index.Search<FormattedMovie>(
                 string.Empty,
                 new SearchQuery { AttributesToHighlight = new string[] { "name" } });
-            movies.Hits.Should().BeEmpty();
+            movies.Hits.Should().NotBeEmpty();
+            movies.Hits.First().Id.Should().NotBeNull();
+            movies.Hits.First().Name.Should().NotBeNull();
+            movies.Hits.First()._Formatted.Id.Should().NotBeNull();
+            movies.Hits.First()._Formatted.Name.Should().NotBeNull();
         }
 
         [Fact]


### PR DESCRIPTION
This PR:
- fails here because the MeiliSearch's release v0.15.0 is not out yet.
- should work locally with the [prerelease v0.15.0rc2](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0rc2)