### PR TITLE
Fix warning in test shorthand for nullable type

### DIFF
--- a/src/Meilisearch/Stats.cs
+++ b/src/Meilisearch/Stats.cs
@@ -16,7 +16,7 @@ namespace Meilisearch
         /// <summary>
         /// Gets or sets last update timestamp.
         /// </summary>
-        public Nullable<DateTime> LastUpdate { get; set; }
+        public DateTime? LastUpdate { get; set; }
 
         /// <summary>
         /// Gets or sets index stats.


### PR DESCRIPTION
Fix warning in tests:
`warning SA1125: Use shorthand for nullable types`