### PR TITLE
Fix GetDumpStatusById test case

### DIFF
--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -84,7 +84,7 @@ namespace Meilisearch.Tests
 
             var dumpStatus = await this.defaultClient.GetDumpStatus(dump.Uid);
 
-            dumpStatus.Status.Should().Be("done");
+            dumpStatus.Status.Should().BeOneOf("done", "in_progress", "failed");
             Assert.Equal(dump.Uid, dumpStatus.Uid);
         }
 

--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -84,7 +84,7 @@ namespace Meilisearch.Tests
 
             var dumpStatus = await this.defaultClient.GetDumpStatus(dump.Uid);
 
-            dumpStatus.Status.Should().BeOneOf("done", "in_progress", "failed");
+            dumpStatus.Status.Should().BeOneOf("done", "in_progress");
             Assert.Equal(dump.Uid, dumpStatus.Uid);
         }
 


### PR DESCRIPTION
Fix for issue where test fails randomly:
https://github.com/meilisearch/meilisearch-dotnet/issues/174

Explanation: https://github.com/meilisearch/meilisearch-dotnet/issues/174#issuecomment-944402168