### PR TITLE
Added settings/displayed-attributes methods (to get, update and reset)

### DIFF
--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -341,7 +341,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateDisplayedAttributes(IEnumerable<string> displayedAttributes)
         {
             JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
-            HttpResponseMessage responseMessage = await this.client.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes", displayedAttributes, options);
+            HttpResponseMessage responseMessage = await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes", displayedAttributes, options);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>();
         }
 

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -330,7 +330,7 @@ namespace Meilisearch
         /// <returns>Returns the displayed attributes setting.</returns>
         public async Task<IEnumerable<string>> GetDisplayedAttributes()
         {
-            return await this.client.GetFromJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes");
+            return await this.http.GetFromJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes");
         }
 
         /// <summary>

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -326,6 +326,37 @@ namespace Meilisearch
         }
 
         /// <summary>
+        /// Gets the displayed attributes setting.
+        /// </summary>
+        /// <returns>Returns the displayed attributes setting.</returns>
+        public async Task<IEnumerable<string>> GetDisplayedAttributes()
+        {
+            return await this.client.GetFromJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes");
+        }
+
+        /// <summary>
+        /// Updates the displayed attributes setting.
+        /// </summary>
+        /// <param name="displayedAttributes">Collection of displayed attributes.</param>
+        /// <returns>Returns the updateID of the asynchronous task.</returns>
+        public async Task<UpdateStatus> UpdateDisplayedAttributes(IEnumerable<string> displayedAttributes)
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
+            HttpResponseMessage responseMessage = await this.client.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes", displayedAttributes, options);
+            return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>();
+        }
+
+        /// <summary>
+        /// Resets the displayed attributes setting.
+        /// </summary>
+        /// <returns>Returns the updateID of the asynchronous task.</returns>
+        public async Task<UpdateStatus> ResetDisplayedAttributes()
+        {
+            var httpresponse = await this.client.DeleteAsync($"/indexes/{this.Uid}/settings/displayed-attributes");
+            return await httpresponse.Content.ReadFromJsonAsync<UpdateStatus>();
+        }
+
+        /// <summary>
         /// Get stats.
         /// </summary>
         /// <returns>Return index stats.</returns>

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -351,7 +351,7 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> ResetDisplayedAttributes()
         {
-            var httpresponse = await this.client.DeleteAsync($"/indexes/{this.Uid}/settings/displayed-attributes");
+            var httpresponse = await this.http.DeleteAsync($"/indexes/{this.Uid}/settings/displayed-attributes");
             return await httpresponse.Content.ReadFromJsonAsync<UpdateStatus>();
         }
 


### PR DESCRIPTION
Change requested in #124 

`SettingsTest.cs` was restructured to remove code duplication and make further tests (for the rest of sub-settings) easier.
If it is required, I can revert part of all of this restructuring (or adjust it as requested).

If this PR will be cleared, rest of sub-settings will be added as one.