### PR TITLE
Rename global settings methods

### DIFF
--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -255,7 +255,7 @@ namespace Meilisearch
         /// Gets all the settings of an index.
         /// </summary>
         /// <returns>Returns all the settings.</returns>
-        public async Task<Settings> GetAllSettings()
+        public async Task<Settings> GetSettings()
         {
             return await this.client.GetFromJsonAsync<Settings>($"/indexes/{this.Uid}/settings");
         }
@@ -266,7 +266,7 @@ namespace Meilisearch
         /// </summary>
         /// <param name="settings">Settings object.</param>
         /// <returns>Returns the updateID of the asynchronous task.</returns>
-        public async Task<UpdateStatus> UpdateAllSettings(Settings settings)
+        public async Task<UpdateStatus> UpdateSettings(Settings settings)
         {
             JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage = await this.client.PostAsJsonAsync<Settings>($"/indexes/{this.Uid}/settings", settings, options);
@@ -277,7 +277,7 @@ namespace Meilisearch
         /// Resets all the settings to their default values.
         /// </summary>
         /// <returns>Returns the updateID of the asynchronous task.</returns>
-        public async Task<UpdateStatus> ResetAllSettings()
+        public async Task<UpdateStatus> ResetSettings()
         {
             var httpresponse = await this.client.DeleteAsync($"/indexes/{this.Uid}/settings");
             return await httpresponse.Content.ReadFromJsonAsync<UpdateStatus>();

--- a/tests/Meilisearch.Tests/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/IndexFixture.cs
@@ -98,7 +98,7 @@ namespace Meilisearch.Tests
             {
                 AttributesForFaceting = new string[] { "genre" },
             };
-            update = await index.UpdateAllSettings(settings);
+            update = await index.UpdateSettings(settings);
 
             // Check the settings have been added
             finalUpdateStatus = await index.WaitForPendingUpdate(update.UpdateId);

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -31,9 +31,9 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
-        public async Task GetAllSettings()
+        public async Task GetSettings()
         {
-            Settings settings = await this.index.GetAllSettings();
+            Settings settings = await this.index.GetSettings();
             settings.Should().NotBeNull();
             Assert.Equal(settings.RankingRules, this.defaultRankingRules);
             settings.DistinctAttribute.Should().BeNull();
@@ -45,7 +45,7 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
-        public async Task UpdateAllSettings()
+        public async Task UpdateSettings()
         {
             Settings newSettings = new Settings
             {
@@ -53,11 +53,11 @@ namespace Meilisearch.Tests
                 StopWords = new string[] { "of", "the" },
                 DistinctAttribute = "name",
             };
-            UpdateStatus update = await this.index.UpdateAllSettings(newSettings);
+            UpdateStatus update = await this.index.UpdateSettings(newSettings);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
             await this.index.WaitForPendingUpdate(update.UpdateId);
 
-            Settings response = await this.index.GetAllSettings();
+            Settings response = await this.index.GetSettings();
             response.Should().NotBeNull();
             response.RankingRules.Should().Equals(this.defaultRankingRules);
             response.DistinctAttribute.Should().Equals("name");
@@ -69,7 +69,7 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
-        public async Task UpdateAllSettingsWithoutOverwritting()
+        public async Task UpdateSettingsWithoutOverwritting()
         {
             // First update
             var synonyms = new Dictionary<string, IEnumerable<string>>();
@@ -82,17 +82,17 @@ namespace Meilisearch.Tests
                 DistinctAttribute = "name",
                 Synonyms = synonyms,
             };
-            UpdateStatus update = await this.index.UpdateAllSettings(newSettings);
+            UpdateStatus update = await this.index.UpdateSettings(newSettings);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
             await this.index.WaitForPendingUpdate(update.UpdateId);
 
             // Second update: this one should not overwritten StopWords and DistinctAttribute.
             newSettings = new Settings { SearchableAttributes = new string[] { "name" } };
-            update = await this.index.UpdateAllSettings(newSettings);
+            update = await this.index.UpdateSettings(newSettings);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
             await this.index.WaitForPendingUpdate(update.UpdateId);
 
-            Settings response = await this.index.GetAllSettings();
+            Settings response = await this.index.GetSettings();
             response.Should().NotBeNull();
             response.RankingRules.Should().Equals(this.defaultRankingRules);
             response.DistinctAttribute.Should().Equals("name");
@@ -105,7 +105,7 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
-        public async Task ResetAllSettings()
+        public async Task ResetSettings()
         {
             // Update all settings
             Settings newSettings = new Settings
@@ -117,17 +117,17 @@ namespace Meilisearch.Tests
                 RankingRules = new string[] { "typo" },
                 AttributesForFaceting = new string[] { "genre" },
             };
-            UpdateStatus update = await this.index.UpdateAllSettings(newSettings);
+            UpdateStatus update = await this.index.UpdateSettings(newSettings);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
             await this.index.WaitForPendingUpdate(update.UpdateId);
-            Settings response = await this.index.GetAllSettings();
+            Settings response = await this.index.GetSettings();
             Assert.Equal(new string[] { "typo" }, response.RankingRules);
 
             // Reset all settings
-            update = await this.index.ResetAllSettings();
+            update = await this.index.ResetSettings();
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
             await this.index.WaitForPendingUpdate(update.UpdateId);
-            response = await this.index.GetAllSettings();
+            response = await this.index.GetSettings();
             response.Should().NotBeNull();
             Assert.Equal(response.RankingRules, this.defaultRankingRules);
             response.DistinctAttribute.Should().BeNull();


### PR DESCRIPTION
`GetAllSettings` -> `GetSettings`
`UpdateAllSettings` -> `UpdateSettings`
`ResetAllSettings` -> `ResetSettings`

Main motivation: the `UpdateAllSettings` name seems meaning that all the settings are going to be updated, but that's bot true. Only the settings in the body are going to be updated. That's why all the other SDKs have the same naming approach.