### PR TITLE
Add pre-release CI

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -23,3 +23,5 @@ replacers:
     replace: ''
   - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
     replace: ''
+  - search: '/(?:and )?@meili-bot,?/g'
+    replace: ''

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -1,0 +1,30 @@
+# Testing the code base against the MeiliSearch pre-releases
+name: Pre-Release Tests
+
+# Will only run for PRs and pushes to bump-meilisearch-v*
+on:
+  push:
+    branches: bump-meilisearch-v*
+  pull_request:
+    branches: bump-meilisearch-v*
+
+jobs:
+  integration_tests:
+    name: integration-tests-against-rc
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Get the latest MeiliSearch RC
+      run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/master/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+    - name: MeiliSearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} ./meilisearch --master-key=masterKey --no-analytics=true
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Run tests
+      run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   integration_tests:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     name: integration-tests
     runs-on: ubuntu-latest
     steps:
@@ -19,7 +22,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
-    - name: MeiliSearch setup with Docker
+    - name: MeiliSearch (latest version) setup with Docker
       run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
     - name: Install dependencies
       run: dotnet restore


### PR DESCRIPTION
Add CI for the pre-release PRs = PRs to `bump-meilisearch-v*` during the pre-release week of MeiliSearch. This CI will run the tests against the MeilliSearch RC instead of the MeiliSearch `latest`.

For each PR to `bump-meilisearch-v*`:
- the `format` job will run
- the `integration-tests-against-rc` job will run
- the `integration-tests` job will be skipped
- the required jobs (for merging) in the settings will be: `format` and `integration-tests-against-rc`

For each **push** to `bump-meilisearch-v*`:
- the `format` job will run
- the `integration-tests-against-rc` job will run
- the `integration-tests` job will run
- the required jobs (for merging) in the settings will be: `format` and `integration-tests`

For any other event (PRs and pushes):
- the `format` job will run
- the `integration-tests-against-rc` job will NOT run
- the `integration-tests` job will run
- the required jobs (for merging) in the settings will be: `format` and `integration-tests`

⚠️ Bors will not work when trying to merge a PR into `bump-meilisearch-v*` since we can not apply conditional jobs for merging with Bors. 