### PR TITLE
Set SearchQuery.Filters type as string

### DIFF
--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -23,9 +23,9 @@ namespace Meilisearch
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Gets or sets filters to apply to the query.
+        /// Gets or sets the filter to apply to the query.
         /// </summary>
-        public IEnumerable<string> Filters { get; set; }
+        public string Filters { get; set; }
 
         /// <summary>
         /// Gets or sets attributes to retrieve.

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -120,6 +120,24 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task CustomSearchWithFilters()
+        {
+            var movies = await this.indexForFaceting.Search<Movie>(
+                null,
+                new SearchQuery
+                {
+                    Filters = "genre = SF",
+                });
+            movies.Hits.Should().NotBeEmpty();
+            movies.FacetsDistribution.Should().BeNull();
+            Assert.Equal(2, movies.Hits.Count());
+            Assert.Equal("12", movies.Hits.First().Id);
+            Assert.Equal("Star Wars", movies.Hits.First().Name);
+            Assert.Equal("SF", movies.Hits.First().Genre);
+            Assert.Equal("SF", movies.Hits.ElementAt(1).Genre);
+        }
+
+        [Fact]
         public async Task CustomSearchWithFacetFilters()
         {
             var movies = await this.indexForFaceting.Search<Movie>(


### PR DESCRIPTION
This PR is relative to issue #85 (Set SearchQuery.Filters type to be a string)
It containes :
- Changed SearchQuery.Filters type to be a string
- Added tests to cover its usage
