### PR TITLE
Use IAsyncLifetime to initialize async data correctly

### DIFF
--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -1,8 +1,8 @@
 namespace Meilisearch.Tests
 {
-    using FluentAssertions;
     using System.Linq;
     using System.Threading.Tasks;
+    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
@@ -19,6 +19,7 @@ namespace Meilisearch.Tests
         }
 
         public async Task InitializeAsync() => await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -1,22 +1,25 @@
 namespace Meilisearch.Tests
 {
+    using FluentAssertions;
     using System.Linq;
     using System.Threading.Tasks;
-    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
-    public class DocumentTests
+    public class DocumentTests : IAsyncLifetime
     {
         private readonly MeilisearchClient client;
-        private readonly IndexFixture fixture;
+
+        private IndexFixture fixture;
 
         public DocumentTests(IndexFixture fixture)
         {
-            fixture.DeleteAllIndexes().Wait(); // Context test cleaned for each [Fact]
             this.fixture = fixture;
             this.client = fixture.DefaultClient;
         }
+
+        public async Task InitializeAsync() => await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         public async Task BasicDocumentsAddition()

--- a/tests/Meilisearch.Tests/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/IndexFixture.cs
@@ -4,7 +4,7 @@ namespace Meilisearch.Tests
     using System.Threading.Tasks;
     using Xunit;
 
-    public class IndexFixture : IDisposable
+    public class IndexFixture : IAsyncLifetime
     {
         public IndexFixture()
         {
@@ -13,10 +13,8 @@ namespace Meilisearch.Tests
 
         public MeilisearchClient DefaultClient { get; private set; }
 
-        public void Dispose()
-        {
-            this.DeleteAllIndexes().Wait(); // Let a clean MeiliSearch instance, for maintainers convenience only.
-        }
+        public Task InitializeAsync() => Task.CompletedTask;
+        public async Task DisposeAsync() => await this.DeleteAllIndexes(); // Let a clean MeiliSearch instance, for maintainers convenience only.
 
         public async Task<Meilisearch.Index> SetUpBasicIndex(string indexUid)
         {

--- a/tests/Meilisearch.Tests/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/IndexFixture.cs
@@ -14,6 +14,7 @@ namespace Meilisearch.Tests
         public MeilisearchClient DefaultClient { get; private set; }
 
         public Task InitializeAsync() => Task.CompletedTask;
+
         public async Task DisposeAsync() => await this.DeleteAllIndexes(); // Let a clean MeiliSearch instance, for maintainers convenience only.
 
         public async Task<Meilisearch.Index> SetUpBasicIndex(string indexUid)

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -1,23 +1,28 @@
 namespace Meilisearch.Tests
 {
+    using FluentAssertions;
     using System;
     using System.Linq;
     using System.Threading.Tasks;
-    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
-    public class IndexTests
+    public class IndexTests : IAsyncLifetime
     {
         private MeilisearchClient defaultClient;
         private string defaultPrimaryKey;
 
+        private IndexFixture fixture;
+
         public IndexTests(IndexFixture fixture)
         {
-            fixture.DeleteAllIndexes().Wait(); // Test context cleaned for each [Fact]
+            this.fixture = fixture;
             this.defaultClient = fixture.DefaultClient;
             this.defaultPrimaryKey = "movieId";
         }
+
+        public async Task InitializeAsync() => await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         public async Task BasicIndexCreation()

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -1,9 +1,9 @@
 namespace Meilisearch.Tests
 {
-    using FluentAssertions;
     using System;
     using System.Linq;
     using System.Threading.Tasks;
+    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
@@ -22,6 +22,7 @@ namespace Meilisearch.Tests
         }
 
         public async Task InitializeAsync() => await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]

--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -1,24 +1,29 @@
 namespace Meilisearch.Tests
 {
+    using FluentAssertions;
+    using HttpClientFactoryLite;
     using System;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using FluentAssertions;
-    using HttpClientFactoryLite;
     using Xunit;
 
     [Collection("Sequential")]
-    public class MeilisearchClientTests
+    public class MeilisearchClientTests : IAsyncLifetime
     {
         private MeilisearchClient defaultClient;
         private string defaultPrimaryKey;
 
+        private IndexFixture fixture;
+
         public MeilisearchClientTests(IndexFixture fixture)
         {
-            fixture.DeleteAllIndexes().Wait(); // Test context cleaned for each [Fact]
+            this.fixture = fixture;
             this.defaultClient = fixture.DefaultClient;
             this.defaultPrimaryKey = "movieId";
         }
+
+        public async Task InitializeAsync() => await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         public async Task GetVersionWithCustomClient()

--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -1,10 +1,10 @@
 namespace Meilisearch.Tests
 {
-    using FluentAssertions;
-    using HttpClientFactoryLite;
     using System;
     using System.Net.Http;
     using System.Threading.Tasks;
+    using FluentAssertions;
+    using HttpClientFactoryLite;
     using Xunit;
 
     [Collection("Sequential")]
@@ -23,6 +23,7 @@ namespace Meilisearch.Tests
         }
 
         public async Task InitializeAsync() => await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -1,8 +1,8 @@
 namespace Meilisearch.Tests
 {
-    using FluentAssertions;
     using System.Linq;
     using System.Threading.Tasks;
+    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
@@ -22,9 +22,9 @@ namespace Meilisearch.Tests
         public async Task InitializeAsync()
         {
             await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
-            this.basicIndex = await fixture.SetUpBasicIndex("BasicIndex-SearchTests");
-            this.indexForFaceting = await fixture.SetUpIndexForFaceting("IndexForFaceting-SearchTests");
-            this.indexWithIntId = await fixture.SetUpBasicIndexWithIntId("IndexWithIntId-SearchTests");
+            this.basicIndex = await this.fixture.SetUpBasicIndex("BasicIndex-SearchTests");
+            this.indexForFaceting = await this.fixture.SetUpIndexForFaceting("IndexForFaceting-SearchTests");
+            this.indexWithIntId = await this.fixture.SetUpBasicIndexWithIntId("IndexWithIntId-SearchTests");
         }
 
         public Task DisposeAsync() => Task.CompletedTask;
@@ -166,7 +166,7 @@ namespace Meilisearch.Tests
                 });
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
-            Assert.Equal(1, movies.Hits.Count());
+            Assert.Single(movies.Hits);
             Assert.Equal("1344", movies.Hits.First().Id);
             Assert.Equal("The Hobbit", movies.Hits.First().Name);
         }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -1,25 +1,33 @@
 namespace Meilisearch.Tests
 {
+    using FluentAssertions;
     using System.Linq;
     using System.Threading.Tasks;
-    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
-    public class SearchTests
+    public class SearchTests : IAsyncLifetime
     {
-        private readonly Index basicIndex;
-        private readonly Index indexForFaceting;
-        private readonly Index indexWithIntId;
+        private Index basicIndex;
+        private Index indexForFaceting;
+        private Index indexWithIntId;
+
+        private IndexFixture fixture;
 
         public SearchTests(IndexFixture fixture)
         {
-            fixture.DeleteAllIndexes().Wait(); // Context test cleaned for each [Fact]
-            var client = fixture.DefaultClient;
-            this.basicIndex = fixture.SetUpBasicIndex("BasicIndex-SearchTests").Result;
-            this.indexForFaceting = fixture.SetUpIndexForFaceting("IndexForFaceting-SearchTests").Result;
-            this.indexWithIntId = fixture.SetUpBasicIndexWithIntId("IndexWithIntId-SearchTests").Result;
+            this.fixture = fixture;
         }
+
+        public async Task InitializeAsync()
+        {
+            await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+            this.basicIndex = await fixture.SetUpBasicIndex("BasicIndex-SearchTests");
+            this.indexForFaceting = await fixture.SetUpIndexForFaceting("IndexForFaceting-SearchTests");
+            this.indexWithIntId = await fixture.SetUpBasicIndexWithIntId("IndexWithIntId-SearchTests");
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         public async Task BasicSearch()

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -1,8 +1,8 @@
 namespace Meilisearch.Tests
 {
-    using FluentAssertions;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
@@ -12,7 +12,6 @@ namespace Meilisearch.Tests
         private MeilisearchClient client;
         private Index index;
         private IndexFixture fixture;
-
 
         public SettingsTests(IndexFixture fixture)
         {
@@ -40,16 +39,15 @@ namespace Meilisearch.Tests
             };
         }
 
+        private delegate Task<TValue> IndexGetMethod<TValue>();
+
         public async Task InitializeAsync()
         {
             await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
-            this.index = await fixture.SetUpBasicIndex("BasicIndex-SettingsTests");
-
+            this.index = await this.fixture.SetUpBasicIndex("BasicIndex-SettingsTests");
         }
 
         public Task DisposeAsync() => Task.CompletedTask;
-
-        private delegate Task<TValue> IndexGetMethod<TValue>();
 
         private delegate Task<UpdateStatus> IndexUpdateMethod<TValue>(TValue newValue);
 

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -1,20 +1,22 @@
 namespace Meilisearch.Tests
 {
+    using FluentAssertions;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
-    public class SettingsTests
+    public class SettingsTests : IAsyncLifetime
     {
         private readonly Settings defaultSettings;
         private MeilisearchClient client;
         private Index index;
+        private IndexFixture fixture;
+
 
         public SettingsTests(IndexFixture fixture)
         {
-            fixture.DeleteAllIndexes().Wait(); // Test context cleaned for each [Fact]
+            this.fixture = fixture;
             this.client = fixture.DefaultClient;
 
             this.defaultSettings = new Settings
@@ -36,9 +38,16 @@ namespace Meilisearch.Tests
                 FilterableAttributes = new string[] { },
                 SortableAttributes = new string[] { },
             };
-
-            this.index = fixture.SetUpBasicIndex("BasicIndex-SettingsTests").Result;
         }
+
+        public async Task InitializeAsync()
+        {
+            await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+            this.index = await fixture.SetUpBasicIndex("BasicIndex-SettingsTests");
+
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         private delegate Task<TValue> IndexGetMethod<TValue>();
 

--- a/tests/Meilisearch.Tests/UpdateStatusTests.cs
+++ b/tests/Meilisearch.Tests/UpdateStatusTests.cs
@@ -1,8 +1,8 @@
 namespace Meilisearch.Tests
 {
-    using FluentAssertions;
     using System.Linq;
     using System.Threading.Tasks;
+    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
@@ -19,7 +19,7 @@ namespace Meilisearch.Tests
         public async Task InitializeAsync()
         {
             await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
-            this.index = await fixture.SetUpBasicIndex("BasicIndex-UpdateStatusTests");
+            this.index = await this.fixture.SetUpBasicIndex("BasicIndex-UpdateStatusTests");
         }
 
         public Task DisposeAsync() => Task.CompletedTask;

--- a/tests/Meilisearch.Tests/UpdateStatusTests.cs
+++ b/tests/Meilisearch.Tests/UpdateStatusTests.cs
@@ -1,21 +1,28 @@
 namespace Meilisearch.Tests
 {
+    using FluentAssertions;
     using System.Linq;
     using System.Threading.Tasks;
-    using FluentAssertions;
     using Xunit;
 
     [Collection("Sequential")]
-    public class UpdateStatusTests
+    public class UpdateStatusTests : IAsyncLifetime
     {
-        private readonly Meilisearch.Index index;
+        private Index index;
+        private IndexFixture fixture;
 
         public UpdateStatusTests(IndexFixture fixture)
         {
-            fixture.DeleteAllIndexes().Wait(); // Test context cleaned for each [Fact]
-            var client = fixture.DefaultClient;
-            this.index = fixture.SetUpBasicIndex("BasicIndex-UpdateStatusTests").Result;
+            this.fixture = fixture;
         }
+
+        public async Task InitializeAsync()
+        {
+            await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+            this.index = await fixture.SetUpBasicIndex("BasicIndex-UpdateStatusTests");
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         public async Task GetAllUpdateStatus()


### PR DESCRIPTION
Instead of using the constructor and things like `Task.Wait()` and `Task.Result` (which are considered anti patterns), I started using the `IAsyncLifeTime` interface to do async initializing correctly.

I believe this is the correct approach. If you read the docs about the `ICollectionFixture<T>`, which is, as far as I can see, the starting point/reason of this async data initialization, it says the following:

```
If asynchronous setup of TFixture is required it should implement the Xunit.IAsyncLifetime interface.
```

This resolves #174 