### PR TITLE
 Add method to get the raw index information

### DIFF
--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -41,12 +41,23 @@ namespace Meilisearch
         public string PrimaryKey { get; internal set; }
 
         /// <summary>
+        /// Gets raw index call response.
+        /// </summary>
+        /// <param name="http">HTTP client to make the call.</param>
+        /// <param name="uid">Uid of the index to retrieve.</param>
+        /// <returns>Call response.</returns>
+        public static async Task<HttpResponseMessage> GetRaw(HttpClient http, string uid)
+        {
+            return await http.GetAsync($"indexes/{uid}");
+        }
+
+        /// <summary>
         /// Fetch the info of the index.
         /// </summary>
         /// <returns>An instance of the index fetch.</returns>
         public async Task<Index> FetchInfo()
         {
-            var response = await this.http.GetAsync($"indexes/{this.Uid}");
+            var response = await GetRaw(this.http, this.Uid);
             var content = await response.Content.ReadFromJsonAsync<Index>();
             this.PrimaryKey = content.PrimaryKey;
             return this;

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -5,6 +5,7 @@ namespace Meilisearch
     using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Json;
+    using System.Text.Json;
     using System.Threading.Tasks;
     using Meilisearch.Extensions;
 
@@ -100,6 +101,17 @@ namespace Meilisearch
         public async Task<Index> GetIndex(string uid)
         {
             return await this.Index(uid).FetchInfo();
+        }
+
+        /// <summary>
+        /// Gets an index in raw format.
+        /// </summary>
+        /// <param name="uid">UID of the index to get.</param>
+        /// <returns>A <see cref="JsonElement"/> which represents the raw index as a JSON object.</returns>
+        public async Task<JsonElement> GetRawIndex(string uid)
+        {
+            var json = await (await Meilisearch.Index.GetRaw(this.http, uid)).Content.ReadAsStringAsync();
+            return JsonDocument.Parse(json).RootElement;
         }
 
         /// <summary>

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -4,15 +4,15 @@ namespace Meilisearch.Tests
     using System.Linq;
     using System.Threading.Tasks;
     using FluentAssertions;
+    using HttpClientFactoryLite;
     using Xunit;
 
     [Collection("Sequential")]
     public class IndexTests : IAsyncLifetime
     {
-        private MeilisearchClient defaultClient;
-        private string defaultPrimaryKey;
-
-        private IndexFixture fixture;
+        private readonly MeilisearchClient defaultClient;
+        private readonly string defaultPrimaryKey;
+        private readonly IndexFixture fixture;
 
         public IndexTests(IndexFixture fixture)
         {
@@ -206,6 +206,19 @@ namespace Meilisearch.Tests
             deleted.Should().BeTrue();
             var deletedAgain = await index.DeleteIfExists();
             deletedAgain.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GetRawIndex()
+        {
+            await this.fixture.SetUpBasicIndex("BasicIndex");
+            var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
+            MeilisearchClient ms = new MeilisearchClient(httpClient);
+
+            var rawIndex = await ms.GetRawIndex("BasicIndex");
+
+            rawIndex.GetProperty("uid").GetString().Should().Be("BasicIndex");
+            rawIndex.GetProperty("name").GetString().Should().Be("BasicIndex");
         }
     }
 }

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -218,7 +218,6 @@ namespace Meilisearch.Tests
             var rawIndex = await ms.GetRawIndex("BasicIndex");
 
             rawIndex.GetProperty("uid").GetString().Should().Be("BasicIndex");
-            rawIndex.GetProperty("name").GetString().Should().Be("BasicIndex");
         }
     }
 }


### PR DESCRIPTION
PR for issue #163 

I have added the method `MeilisearchClient#getRawIndex` (which returns `JsonElement`, not sure if that fits your needs) and the test `MeilisearchClientTests#getRawIndex`. Let me know if it is ok :)