### PR TITLE
Update version for the next release (v0.8.0)

### DIFF
--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>MeiliSearch</PackageId>
-        <Version>0.7.2</Version>
+        <Version>0.8.0</Version>
         <Description>.NET wrapper for MeiliSearch, an open-source search engine</Description>
         <RepositoryUrl>https://github.com/meilisearch/meilisearch-dotnet</RepositoryUrl>
         <PackageTags>meilisearch;dotnet;sdk;search-engine;search;instant-search</PackageTags>


### PR DESCRIPTION
Breaking because of https://github.com/meilisearch/meilisearch-dotnet/pull/180 and https://github.com/meilisearch/meilisearch-dotnet/pull/189