### PR TITLE
Add method to delete an index without throwing any error (`DeleteIfExist`, `DeleteIndexIfExist`)

### DIFF
--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -111,7 +111,6 @@ namespace Meilisearch
 
                 throw;
             }
-
         }
 
         /// <summary>

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -94,7 +94,7 @@ namespace Meilisearch
         {
             try
             {
-                var responseMessage = await this.client.DeleteAsync($"/indexes/{this.Uid}");
+                var responseMessage = await this.http.DeleteAsync($"/indexes/{this.Uid}");
                 if (responseMessage.StatusCode != HttpStatusCode.NoContent)
                 {
                     throw new HttpRequestException($"Client failed to delete index ${this.Uid}");

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -85,6 +85,36 @@ namespace Meilisearch
         }
 
         /// <summary>
+        /// Deletes the index if it exists.
+        /// It's not a recovery delete. You will also lose the documents within the index.
+        /// </summary>
+        /// <returns>Returns the status of the delete operation.
+        /// True if the index existed and was deleted. False if it did not exist. </returns>
+        public async Task<bool> DeleteIfExists()
+        {
+            try
+            {
+                var responseMessage = await this.client.DeleteAsync($"/indexes/{this.Uid}");
+                if (responseMessage.StatusCode != HttpStatusCode.NoContent)
+                {
+                    throw new HttpRequestException($"Client failed to delete index ${this.Uid}");
+                }
+
+                return true;
+            }
+            catch (MeilisearchApiError error)
+            {
+                if (error.ErrorCode == "index_not_found")
+                {
+                    return false;
+                }
+
+                throw;
+            }
+
+        }
+
+        /// <summary>
         /// Add documents.
         /// </summary>
         /// <param name="documents">Documents to add.</param>

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -201,20 +201,7 @@ namespace Meilisearch
         /// True if the index existed and was deleted. False if it did not exist. </returns>
         public async Task<bool> DeleteIndexIfExists(string uid)
         {
-            try
-            {
-                await this.Index(uid).Delete();
-                return true;
-            }
-            catch (MeilisearchApiError error)
-            {
-                if (error.ErrorCode == "index_not_found")
-                {
-                    return false;
-                }
-
-                throw;
-            }
+            return await this.Index(uid).DeleteIfExists();
         }
     }
 }

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -201,5 +201,30 @@ namespace Meilisearch
         {
             return await this.Index(uid).Delete();
         }
+
+        /// <summary>
+        /// Deletes the index if it exists.
+        /// It's not a recovery delete. You will also lose the documents within the index.
+        /// </summary>
+        /// <param name="uid">unique dump identifier.</param>
+        /// <returns>Returns the status of the delete operation.
+        /// True if the index existed and was deleted. False if it did not exist. </returns>
+        public async Task<bool> DeleteIndexIfExists(string uid)
+        {
+            try
+            {
+                await this.Index(uid).Delete();
+                return true;
+            }
+            catch (MeilisearchApiError error)
+            {
+                if (error.ErrorCode == "index_not_found")
+                {
+                    return false;
+                }
+
+                throw;
+            }
+        }
     }
 }

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -177,5 +177,29 @@ namespace Meilisearch.Tests
             var stats = await index.GetStats();
             stats.Should().NotBeNull();
         }
+
+        [Fact]
+        public async Task WhenIndexExists_DeleteIfExists_ShouldReturnTrue()
+        {
+            var indexUid = "DeleteIndexTestUid";
+            var index = await this.defaultClient.GetOrCreateIndex(indexUid);
+            index.Uid.Should().Be(indexUid);
+            index.PrimaryKey.Should().BeNull();
+            var deleted = await index.DeleteIfExists();
+            deleted.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task WhenIndexNoLongerExists_DeleteIfExists_ShouldReturnFalse()
+        {
+            var indexUid = "DeleteIndexTestUid";
+            var index = await this.defaultClient.GetOrCreateIndex(indexUid);
+            index.Uid.Should().Be(indexUid);
+            index.PrimaryKey.Should().BeNull();
+            var deleted = await index.DeleteIfExists();
+            deleted.Should().BeTrue();
+            var deletedAgain = await index.DeleteIfExists();
+            deletedAgain.Should().BeFalse();
+        }
     }
 }

--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -134,5 +134,26 @@ namespace Meilisearch.Tests
             var deletedResult = await ms.DeleteIndex(indexUid);
             deletedResult.Should().BeTrue();
         }
+
+        [Fact]
+        public async Task GivenValidIndex_DeleteIndexIfExists_ShouldReturnTrue()
+        {
+            var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
+            MeilisearchClient ms = new MeilisearchClient(httpClient);
+            var indexUid = "DeleteIndexIfExistsTest";
+            var index = await ms.CreateIndex(indexUid, this.defaultPrimaryKey);
+            var deletedResult = await ms.DeleteIndexIfExists(indexUid);
+            deletedResult.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GivenInvalidIndex_DeleteIndexIfExists_ShouldReturnFalse()
+        {
+            var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
+            MeilisearchClient ms = new MeilisearchClient(httpClient);
+            var invalidIndexUid = "NonExistingIndexTest";
+            var deletedResult = await ms.DeleteIndexIfExists(invalidIndexUid);
+            deletedResult.Should().BeFalse();
+        }
     }
 }


### PR DESCRIPTION
- Added DeleteIfExist method to Index
- Added DeleteIndexIfExist method to Client
- Added unit tests for existing/non-existing index

Closes #156 