### PR TITLE
Remove dependancy on Microsoft.AspNetCore.WebUtilities

### DIFF
--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -9,7 +9,6 @@ namespace Meilisearch
     using System.Text.Json;
     using System.Threading.Tasks;
     using Meilisearch.Extensions;
-    using Microsoft.AspNetCore.WebUtilities;
 
     /// <summary>
     /// MeiliSearch index to search and manage documents.
@@ -156,7 +155,7 @@ namespace Meilisearch
             string uri = $"/indexes/{this.Uid}/documents";
             if (primaryKey != default)
             {
-                uri = QueryHelpers.AddQueryString(uri, new { primaryKey = primaryKey }.AsDictionary());
+                uri = $"{uri}?{new { primaryKey = primaryKey }.ToQueryString()}";
             }
 
             responseMessage = await this.http.PostJsonCustomAsync(uri, documents);
@@ -195,7 +194,7 @@ namespace Meilisearch
             string uri = $"/indexes/{this.Uid}/documents";
             if (primaryKey != default)
             {
-                uri = QueryHelpers.AddQueryString(uri, new { primaryKey = primaryKey }.AsDictionary());
+                uri = $"{uri}?{new { primaryKey = primaryKey }.ToQueryString()}";
             }
 
             var filteredDocuments = documents.RemoveNullValues();
@@ -256,7 +255,7 @@ namespace Meilisearch
             string uri = $"/indexes/{this.Uid}/documents";
             if (query != null)
             {
-                uri = QueryHelpers.AddQueryString(uri, query.AsDictionary());
+                uri = $"{uri}?{query.ToQueryString()}";
             }
 
             return await this.http.GetFromJsonAsync<IEnumerable<T>>(uri);

--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -11,7 +11,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>

--- a/src/Meilisearch/ObjectExtensions.cs
+++ b/src/Meilisearch/ObjectExtensions.cs
@@ -25,7 +25,7 @@ namespace Meilisearch
         }
 
         /// <summary>
-        /// Transforms an MeiliSearch object into an url encoded query string.
+        /// Transforms a MeiliSearch object into an URL encoded query string.
         /// </summary>
         /// <param name="source">Object to transform.</param>
         /// <param name="bindingAttr">Binding flags.</param>

--- a/src/Meilisearch/ObjectExtensions.cs
+++ b/src/Meilisearch/ObjectExtensions.cs
@@ -1,5 +1,6 @@
 namespace Meilisearch
 {
+    using System;
     using System.Collections.Generic;
     using System.Dynamic;
     using System.Linq;
@@ -21,6 +22,22 @@ namespace Meilisearch
             return source.GetType().GetProperties(bindingAttr).Where(p => p.GetValue(source, null) != null).ToDictionary(
                 propInfo => char.ToLowerInvariant(propInfo.Name[0]) + propInfo.Name.Substring(1),
                 propInfo => propInfo.GetValue(source, null).ToString());
+        }
+
+        /// <summary>
+        /// Transforms an MeiliSearch object into an url encoded query string.
+        /// </summary>
+        /// <param name="source">Object to transform.</param>
+        /// <param name="bindingAttr">Binding flags.</param>
+        /// <returns>Returns an url encoded query string.</returns>
+        public static string ToQueryString(this object source, BindingFlags bindingAttr = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance)
+        {
+            var values = source.GetType().GetProperties(bindingAttr)
+            .Where(p => p.GetValue(source, null) != null)
+            .Select(p =>
+                Uri.EscapeDataString(char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1)) + "=" + Uri.EscapeDataString(p.GetValue(source, null).ToString()));
+            var queryString = string.Join("&", values);
+            return queryString;
         }
 
         /// <summary>

--- a/tests/Meilisearch.Tests/Meilisearch.Tests.csproj
+++ b/tests/Meilisearch.Tests/Meilisearch.Tests.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
         <PackageReference Include="FluentAssertions" Version="6.2.0" />
         <PackageReference Include="HttpClientFactoryLite" Version="0.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
+++ b/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
@@ -1,0 +1,41 @@
+namespace Meilisearch.Tests
+{
+    using Microsoft.AspNetCore.WebUtilities;
+    using Xunit;
+
+    public class ObjectExtensionsTests
+    {
+        [Theory]
+        [InlineData("simple")]
+        [InlineData("com pl <->& ex")]
+        void QueryStringsAreEqualsForPrimaryKey(string key)
+        {
+            string uri = "/indexes/myindex/documents";
+            var o = new { primaryKey = key };
+
+            string expected = QueryHelpers.AddQueryString(uri, o.AsDictionary());
+            string actual = $"{uri}?{o.ToQueryString()}";
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Theory]
+        [InlineData(null, null, "")]
+        [InlineData(1, null, "")]
+        [InlineData(null, 3, "")]
+        [InlineData(null, null, "attr")]
+        [InlineData(1, 2, "")]
+        [InlineData(1, null, "attr")]
+        [InlineData(null, 2, "attr")]
+        [InlineData(1, 2, "attr")]
+        void QueryStringsAreEqualsForDocumentQuery(int? offset, int? limit, string attributesToRetrieve)
+        {
+            string uri = "/indexes/myindex/documents";
+            var dq = new DocumentQuery { Offset = offset, Limit = limit, AttributesToRetrieve = attributesToRetrieve };
+
+            string expected = QueryHelpers.AddQueryString(uri, dq.AsDictionary());
+            string actual = $"{uri}?{dq.ToQueryString()}";
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #176 

This method is actually used in order to work with `QueryHelpers.AddQueryString`

```C#
public static IDictionary<string, string> AsDictionary(this object source, BindingFlags bindingAttr = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance)
{
    return source.GetType().GetProperties(bindingAttr).Where(p => p.GetValue(source, null) != null).ToDictionary(
        propInfo => char.ToLowerInvariant(propInfo.Name[0]) + propInfo.Name.Substring(1),
        propInfo => propInfo.GetValue(source, null).ToString());
}
```

I've created a new one that takes an object and transform it to a query string.

```C#
public static string ToQueryString(this object source, BindingFlags bindingAttr = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance)
{
    var values = source.GetType().GetProperties(bindingAttr)
    .Where(p => p.GetValue(source, null) != null)
    .Select(p =>
        Uri.EscapeDataString(char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1)) + "=" + Uri.EscapeDataString(p.GetValue(source, null).ToString()));
    var queryString = string.Join("&", values);
    return queryString;
}
```

I've change in `Index.cs`

```C#
// FROM
uri = QueryHelpers.AddQueryString(uri, new { primaryKey = primaryKey }.AsDictionary());
// TO
uri = $"{uri}?{new { primaryKey = primaryKey }.ToQueryString()}";
```

The query string is appended by hand, you may want to have a helper method to do this

Some tests have been added to make sure queries are the same.

