### PR TITLE
Adding Error Handler Dotnet

### DIFF
--- a/src/Meilisearch/Errors/MeilisearchApiError.cs
+++ b/src/Meilisearch/Errors/MeilisearchApiError.cs
@@ -10,7 +10,7 @@ namespace Meilisearch
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MeilisearchApiError"/> class.
-        /// Handler Exception received from Meilisearch API.
+        /// Handler Exception received from MeiliSearch API.
         /// </summary>
         /// <param name="apiError">Specific error message from Meilisearch Api.</param>
         public MeilisearchApiError(MeilisearchApiErrorContent apiError)

--- a/src/Meilisearch/Errors/MeilisearchApiError.cs
+++ b/src/Meilisearch/Errors/MeilisearchApiError.cs
@@ -1,0 +1,38 @@
+namespace Meilisearch
+{
+    using System;
+    using System.Net;
+
+    /// <summary>
+    /// Error sent by MeiliSearch API.
+    /// </summary>
+    public class MeilisearchApiError : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeilisearchApiError"/> class.
+        /// Handler Exception received from Meilisearch API.
+        /// </summary>
+        /// <param name="apiError">Specific error message from Meilisearch Api.</param>
+        public MeilisearchApiError(MeilisearchApiErrorContent apiError)
+            : base(string.Format("MeilisearchApiError, Message: {0}, ErrorCode: {1}, ErrorType: {2}, ErrorLink: {3}", apiError.Message, apiError.ErrorCode, apiError.ErrorType, apiError.ErrorLink))
+        {
+            this.ErrorCode = apiError.ErrorCode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeilisearchApiError"/> class.
+        /// Handler Exception when Meilisearch API doesn't send a response message.
+        /// </summary>
+        /// <param name="statusCode">Status code from http response message.</param>
+        /// <param name="reasonPhrase">Reason Phrase from http response message.</param>
+        public MeilisearchApiError(HttpStatusCode statusCode, string reasonPhrase)
+            : base(string.Format("MeilisearchApiError, Message: {0}, ErrorCode: {1}", reasonPhrase, (int)statusCode))
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the errorCode return by MeilisearchApi..
+        /// </summary>
+        public string ErrorCode { get; set; }
+    }
+}

--- a/src/Meilisearch/Errors/MeilisearchApiError.cs
+++ b/src/Meilisearch/Errors/MeilisearchApiError.cs
@@ -31,7 +31,7 @@ namespace Meilisearch
         }
 
         /// <summary>
-        /// Gets or sets the errorCode return by MeilisearchApi..
+        /// Gets or sets the errorCode return by MeilisearchApi.
         /// </summary>
         public string ErrorCode { get; set; }
     }

--- a/src/Meilisearch/Errors/MeilisearchApiErrorContent.cs
+++ b/src/Meilisearch/Errors/MeilisearchApiErrorContent.cs
@@ -1,0 +1,34 @@
+namespace Meilisearch
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Error sent by MeiliSearch API.
+    /// </summary>
+    public class MeilisearchApiErrorContent
+    {
+        /// <summary>
+        /// Gets or sets the message.
+        /// </summary>
+        [JsonPropertyName("message")]
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the errorCode.
+        /// </summary>
+        [JsonPropertyName("errorCode")]
+        public string ErrorCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the errorType.
+        /// </summary>
+        [JsonPropertyName("errorType")]
+        public string ErrorType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the errorLink.
+        /// </summary>
+        [JsonPropertyName("errorLink")]
+        public string ErrorLink { get; set; }
+    }
+}

--- a/src/Meilisearch/Errors/MeilisearchCommunicationError.cs
+++ b/src/Meilisearch/Errors/MeilisearchCommunicationError.cs
@@ -3,7 +3,7 @@ namespace Meilisearch
     using System;
 
     /// <summary>
-    /// Error sent when trying to connecting to Meilisearch.
+    /// Error sent when trying to connecting to MeiliSearch.
     /// </summary>
     public class MeilisearchCommunicationError : Exception
     {

--- a/src/Meilisearch/Errors/MeilisearchCommunicationError.cs
+++ b/src/Meilisearch/Errors/MeilisearchCommunicationError.cs
@@ -1,0 +1,21 @@
+namespace Meilisearch
+{
+    using System;
+
+    /// <summary>
+    /// Error sent when trying to connecting to Meilisearch.
+    /// </summary>
+    public class MeilisearchCommunicationError : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeilisearchCommunicationError"/> class.
+        /// Handler Exception for MeilisearchCommunicationError with message and inner exception.
+        /// </summary>
+        /// <param name="message">Custom error message.</param>
+        /// <param name="innerException">Inner exception.</param>
+        public MeilisearchCommunicationError(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Meilisearch/Errors/MeilisearchTimeoutError.cs
+++ b/src/Meilisearch/Errors/MeilisearchTimeoutError.cs
@@ -1,0 +1,20 @@
+namespace Meilisearch
+{
+    using System;
+
+    /// <summary>
+    /// Error sent when request not processed in expected time.
+    /// </summary>
+    public class MeilisearchTimeoutError : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeilisearchTimeoutError"/> class.
+        /// Handler Exception for MeilisearchTimeoutError with message.
+        /// </summary>
+        /// <param name="message">Custom error message.</param>
+        public MeilisearchTimeoutError(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -248,7 +248,7 @@ namespace Meilisearch
                 await Task.Delay(intervalMs);
             }
 
-            throw new Exception("The task " + updateId.ToString() + " timed out.");
+            throw new MeilisearchTimeoutError("The task " + updateId.ToString() + " timed out.");
         }
 
         /// <summary>

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -22,7 +22,7 @@ namespace Meilisearch
         /// <param name="apiKey">API key for the usage.</param>
         public MeilisearchClient(string url, string apiKey = default)
         {
-            this.client = new HttpClient { BaseAddress = new Uri(url) };
+            this.client = new HttpClient(new MeilisearchMessageHandler(new HttpClientHandler())) { BaseAddress = new Uri(url) };
             if (!string.IsNullOrEmpty(apiKey))
             {
                 this.client.DefaultRequestHeaders.Add("X-Meili-API-Key", apiKey);
@@ -52,7 +52,7 @@ namespace Meilisearch
         public async Task<MeiliSearchVersion> GetVersion()
         {
             var response = await this.client.GetAsync("/version");
-            response.EnsureSuccessStatusCode();
+
             return await response.Content.ReadFromJsonAsync<MeiliSearchVersion>();
         }
 
@@ -68,8 +68,7 @@ namespace Meilisearch
             Index index = new Index(uid, primaryKey);
             var response = await this.client.PostAsJsonAsync("/indexes", index);
 
-            // TODO : Revisit the Exception, We need to handle it better.
-            return response.IsSuccessStatusCode ? index.WithHttpClient(this.client) : throw new Exception("Not able to create index. May be Index already exist");
+            return index.WithHttpClient(this.client);
         }
 
         /// <summary>
@@ -79,7 +78,7 @@ namespace Meilisearch
         public async Task<IEnumerable<Index>> GetAllIndexes()
         {
             var response = await this.client.GetAsync("/indexes");
-            response.EnsureSuccessStatusCode();
+
             var content = await response.Content.ReadFromJsonAsync<IEnumerable<Index>>();
             return content
                 .Select(p => p.WithHttpClient(this.client));
@@ -93,20 +92,13 @@ namespace Meilisearch
         public async Task<Index> GetIndex(string uid)
         {
             var response = await this.client.GetAsync($"/indexes/{uid}");
-            if (response.IsSuccessStatusCode)
-            {
-                var content = await response.Content.ReadFromJsonAsync<Index>();
-                return content.WithHttpClient(this.client);
-            }
+            var content = await response.Content.ReadFromJsonAsync<Index>();
 
-            return null;  // TODO:  Yikes!! returning Null  Need to come back to solve this.
+            return content.WithHttpClient(this.client);
         }
 
         /// <summary>
         /// Gets the index instance or creates the index if it does not exist.
-        ///
-        /// /!\ Really basics. An error handler should be created to check the errorCode.
-        /// cf https://docs.meilisearch.com/errors/#index_already_exists.
         /// </summary>
         /// <param name="uid">Unique Id.</param>
         /// <param name="primaryKey">Primary key for documents.</param>
@@ -115,18 +107,16 @@ namespace Meilisearch
         {
             try
             {
-                return await this.CreateIndex(uid, primaryKey);
+                return await this.GetIndex(uid);
             }
-            catch (Exception e)
+            catch (MeilisearchApiError e)
             {
-                if (e.Message == "Not able to create index. May be Index already exist")
-                {
-                    return await this.GetIndex(uid);
-                }
-                else
+                if (e.ErrorCode != "index_not_found")
                 {
                     throw e;
                 }
+
+                return await this.CreateIndex(uid, primaryKey);
             }
         }
 
@@ -146,7 +136,7 @@ namespace Meilisearch
         public async Task<MeiliSearchHealth> Health()
         {
             var response = await this.client.GetAsync("/health");
-            response.EnsureSuccessStatusCode();
+
             return await response.Content.ReadFromJsonAsync<MeiliSearchHealth>();
         }
 
@@ -175,9 +165,7 @@ namespace Meilisearch
         {
             var response = await this.client.PostAsync("/dumps", default, default);
 
-            return response.IsSuccessStatusCode
-                ? await response.Content.ReadFromJsonAsync<DumpStatus>()
-                : throw new Exception("Another dump is already in progress");
+            return await response.Content.ReadFromJsonAsync<DumpStatus>();
         }
 
         /// <summary>

--- a/tests/Meilisearch.Tests/ClientFactory.cs
+++ b/tests/Meilisearch.Tests/ClientFactory.cs
@@ -1,6 +1,7 @@
 namespace Meilisearch.Tests
 {
     using System;
+    using System.Net.Http;
     using HttpClientFactoryLite;
 
     public class ClientFactory
@@ -10,13 +11,13 @@ namespace Meilisearch.Tests
                 new Lazy<HttpClientFactory>(() =>
                 {
                     var httpClientFactory = new HttpClientFactory();
-                    httpClientFactory.Register<MeilisearchClient>(
-                        builder =>
-                            builder.ConfigureHttpClient(p =>
+                    httpClientFactory.Register<MeilisearchClient>(builder => builder
+                        .ConfigureHttpClient(p =>
                             {
                                 p.BaseAddress = new Uri("http://localhost:7700/");
                                 p.DefaultRequestHeaders.Add("X-Meili-API-Key", "masterKey");
-                            }));
+                            })
+                        .ConfigurePrimaryHttpMessageHandler(() => new MeilisearchMessageHandler(new HttpClientHandler())));
                     return httpClientFactory;
                 });
 

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -37,6 +37,28 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task BasicDocumentsAdditionWithTimeoutError()
+        {
+            var indexUID = "BasicDocumentsAdditionWithTimeoutError";
+            Index index = await this.client.GetOrCreateIndex(indexUID);
+
+            // Add the documents
+            UpdateStatus update = await index.AddDocuments(new[] { new Movie { Id = "1", Name = "Batman" } });
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForPendingUpdate(update.UpdateId, 0));
+        }
+
+        [Fact]
+        public async Task BasicDocumentsAdditionWithTimeoutErrorByInterval()
+        {
+            var indexUID = "BasicDocumentsAdditionWithTimeoutError";
+            Index index = await this.client.GetOrCreateIndex(indexUID);
+
+            // Add the documents
+            UpdateStatus update = await index.AddDocuments(new[] { new Movie { Id = "1", Name = "Batman" } });
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForPendingUpdate(update.UpdateId, 0, 10));
+        }
+
+        [Fact]
         public async Task BasicDocumentsUpdate()
         {
             var indexUID = "BasicDocumentsUpdateTest";
@@ -116,7 +138,8 @@ namespace Meilisearch.Tests
             // Check the document has been deleted
             var docs = await index.GetDocuments<Movie>();
             Assert.Equal(6, docs.Count());
-            await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => index.GetDocument<Movie>("11"));
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<Movie>("11"));
+            Assert.Equal("document_not_found", ex.ErrorCode);
         }
 
         [Fact]
@@ -132,7 +155,8 @@ namespace Meilisearch.Tests
             // Check the document has been deleted
             var docs = await index.GetDocuments<MovieWithIntId>();
             Assert.Equal(6, docs.Count());
-            await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => index.GetDocument<MovieWithIntId>(11));
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<MovieWithIntId>(11));
+            Assert.Equal("document_not_found", ex.ErrorCode);
         }
 
         [Fact]
@@ -148,9 +172,13 @@ namespace Meilisearch.Tests
             // Check the documents have been deleted
             var docs = await index.GetDocuments<Movie>();
             Assert.Equal(4, docs.Count());
-            await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => index.GetDocument<Movie>("12"));
-            await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => index.GetDocument<Movie>("13"));
-            await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => index.GetDocument<Movie>("14"));
+            MeilisearchApiError ex;
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<Movie>("12"));
+            Assert.Equal("document_not_found", ex.ErrorCode);
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<Movie>("13"));
+            Assert.Equal("document_not_found", ex.ErrorCode);
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<Movie>("14"));
+            Assert.Equal("document_not_found", ex.ErrorCode);
         }
 
         [Fact]
@@ -166,9 +194,13 @@ namespace Meilisearch.Tests
             // Check the documents have been deleted
             var docs = await index.GetDocuments<MovieWithIntId>();
             Assert.Equal(4, docs.Count());
-            await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => index.GetDocument<MovieWithIntId>(12));
-            await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => index.GetDocument<MovieWithIntId>(13));
-            await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => index.GetDocument<MovieWithIntId>(14));
+            MeilisearchApiError ex;
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<MovieWithIntId>("12"));
+            Assert.Equal("document_not_found", ex.ErrorCode);
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<MovieWithIntId>("13"));
+            Assert.Equal("document_not_found", ex.ErrorCode);
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<MovieWithIntId>("14"));
+            Assert.Equal("document_not_found", ex.ErrorCode);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/UpdateStatusTests.cs
+++ b/tests/Meilisearch.Tests/UpdateStatusTests.cs
@@ -1,6 +1,5 @@
 namespace Meilisearch.Tests
 {
-    using System;
     using System.Linq;
     using System.Threading.Tasks;
     using FluentAssertions;
@@ -58,7 +57,7 @@ namespace Meilisearch.Tests
         public async Task WaitForPendingUpdateWithException()
         {
             var status = await this.index.AddDocuments(new[] { new Movie { Id = "5" } });
-            await Assert.ThrowsAsync<Exception>(() => this.index.WaitForPendingUpdate(status.UpdateId, 0.0, 20));
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => this.index.WaitForPendingUpdate(status.UpdateId, 0.0, 20));
         }
     }
 }


### PR DESCRIPTION
**Description**
Implement the error handler by using `HttpMessageHandler` and adapt to the error handler of other SDKs with 3 main errors type:
- `MeiliSearchApiError`
- `MeiliSearchCommunicationError`
- `MeiliSearchTimeoutError`

**Issue related**
#30