### PR TITLE
Batch Operations quickfix

### DIFF
--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -697,7 +697,7 @@ namespace Meilisearch
             var result = new List<UpdateStatus>();
             for (var i = 0; i < numberOfBatches; i++)
             {
-                var actualSize = Math.Min(batchSize, itemsList.Count - (i*batchSize));
+                var actualSize = Math.Min(batchSize, itemsList.Count - (i * batchSize));
                 var batch = itemsList.GetRange(i * batchSize, actualSize);
                 await action.Invoke(batch, result);
             }

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -697,7 +697,8 @@ namespace Meilisearch
             var result = new List<UpdateStatus>();
             for (var i = 0; i < numberOfBatches; i++)
             {
-                var batch = itemsList.GetRange(i * batchSize, batchSize);
+                var actualSize = Math.Min(batchSize, itemsList.Count - (i*batchSize));
+                var batch = itemsList.GetRange(i * batchSize, actualSize);
                 await action.Invoke(batch, result);
             }
 

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -53,6 +53,7 @@ namespace Meilisearch.Tests
                 new Movie { Id = "2", Name = "Reservoir Dogs" },
                 new Movie { Id = "3", Name = "Taxi Driver" },
                 new Movie { Id = "4", Name = "Interstellar" },
+                new Movie { Id = "5", Name = "Titanic" },
             };
             var updates = await index.AddDocumentsInBatches(movies, 2);
             foreach (var u in updates)
@@ -170,6 +171,7 @@ namespace Meilisearch.Tests
                 new Movie { Id = "2", Name = "Reservoir Dogs" },
                 new Movie { Id = "3", Name = "Taxi Driver" },
                 new Movie { Id = "4", Name = "Interstellar" },
+                new Movie { Id = "5", Name = "Titanic" },
             };
             var updates = await index.AddDocumentsInBatches(movies, 2);
             foreach (var u in updates)
@@ -184,6 +186,7 @@ namespace Meilisearch.Tests
                 new Movie { Id = "2", Name = "Reservoir Dogs", Genre = "Drama" },
                 new Movie { Id = "3", Name = "Taxi Driver", Genre = "Drama" },
                 new Movie { Id = "4", Name = "Interstellar", Genre = "Sci-Fi" },
+                new Movie { Id = "5", Name = "Titanic", Genre = "Drama" },
             };
             updates = await index.UpdateDocumentsInBatches(movies, 2);
             foreach (var u in updates)


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes a little bug where the Documents Count is not a mulitple of BachSizes when Adding/Updating Document In Batches

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to MeiliSearch!
