### PR TITLE
Fix tests

### DIFF
--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -257,6 +257,7 @@ namespace Meilisearch
                 body = searchAttributes;
                 body.Q = query;
             }
+
             JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
 
             var responseMessage = await this.client.PostAsJsonAsync<SearchQuery>($"/indexes/{this.Uid}/search", body, options);

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -257,8 +257,9 @@ namespace Meilisearch
                 body = searchAttributes;
                 body.Q = query;
             }
+            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
 
-            var responseMessage = await this.client.PostAsJsonAsync<SearchQuery>($"/indexes/{this.Uid}/search", body);
+            var responseMessage = await this.client.PostAsJsonAsync<SearchQuery>($"/indexes/{this.Uid}/search", body, options);
             return await responseMessage.Content.ReadFromJsonAsync<SearchResult<T>>();
         }
 

--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -30,7 +30,7 @@ namespace Meilisearch
         /// Gets or sets the filter to apply to the query.
         /// </summary>
         [JsonPropertyName("filter")]
-        public string Filter { get; set; }
+        public dynamic Filter { get; set; }
 
         /// <summary>
         /// Gets or sets attributes to retrieve.

--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -1,6 +1,7 @@
 namespace Meilisearch
 {
     using System.Collections.Generic;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Search Query for MeiliSearch class.
@@ -10,51 +11,61 @@ namespace Meilisearch
         /// <summary>
         /// Gets or sets query string.
         /// </summary>
+        [JsonPropertyName("q")]
         public string Q { get; set; }
 
         /// <summary>
         /// Gets or sets offset for the Query.
         /// </summary>
+        [JsonPropertyName("offset")]
         public int? Offset { get; set; }
 
         /// <summary>
         /// Gets or sets limits the number of results.
         /// </summary>
+        [JsonPropertyName("limit")]
         public int? Limit { get; set; }
 
         /// <summary>
         /// Gets or sets the filter to apply to the query.
         /// </summary>
+        [JsonPropertyName("filter")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets attributes to retrieve.
         /// </summary>
+        [JsonPropertyName("attributesToRetrieve")]
         public IEnumerable<string> AttributesToRetrieve { get; set; }
 
         /// <summary>
         /// Gets or sets attributes to crop.
         /// </summary>
+        [JsonPropertyName("attributesToCrop")]
         public IEnumerable<string> AttributesToCrop { get; set; }
 
         /// <summary>
         /// Gets or sets length used to crop field values.
         /// </summary>
+        [JsonPropertyName("cropLength")]
         public int? CropLength { get; set; }
 
         /// <summary>
         /// Gets or sets attributes to highlight.
         /// </summary>
+        [JsonPropertyName("attributesToHighlight")]
         public IEnumerable<string> AttributesToHighlight { get; set; }
 
         /// <summary>
         /// Gets or sets the facets distribution for the query.
         /// </summary>
+        [JsonPropertyName("facetsDistribution")]
         public IEnumerable<string> FacetsDistribution { get; set; }
 
         /// <summary>
         /// Gets or sets matches. It defines whether an object that contains information about the matches should be returned or not.
         /// </summary>
+        [JsonPropertyName("matches")]
         public bool? Matches { get; set; }
     }
 }

--- a/src/Meilisearch/Stats.cs
+++ b/src/Meilisearch/Stats.cs
@@ -16,7 +16,7 @@ namespace Meilisearch
         /// <summary>
         /// Gets or sets last update timestamp.
         /// </summary>
-        public Nullable <DateTime> LastUpdate { get; set; }
+        public Nullable<DateTime> LastUpdate { get; set; }
 
         /// <summary>
         /// Gets or sets index stats.

--- a/src/Meilisearch/Stats.cs
+++ b/src/Meilisearch/Stats.cs
@@ -16,7 +16,7 @@ namespace Meilisearch
         /// <summary>
         /// Gets or sets last update timestamp.
         /// </summary>
-        public DateTime LastUpdate { get; set; }
+        public string LastUpdate { get; set; }
 
         /// <summary>
         /// Gets or sets index stats.

--- a/src/Meilisearch/Stats.cs
+++ b/src/Meilisearch/Stats.cs
@@ -16,7 +16,7 @@ namespace Meilisearch
         /// <summary>
         /// Gets or sets last update timestamp.
         /// </summary>
-        public string LastUpdate { get; set; }
+        public Nullable <DateTime> LastUpdate { get; set; }
 
         /// <summary>
         /// Gets or sets index stats.

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -123,7 +123,7 @@ namespace Meilisearch.Tests
             movies.Hits.First().Id.Should().NotBeEmpty();
             movies.Hits.First().Genre.Should().BeNull();
             movies.Hits.First()._Formatted.Name.Should().NotBeEmpty();
-            movies.Hits.First()._Formatted.Id.Should().BeNull();
+            movies.Hits.First()._Formatted.Id.Should().Equals(15);
             movies.Hits.First()._Formatted.Genre.Should().BeNull();
         }
 
@@ -173,6 +173,14 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithFacetsDistribution()
         {
+            Settings newFilters = new Settings
+            {
+                FilterableAttributes = new string[] { "name"},
+            };
+            UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
+            update.UpdateId.Should().BeGreaterOrEqualTo(0);
+            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
+
             var movies = await this.indexForFaceting.Search<Movie>(
                 null,
                 new SearchQuery

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -10,6 +10,7 @@ namespace Meilisearch.Tests
     {
         private readonly Index basicIndex;
         private readonly Index indexForFaceting;
+        private readonly Index indexWithIntId;
 
         public SearchTests(IndexFixture fixture)
         {
@@ -17,6 +18,7 @@ namespace Meilisearch.Tests
             var client = fixture.DefaultClient;
             this.basicIndex = fixture.SetUpBasicIndex("BasicIndex-SearchTests").Result;
             this.indexForFaceting = fixture.SetUpIndexForFaceting("IndexForFaceting-SearchTests").Result;
+            this.indexWithIntId = fixture.SetUpBasicIndexWithIntId("IndexWithIntId-SearchTests").Result;
         }
 
         [Fact]
@@ -160,9 +162,9 @@ namespace Meilisearch.Tests
             {
                 FilterableAttributes = new string[] { "id" },
             };
-            UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
+            UpdateStatus update = await this.indexWithIntId.UpdateSettings(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
+            await this.indexWithIntId.WaitForPendingUpdate(update.UpdateId);
 
             var movies = await this.indexForFaceting.Search<Movie>(
                 null,
@@ -176,7 +178,6 @@ namespace Meilisearch.Tests
             Assert.Equal("12", movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
             Assert.Equal("SF", movies.Hits.First().Genre);
-            Assert.Equal("SF", movies.Hits.ElementAt(1).Genre);
         }
 
         [Fact]
@@ -215,7 +216,6 @@ namespace Meilisearch.Tests
             Assert.Equal("13", movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
             Assert.Equal("SF", movies.Hits.First().Genre);
-            Assert.Equal("SF", movies.Hits.ElementAt(1).Genre);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -175,7 +175,7 @@ namespace Meilisearch.Tests
         {
             Settings newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "name"},
+                FilterableAttributes = new string[] { "genre"},
             };
             UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -154,6 +154,32 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task CustomSearchWithNumberFilter()
+        {
+            Settings newFilters = new Settings
+            {
+                FilterableAttributes = new string[] { "id" },
+            };
+            UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
+            update.UpdateId.Should().BeGreaterOrEqualTo(0);
+            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
+
+            var movies = await this.indexForFaceting.Search<Movie>(
+                null,
+                new SearchQuery
+                {
+                    Filter = "id = 12",
+                });
+            movies.Hits.Should().NotBeEmpty();
+            movies.FacetsDistribution.Should().BeNull();
+            Assert.Equal(1, movies.Hits.Count());
+            Assert.Equal("12", movies.Hits.First().Id);
+            Assert.Equal("Star Wars", movies.Hits.First().Name);
+            Assert.Equal("SF", movies.Hits.First().Genre);
+            Assert.Equal("SF", movies.Hits.ElementAt(1).Genre);
+        }
+
+        [Fact]
         public async Task CustomSearchWithMultipleFilter()
         {
             Settings newFilters = new Settings
@@ -186,7 +212,7 @@ namespace Meilisearch.Tests
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
             Assert.Equal(1, movies.Hits.Count());
-            Assert.Equal("12", movies.Hits.First().Id);
+            Assert.Equal("13", movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
             Assert.Equal("SF", movies.Hits.First().Genre);
             Assert.Equal("SF", movies.Hits.ElementAt(1).Genre);

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -190,9 +190,9 @@ namespace Meilisearch.Tests
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().NotBeEmpty();
             movies.FacetsDistribution["genre"].Should().NotBeEmpty();
-            Assert.Equal(3, movies.FacetsDistribution["genre"]["Action"]);
-            Assert.Equal(2, movies.FacetsDistribution["genre"]["SF"]);
-            Assert.Equal(1, movies.FacetsDistribution["genre"]["French movie"]);
+            Assert.Equal(3, movies.FacetsDistribution["genre"]["action"]);
+            Assert.Equal(2, movies.FacetsDistribution["genre"]["sf"]);
+            Assert.Equal(1, movies.FacetsDistribution["genre"]["french movie"]);
         }
     }
 }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -62,6 +62,14 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithAttributesToHighlight()
         {
+            Settings newFilters = new Settings
+            {
+                FilterableAttributes = new string[] { "name"},
+            };
+            UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
+            update.UpdateId.Should().BeGreaterOrEqualTo(0);
+            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
+
             var movies = await this.basicIndex.Search<FormattedMovie>(
                 "man",
                 new SearchQuery { AttributesToHighlight = new string[] { "name" } });
@@ -122,6 +130,14 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithFilter()
         {
+            Settings newFilters = new Settings
+            {
+                FilterableAttributes = new string[] { "genre"},
+            };
+            UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
+            update.UpdateId.Should().BeGreaterOrEqualTo(0);
+            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
+
             var movies = await this.indexForFaceting.Search<Movie>(
                 null,
                 new SearchQuery

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -265,9 +265,9 @@ namespace Meilisearch.Tests
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().NotBeEmpty();
             movies.FacetsDistribution["genre"].Should().NotBeEmpty();
-            Assert.Equal(3, movies.FacetsDistribution["genre"]["action"]);
-            Assert.Equal(2, movies.FacetsDistribution["genre"]["sf"]);
-            Assert.Equal(1, movies.FacetsDistribution["genre"]["french movie"]);
+            Assert.Equal(3, movies.FacetsDistribution["genre"]["Action"]);
+            Assert.Equal(2, movies.FacetsDistribution["genre"]["Sf"]);
+            Assert.Equal(1, movies.FacetsDistribution["genre"]["French movie"]);
         }
     }
 }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -132,19 +132,47 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithFilter()
         {
-            Settings newFilters = new Settings
-            {
-                FilterableAttributes = new string[] { "genre" },
-            };
-            UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
-            update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
-
             var movies = await this.indexForFaceting.Search<Movie>(
                 null,
                 new SearchQuery
                 {
                     Filter = "genre = SF",
+                });
+            movies.Hits.Should().NotBeEmpty();
+            movies.FacetsDistribution.Should().BeNull();
+            Assert.Equal(2, movies.Hits.Count());
+            Assert.Equal("12", movies.Hits.First().Id);
+            Assert.Equal("Star Wars", movies.Hits.First().Name);
+            Assert.Equal("SF", movies.Hits.First().Genre);
+            Assert.Equal("SF", movies.Hits.ElementAt(1).Genre);
+        }
+
+        [Fact]
+        public async Task CustomSearchWithFilterArray()
+        {
+            var movies = await this.indexForFaceting.Search<Movie>(
+                null,
+                new SearchQuery
+                {
+                    Filter = new string[] { "genre = SF" },
+                });
+            movies.Hits.Should().NotBeEmpty();
+            movies.FacetsDistribution.Should().BeNull();
+            Assert.Equal(2, movies.Hits.Count());
+            Assert.Equal("12", movies.Hits.First().Id);
+            Assert.Equal("Star Wars", movies.Hits.First().Name);
+            Assert.Equal("SF", movies.Hits.First().Genre);
+            Assert.Equal("SF", movies.Hits.ElementAt(1).Genre);
+        }
+
+        [Fact]
+        public async Task CustomSearchWithFilterMultipleArray()
+        {
+            var movies = await this.indexForFaceting.Search<Movie>(
+                null,
+                new SearchQuery
+                {
+                    Filter = new string[][] { new string[] { "genre = SF", "genre = SF" }, new string[] { "genre = SF" } },
                 });
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -64,7 +64,7 @@ namespace Meilisearch.Tests
         {
             Settings newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "name"},
+                FilterableAttributes = new string[] { "name" },
             };
             UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
@@ -132,7 +132,7 @@ namespace Meilisearch.Tests
         {
             Settings newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "genre"},
+                FilterableAttributes = new string[] { "genre" },
             };
             UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
@@ -175,7 +175,7 @@ namespace Meilisearch.Tests
         {
             Settings newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "genre"},
+                FilterableAttributes = new string[] { "genre" },
             };
             UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -266,7 +266,7 @@ namespace Meilisearch.Tests
             movies.FacetsDistribution.Should().NotBeEmpty();
             movies.FacetsDistribution["genre"].Should().NotBeEmpty();
             Assert.Equal(3, movies.FacetsDistribution["genre"]["Action"]);
-            Assert.Equal(2, movies.FacetsDistribution["genre"]["Sf"]);
+            Assert.Equal(2, movies.FacetsDistribution["genre"]["SF"]);
             Assert.Equal(1, movies.FacetsDistribution["genre"]["French movie"]);
         }
     }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -174,7 +174,7 @@ namespace Meilisearch.Tests
                 });
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
-            Assert.Equal(1, movies.Hits.Count());
+            Assert.Single(movies.Hits);
             Assert.Equal(12, movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
             Assert.Equal("SF", movies.Hits.First().Genre);
@@ -199,7 +199,7 @@ namespace Meilisearch.Tests
                 });
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
-            Assert.Equal(1, movies.Hits.Count());
+            Assert.Single(movies.Hits);
             Assert.Equal(13, movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
             Assert.Equal("SF", movies.Hits.First().Genre);
@@ -211,7 +211,7 @@ namespace Meilisearch.Tests
             var movies = await this.indexForFaceting.Search<Movie>("coco \"harry\"");
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
-            Assert.Equal(1, movies.Hits.Count());
+            Assert.Single(movies.Hits);
             Assert.Equal("13", movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
             Assert.Equal("SF", movies.Hits.First().Genre);

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -166,7 +166,7 @@ namespace Meilisearch.Tests
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
             await this.indexWithIntId.WaitForPendingUpdate(update.UpdateId);
 
-            var movies = await this.indexForFaceting.Search<Movie>(
+            var movies = await this.indexWithIntId.Search<MovieWithIntId>(
                 null,
                 new SearchQuery
                 {
@@ -175,7 +175,7 @@ namespace Meilisearch.Tests
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
             Assert.Equal(1, movies.Hits.Count());
-            Assert.Equal("12", movies.Hits.First().Id);
+            Assert.Equal(12, movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
             Assert.Equal("SF", movies.Hits.First().Genre);
         }
@@ -187,11 +187,11 @@ namespace Meilisearch.Tests
             {
                 FilterableAttributes = new string[] { "genre", "id" },
             };
-            UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
+            UpdateStatus update = await this.indexWithIntId.UpdateSettings(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
+            await this.indexWithIntId.WaitForPendingUpdate(update.UpdateId);
 
-            var movies = await this.indexForFaceting.Search<Movie>(
+            var movies = await this.indexWithIntId.Search<MovieWithIntId>(
                 null,
                 new SearchQuery
                 {
@@ -200,10 +200,9 @@ namespace Meilisearch.Tests
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
             Assert.Equal(1, movies.Hits.Count());
-            Assert.Equal("12", movies.Hits.First().Id);
+            Assert.Equal(13, movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
             Assert.Equal("SF", movies.Hits.First().Genre);
-            Assert.Equal("SF", movies.Hits.ElementAt(1).Genre);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -50,7 +50,7 @@ namespace Meilisearch.Tests
             {
                 SearchableAttributes = new string[] { "name", "genre" },
                 StopWords = new string[] { "of", "the" },
-                // DistinctAttribute = "name",
+                DistinctAttribute = "name",
             };
             UpdateStatus update = await this.index.UpdateSettings(newSettings);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
@@ -59,7 +59,7 @@ namespace Meilisearch.Tests
             Settings response = await this.index.GetSettings();
             response.Should().NotBeNull();
             response.RankingRules.Should().Equals(this.defaultRankingRules);
-            // response.DistinctAttribute.Should().Equals("name");
+            response.DistinctAttribute.Should().Equals("name");
             Assert.Equal(new string[] { "name", "genre" }, response.SearchableAttributes);
             Assert.Equal(this.defaultSearchableAndDisplayedAttributes, response.DisplayedAttributes);
             Assert.Equal(new string[] { "of", "the" }, response.StopWords);

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -50,7 +50,7 @@ namespace Meilisearch.Tests
             {
                 SearchableAttributes = new string[] { "name", "genre" },
                 StopWords = new string[] { "of", "the" },
-                DistinctAttribute = "name",
+                // DistinctAttribute = "name",
             };
             UpdateStatus update = await this.index.UpdateSettings(newSettings);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
@@ -59,7 +59,7 @@ namespace Meilisearch.Tests
             Settings response = await this.index.GetSettings();
             response.Should().NotBeNull();
             response.RankingRules.Should().Equals(this.defaultRankingRules);
-            response.DistinctAttribute.Should().Equals("name");
+            // response.DistinctAttribute.Should().Equals("name");
             Assert.Equal(new string[] { "name", "genre" }, response.SearchableAttributes);
             Assert.Equal(this.defaultSearchableAndDisplayedAttributes, response.DisplayedAttributes);
             Assert.Equal(new string[] { "of", "the" }, response.StopWords);

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -19,11 +19,10 @@ namespace Meilisearch.Tests
             this.client = fixture.DefaultClient;
             this.defaultRankingRules = new string[]
             {
-                "typo",
                 "words",
+                "typo",
                 "proximity",
                 "attribute",
-                "wordsPosition",
                 "exactness",
             };
             this.defaultSearchableAndDisplayedAttributes = new string[] { "*" };

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -38,8 +38,8 @@ namespace Meilisearch.Tests
             settings.DistinctAttribute.Should().BeNull();
             Assert.Equal(settings.SearchableAttributes, this.defaultSearchableAndDisplayedAttributes);
             Assert.Equal(settings.DisplayedAttributes, this.defaultSearchableAndDisplayedAttributes);
-            settings.StopWords.Should().BeNull();
-            settings.Synonyms.Should().BeNull();
+            settings.StopWords.Should().BeEmpty();
+            settings.Synonyms.Should().BeEmpty();
             settings.FilterableAttributes.Should().BeEmpty();
         }
 


### PR DESCRIPTION
- Adapts tests according to v0.21.0 breaking changes:
   - Add `FilterableAttributes` to `CustomSearchWithFilter` and `CustomSearchWithFacetsDistribution` Tests
   - Adapts `RankingRules`
   - Wait for fix: `filterableAttributes` including `distinctAttribute` in addition to values set who do fail test: `Meilisearch.Tests.SettingsTests.UpdateSettings` and `Meilisearch.Tests.SettingsTests.UpdateSettingsWithoutOverwritting`
- Add tests:
  - Add phrase search tests
  - Add search test including filter with numbers