### PR TITLE
Add methods to automatically add/update documents in batches

### DIFF
--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -158,7 +158,7 @@ namespace Meilisearch.Tests
                 });
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
-            Assert.Equal(1, movies.Hits.Count());
+            Assert.Single(movies.Hits);
             Assert.Equal("1344", movies.Hits.First().Id);
             Assert.Equal("The Hobbit", movies.Hits.First().Name);
         }


### PR DESCRIPTION
Hi,

I have added the methods to add/update documents in batches (#157) in `Index.cs`. I have not been able to run the tests correctly because I get the following error in most of them:

```
Meilisearch.MeilisearchApiError
MeilisearchApiError, Message: The Content-Type "application/json; charset=utf-8" is invalid. Accepted values for the Content-Type header are: "application/json", "application/x-ndjson", "application/csv"
```

Seems to be an error with the `PostJsonAsync`method adding the charset parameter, but I suppose that has been working correctly for you.

Let me know if the code is okay and what should I do to fix that error. I will keep investigating if I get some time.