### PR TITLE
Added NbHits and ExhaustiveNbHits to SearchResult<T> object.

### DIFF
--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -37,5 +37,15 @@ namespace Meilisearch
         /// Gets or sets a value indicating whether the facets distribution is exhaustive or not.
         /// </summary>
         public bool ExhaustiveFacetsCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the nbHits returned by the search.
+        /// </summary>
+        public int NbHits { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the nbHits number returned by the search is exhaustive or not.
+        /// </summary>
+        public bool ExhaustiveNbHits { get; set; }
     }
 }


### PR DESCRIPTION
Added NbHits and ExhaustiveNbHits to SearchResult<T> object. Currently these values are returned by the meilisearch api but not mapped to the SearchResutl object. Fixes #109