### PR TITLE
Rename all async methods with an Async suffix

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -18,7 +18,7 @@ delete_documents_1: |-
 search_post_1: |-
 get_update_1: |-
 get_all_updates_1: |-
-  var updates = await client.Index("movies").GetAllUpdateStatus();
+  var updates = await client.IndexAsync("movies").GetAllUpdateStatus();
   foreach (UpdateStatus update in updates)
   {
       Console.WriteLine(update.Status);
@@ -37,25 +37,25 @@ get_ranking_rules_1: |-
 update_ranking_rules_1: |-
 reset_ranking_rules_1: |-
 get_distinct_attribute_1: |-
-  string result = await client.Index("shoes").GetDistinctAttribute();
+  string result = await client.IndexAsync("shoes").GetDistinctAttribute();
 update_distinct_attribute_1: |-
-  UpdateStatus result = await client.Index("shoes").UpdateDistinctAttribute("skuid");
+  UpdateStatus result = await client.IndexAsync("shoes").UpdateDistinctAttribute("skuid");
 reset_distinct_attribute_1: |-
-  UpdateStatus result = await client.Index("shoes").ResetDistinctAttribute();
+  UpdateStatus result = await client.IndexAsync("shoes").ResetDistinctAttribute();
 get_searchable_attributes_1: |-
 update_searchable_attributes_1: |-
 reset_searchable_attributes_1: |-
 get_filterable_attributes_1: |-
-  IEnumerable<string> attributes = await client.Index("movies").GetFilterableAttributes();
+  IEnumerable<string> attributes = await client.IndexAsync("movies").GetFilterableAttributes();
   foreach (string attribute in attributes)
   {
       Console.WriteLine(attribute);
   }
 update_filterable_attributes_1: |-
   List<string> attributes = new() { "genres", "director" };
-  UpdateStatus result = await client.Index("movies").UpdateFilterableAttributes(attributes);
+  UpdateStatus result = await client.Index("movies").UpdateFilterableAttributesAsync(attributes);
 reset_filterable_attributes_1: |-
-  UpdateStatus result = await client.Index("movies").ResetFilterableAttributes();
+  UpdateStatus result = await client.Index("movies").ResetFilterableAttributesAsync();
 get_displayed_attributes_1: |-
 update_displayed_attributes_1: |-
 reset_displayed_attributes_1: |-
@@ -68,7 +68,7 @@ field_properties_guide_searchable_1: |-
 field_properties_guide_displayed_1: |-
 filtering_guide_1: |-
   SearchQuery filters = new SearchQuery() { Filter = "release_date > \"795484800\"" };
-  SearchResult<Movie> movies = await client.Index("movies").Search<Movie>("Avengers", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Avengers", filters);
   foreach (var movie in movies.Hits)
   {
       Console.WriteLine(movie.Title);
@@ -76,21 +76,21 @@ filtering_guide_1: |-
 filtering_guide_2: |-
   SearchQuery filters = new SearchQuery() { Filter = "release_date > 795484800 AND (director =
   \"Tim Burton\" OR director = \"Christopher Nolan\")" };
-  SearchResult<Movie> movies = await client.Index("movies").Search<Movie>("Batman", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Batman", filters);
   foreach (var movie in movies.Hits)
   {
       Console.WriteLine(movie.Title);
   }
 filtering_guide_3: |-
   SearchQuery filters = new SearchQuery() { Filter = "director = \"Jordan Peele\"" };
-  SearchResult<Movie> movies = await client.Index("movies").Search<Movie>("horror", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("horror", filters);
   foreach (var movie in movies.Hits)
   {
       Console.WriteLine(movie.Title);
   }
 filtering_guide_4: |-
   SearchQuery filters = new SearchQuery() { Filter = "rating >= 3 AND (NOT director = \"Tim Burton\"" };
-  SearchResult<Movie> movies = await client.Index("movies").Search<Movie>("Planet of the Apes", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Planet of the Apes", filters);
   foreach (var movie in movies.Hits)
   {
       Console.WriteLine(movie.Title);
@@ -150,7 +150,7 @@ getting_started_add_documents_md: |-
               var movies = JsonSerializer.Deserialize<IEnumerable<Movie>>(jsonString, options);
 
               var index = client.Index("movies");
-              await index.AddDocuments<Movie>(movies);
+              await index.AddDocumentsAsync<Movie>(movies);
           }
       }
   }
@@ -161,7 +161,7 @@ getting_started_search_md: |-
   MeilisearchClient client = new MeilisearchClient("http://localhost:7700", "masterKey");
   var index = client.Index("movies");
 
-  SearchResult<Movie> movies = await index.Search<Movie>("harry pottre");
+  SearchResult<Movie> movies = await index.SearchAsync<Movie>("harry pottre");
   foreach (var movie in movies.Hits)
   {
       Console.WriteLine(movie.Title);
@@ -179,7 +179,7 @@ faceted_search_filter_1: |-
       }
   };
 
-  SearchResult<Movie> movies = await client.Index("movies").Search<Movie>("thriller", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("thriller", filters);
   foreach (var movie in movies.Hits)
   {
       Console.WriteLine(movie.Title);
@@ -190,7 +190,7 @@ faceted_search_facets_distribution_1: |-
       FacetsDistribution = new string[] { "genres" }
   };
 
-  SearchResult<Movie> movies = await client.Index("movies").Search<Movie>("Batman", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Batman", filters);
   foreach (var movie in movies.Hits)
   {
       Console.WriteLine(movie.Title);
@@ -212,10 +212,10 @@ reset_sortable_attributes_1: |-
 search_parameter_guide_sort_1: |-
 geosearch_guide_filter_settings_1: |-
   List<string> attributes = new() { "_geo" };
-  UpdateStatus result = await client.Index("movies").UpdateFilterableAttributes(attributes);
+  UpdateStatus result = await client.Index("movies").UpdateFilterableAttributesAsync(attributes);
 geosearch_guide_filter_usage_1: |-
   SearchQuery filters = new SearchQuery() { Filter = "_geoRadius(45.4628328, 9.1076931, 2000)" };
-  SearchResult<Restaurant> restaurants = await client.Index("restaurants").Search<Restaurant>("", filters);
+  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>("", filters);
   foreach (var restaurant in restaurants.Hits)
   {
       Console.WriteLine(restaurant.Name);
@@ -226,21 +226,21 @@ geosearch_guide_filter_usage_2: |-
       Filter = new string[] { "_geoRadius(45.4628328, 9.1076931, 2000) AND type = pizza" }
   };
 
-  SearchResult<Restaurant> restaurants = await client.Index("restaurants").Search<Restaurant>("restaurants", filters);
+  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>("restaurants", filters);
   foreach (var restaurant in restaurants.Hits)
   {
       Console.WriteLine(restaurant.Name);
   }
 geosearch_guide_sort_settings_1: |-
   List<string> attributes = new() { "_geo" };
-  UpdateStatus result = await client.Index("restaurants").UpdateSortableAttributes(attributes);
+  UpdateStatus result = await client.Index("restaurants").UpdateSortableAttributesAsync(attributes);
 geosearch_guide_sort_usage_1: |-
   SearchQuery filters = new SearchQuery()
   {
       Sort = new string[] { "_geoPoint(48.8583701,2.2922926):asc" }
   };
 
-  SearchResult<Restaurant> restaurants = await client.Index("restaurants").Search<Restaurant>("", filters);
+  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>("", filters);
   foreach (var restaurant in restaurants.Hits)
   {
       Console.WriteLine(restaurant.Name);
@@ -254,7 +254,7 @@ geosearch_guide_sort_usage_2: |-
       }
   };
 
-  SearchResult<Restaurant> restaurants = await client.Index("restaurants").Search<Restaurant>("restaurants", filters);
+  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>("restaurants", filters);
   foreach (var restaurant in restaurants.Hits)
   {
       Console.WriteLine(restaurant.Name);

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -18,7 +18,7 @@ delete_documents_1: |-
 search_post_1: |-
 get_update_1: |-
 get_all_updates_1: |-
-  var updates = await client.IndexAsync("movies").GetAllUpdateStatus();
+  var updates = await client.Index("movies").GetAllUpdateStatusAsync();
   foreach (UpdateStatus update in updates)
   {
       Console.WriteLine(update.Status);
@@ -37,16 +37,16 @@ get_ranking_rules_1: |-
 update_ranking_rules_1: |-
 reset_ranking_rules_1: |-
 get_distinct_attribute_1: |-
-  string result = await client.IndexAsync("shoes").GetDistinctAttribute();
+  string result = await client.Index("shoes").GetDistinctAttributeAsync();
 update_distinct_attribute_1: |-
-  UpdateStatus result = await client.IndexAsync("shoes").UpdateDistinctAttribute("skuid");
+  UpdateStatus result = await client.Index("shoes").UpdateDistinctAttributeAsync("skuid");
 reset_distinct_attribute_1: |-
-  UpdateStatus result = await client.IndexAsync("shoes").ResetDistinctAttribute();
+  UpdateStatus result = await client.Index("shoes").ResetDistinctAttributeAsync();
 get_searchable_attributes_1: |-
 update_searchable_attributes_1: |-
 reset_searchable_attributes_1: |-
 get_filterable_attributes_1: |-
-  IEnumerable<string> attributes = await client.IndexAsync("movies").GetFilterableAttributes();
+  IEnumerable<string> attributes = await client.Index("movies").GetFilterableAttributesAsync();
   foreach (string attribute in attributes)
   {
       Console.WriteLine(attribute);

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ namespace GettingStarted
             };
 
             // If the index 'movies' does not exist, MeiliSearch creates it when you first add the documents.
-            var update = await index.AddDocuments<Movie>(documents); // # => { "updateId": 0 }
+            var update = await index.AddDocumentsAsync<Movie>(documents); // # => { "updateId": 0 }
         }
     }
 }
@@ -121,7 +121,7 @@ With the `updateId` (via `update.UpdateId`), you can check the status (`enqueued
 
 ```c#
 # MeiliSearch is typo-tolerant:
-SearchResult<Movie> movies = await index.Search<Movie>("philadalphia");
+SearchResult<Movie> movies = await index.SearchAsync<Movie>("philadalphia");
 foreach(var prop in movies.Hits) {
     Console.WriteLine (prop.Title);
 }
@@ -149,7 +149,7 @@ JSON Output:
 All the supported options are described in the [search parameters](https://docs.meilisearch.com/reference/features/search_parameters.html) section of the documentation.
 
 ```c#
-SearchResult<Movie> movies = await index.Search<Movie>(
+SearchResult<Movie> movies = await index.SearchAsync<Movie>(
     "car",
     new SearchQuery
     {
@@ -194,25 +194,25 @@ This package only guarantees the compatibility with the [version v0.24.0 of Meil
 #### Create an index <!-- omit in toc -->
 
 ```c#
-var index = await client.CreateIndex("movies");
+var index = await client.CreateIndexAsync("movies");
 ```
 
 #### Create an index and give the primary-key <!-- omit in toc -->
 
 ```c#
-var index = await client.CreateIndex("movies", "id");
+var index = await client.CreateIndexAsync("movies", "id");
 ```
 
 #### List all an index <!-- omit in toc -->
 
 ```c#
-var indexes = await client.GetAllIndexes();
+var indexes = await client.GetAllIndexesAsync();
 ```
 
 #### Get an Index object <!-- omit in toc -->
 
 ```c#
-var index = await client.GetIndex("movies");
+var index = await client.GetIndexAsync("movies");
 ```
 
 ### Documents
@@ -220,8 +220,8 @@ var index = await client.GetIndex("movies");
 #### Add or Update Documents <!-- omit in toc -->
 
 ```c#
-var updateStatus = await index.AddDocuments(new Movie[] { new Movie { Id = "1", Title = "Carol" } } );
-var updateStatus = await index.UpdateDocuments(new Movie[] { new Movie { Id = "1", Title = "Carol" } } );
+var updateStatus = await index.AddDocumentsAsync(new Movie[] { new Movie { Id = "1", Title = "Carol" } } );
+var updateStatus = await index.UpdateDocumentsAsync(new Movie[] { new Movie { Id = "1", Title = "Carol" } } );
 ```
 
 Update Status has a reference `UpdateId` to get the status of the action.
@@ -229,31 +229,31 @@ Update Status has a reference `UpdateId` to get the status of the action.
 #### Get Documents <!-- omit in toc -->
 
 ```c#
-var documents = await index.GetDocuments<Movie>(new DocumentQuery { Limit = 1 });
+var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery { Limit = 1 });
 ```
 
 #### Get Document by Id <!-- omit in toc -->
 
 ```c#
-var document = await index.GetDocument<Movie>("10");
+var document = await index.GetDocumentAsync<Movie>("10");
 ```
 
 #### Delete documents <!-- omit in toc -->
 
 ```c#
-var updateStatus = await index.DeleteOneDocument("11");
+var updateStatus = await index.DeleteOneDocumentAsync("11");
 ```
 
 #### Delete in Batch <!-- omit in toc -->
 
 ```c#
-var updateStatus = await index.DeleteDocuments(new [] {"12","13","14"});
+var updateStatus = await index.DeleteDocumentsAsync(new [] {"12","13","14"});
 ```
 
 #### Delete all documents <!-- omit in toc -->
 
 ```c#
-var updateStatus = await indextoDelete.DeleteAllDocuments();
+var updateStatus = await indextoDelete.DeleteAllDocumentsAsync();
 ```
 
 ### Update Status
@@ -261,13 +261,13 @@ var updateStatus = await indextoDelete.DeleteAllDocuments();
 #### Get Update Status By Id <!-- omit in toc -->
 
 ```c#
-UpdateStatus individualStatus = await index.GetUpdateStatus(1);
+UpdateStatus individualStatus = await index.GetUpdateStatusAsync(1);
 ```
 
 #### Get All Update Status <!-- omit in toc -->
 
 ```c#
-var status = await index.GetAllUpdateStatus();
+var status = await index.GetAllUpdateStatusAsync();
 ```
 
 ### Search
@@ -275,13 +275,13 @@ var status = await index.GetAllUpdateStatus();
 #### Basic Search <!-- omit in toc -->
 
 ```c#
-var movies = await this.index.Search<Movie>("prince");
+var movies = await this.index.SearchAsync<Movie>("prince");
 ```
 
 #### Custom Search <!-- omit in toc -->
 
 ```c#
-var movies = await this.index.Search<Movie>("prince", new SearchQuery { Limit = 100 });
+var movies = await this.index.SearchAsync<Movie>("prince", new SearchQuery { Limit = 100 });
 ```
 
 ## 🧰 Use a Custom HTTP Client

--- a/src/Meilisearch/Extensions/HttpExtensions.cs
+++ b/src/Meilisearch/Extensions/HttpExtensions.cs
@@ -3,6 +3,7 @@ namespace Meilisearch.Extensions
     using System.Net.Http;
     using System.Text;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -16,13 +17,14 @@ namespace Meilisearch.Extensions
         /// <param name="client">HttpClient.</param>
         /// <param name="uri">Endpoint.</param>
         /// <param name="body">Body sent.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the body to send.</typeparam>
         /// <returns>Returns the HTTP response from the MeiliSearch server.</returns>
-        public static async Task<HttpResponseMessage> PostJsonCustomAsync<T>(this HttpClient client, string uri, T body)
+        public static async Task<HttpResponseMessage> PostJsonCustomAsync<T>(this HttpClient client, string uri, T body, CancellationToken cancellationToken = default)
         {
             var payload = PrepareJsonPayload<T>(body);
 
-            return await client.PostAsync(uri, payload);
+            return await client.PostAsync(uri, payload, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -32,13 +34,14 @@ namespace Meilisearch.Extensions
         /// <param name="uri">Endpoint.</param>
         /// <param name="body">Body sent.</param>
         /// <param name="options">Json options for serialization.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the body to send.</typeparam>
         /// <returns>Returns the HTTP response from the MeiliSearch server.</returns>
-        public static async Task<HttpResponseMessage> PostJsonCustomAsync<T>(this HttpClient client, string uri, T body, JsonSerializerOptions options)
+        public static async Task<HttpResponseMessage> PostJsonCustomAsync<T>(this HttpClient client, string uri, T body, JsonSerializerOptions options, CancellationToken cancellationToken = default)
         {
             var payload = PrepareJsonPayload<T>(body, options);
 
-            return await client.PostAsync(uri, payload);
+            return await client.PostAsync(uri, payload, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -47,13 +50,14 @@ namespace Meilisearch.Extensions
         /// <param name="client">HttpClient.</param>
         /// <param name="uri">Endpoint.</param>
         /// <param name="body">Body sent.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the body to send.</typeparam>
         /// <returns>Returns the HTTP response from the MeiliSearch server.</returns>
-        public static async Task<HttpResponseMessage> PutJsonCustomAsync<T>(this HttpClient client, string uri, T body)
+        public static async Task<HttpResponseMessage> PutJsonCustomAsync<T>(this HttpClient client, string uri, T body, CancellationToken cancellationToken = default)
         {
             var payload = PrepareJsonPayload<T>(body);
 
-            return await client.PutAsync(uri, payload);
+            return await client.PutAsync(uri, payload, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Meilisearch/MeilisearchMessageHandler.cs
+++ b/src/Meilisearch/MeilisearchMessageHandler.cs
@@ -35,7 +35,7 @@ namespace Meilisearch
                 {
                     if (response.Content.Headers.ContentLength != 0)
                     {
-                        var content = await response.Content.ReadFromJsonAsync<MeilisearchApiErrorContent>();
+                        var content = await response.Content.ReadFromJsonAsync<MeilisearchApiErrorContent>(cancellationToken: cancellationToken).ConfigureAwait(false);
                         throw new MeilisearchApiError(content);
                     }
 

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -29,12 +29,12 @@ namespace Meilisearch.Tests
             Index index = this.client.Index(indexUID);
 
             // Add the documents
-            UpdateStatus update = await index.AddDocuments(new[] { new Movie { Id = "1", Name = "Batman" } });
+            UpdateStatus update = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Check the documents have been added
-            var docs = await index.GetDocuments<Movie>();
+            var docs = await index.GetDocumentsAsync<Movie>();
             Assert.Equal("1", docs.First().Id);
             Assert.Equal("Batman", docs.First().Name);
             docs.First().Genre.Should().BeNull();
@@ -55,15 +55,15 @@ namespace Meilisearch.Tests
                 new Movie { Id = "4", Name = "Interstellar" },
                 new Movie { Id = "5", Name = "Titanic" },
             };
-            var updates = await index.AddDocumentsInBatches(movies, 2);
+            var updates = await index.AddDocumentsInBatchesAsync(movies, 2);
             foreach (var u in updates)
             {
                 u.UpdateId.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForPendingUpdate(u.UpdateId);
+                await index.WaitForPendingUpdateAsync(u.UpdateId);
             }
 
             // Check the documents have been added (one movie from each batch)
-            var docs = (await index.GetDocuments<Movie>()).ToList();
+            var docs = (await index.GetDocumentsAsync<Movie>()).ToList();
             Assert.Equal("1", docs.ElementAt(0).Id);
             Assert.Equal("Batman", docs.ElementAt(0).Name);
             Assert.Equal("3", docs.ElementAt(2).Id);
@@ -74,15 +74,15 @@ namespace Meilisearch.Tests
         public async Task BasicDocumentsAdditionWithCreateIndex()
         {
             var indexUID = "BasicDocumentsAdditionWithCreateIndexTest";
-            Index index = await this.client.CreateIndex(indexUID);
+            Index index = await this.client.CreateIndexAsync(indexUID);
 
             // Add the documents
-            UpdateStatus update = await index.AddDocuments(new[] { new Movie { Id = "1", Name = "Batman" } });
+            UpdateStatus update = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Check the documents have been added
-            var docs = await index.GetDocuments<Movie>();
+            var docs = await index.GetDocumentsAsync<Movie>();
             Assert.Equal("1", docs.First().Id);
             Assert.Equal("Batman", docs.First().Name);
             docs.First().Genre.Should().BeNull();
@@ -92,22 +92,22 @@ namespace Meilisearch.Tests
         public async Task BasicDocumentsAdditionWithTimeoutError()
         {
             var indexUID = "BasicDocumentsAdditionWithTimeoutError";
-            Index index = await this.client.GetOrCreateIndex(indexUID);
+            Index index = await this.client.GetOrCreateIndexAsync(indexUID);
 
             // Add the documents
-            UpdateStatus update = await index.AddDocuments(new[] { new Movie { Id = "1", Name = "Batman" } });
-            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForPendingUpdate(update.UpdateId, 0));
+            UpdateStatus update = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForPendingUpdateAsync(update.UpdateId, 0));
         }
 
         [Fact]
         public async Task BasicDocumentsAdditionWithTimeoutErrorByInterval()
         {
             var indexUID = "BasicDocumentsAdditionWithTimeoutErrorByIntervalTest";
-            Index index = await this.client.GetOrCreateIndex(indexUID);
+            Index index = await this.client.GetOrCreateIndexAsync(indexUID);
 
             // Add the documents
-            UpdateStatus update = await index.AddDocuments(new[] { new Movie { Id = "1", Name = "Batman" } });
-            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForPendingUpdate(update.UpdateId, 0, 10));
+            UpdateStatus update = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForPendingUpdateAsync(update.UpdateId, 0, 10));
         }
 
         [Fact]
@@ -118,8 +118,8 @@ namespace Meilisearch.Tests
             index.PrimaryKey.Should().BeNull();
 
             // Add the documents
-            var update = await index.AddDocuments(new[] { new { Key = "1", Name = "Ironman" } }, "key");
-            await index.WaitForPendingUpdate(update.UpdateId);
+            var update = await index.AddDocumentsAsync(new[] { new { Key = "1", Name = "Ironman" } }, "key");
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
 
             // Check the primary key has been set
@@ -134,21 +134,21 @@ namespace Meilisearch.Tests
             Index index = this.client.Index(indexUID);
 
             // Add the documents
-            UpdateStatus update = await index.AddDocuments(new[]
+            UpdateStatus update = await index.AddDocumentsAsync(new[]
             {
                 new Movie { Id = "1", Name = "Batman", Genre = "Action" },
                 new Movie { Id = "2", Name = "Superman" },
             });
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Update the documents
-            update = await index.UpdateDocuments(new[] { new Movie { Id = "1", Name = "Ironman" } });
+            update = await index.UpdateDocumentsAsync(new[] { new Movie { Id = "1", Name = "Ironman" } });
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Check the documents have been updated and added
-            var docs = await index.GetDocuments<Movie>();
+            var docs = await index.GetDocumentsAsync<Movie>();
             Assert.Equal("1", docs.First().Id);
             Assert.Equal("Ironman", docs.First().Name);
 
@@ -173,11 +173,11 @@ namespace Meilisearch.Tests
                 new Movie { Id = "4", Name = "Interstellar" },
                 new Movie { Id = "5", Name = "Titanic" },
             };
-            var updates = await index.AddDocumentsInBatches(movies, 2);
+            var updates = await index.AddDocumentsInBatchesAsync(movies, 2);
             foreach (var u in updates)
             {
                 u.UpdateId.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForPendingUpdate(u.UpdateId);
+                await index.WaitForPendingUpdateAsync(u.UpdateId);
             }
 
             movies = new Movie[]
@@ -188,15 +188,15 @@ namespace Meilisearch.Tests
                 new Movie { Id = "4", Name = "Interstellar", Genre = "Sci-Fi" },
                 new Movie { Id = "5", Name = "Titanic", Genre = "Drama" },
             };
-            updates = await index.UpdateDocumentsInBatches(movies, 2);
+            updates = await index.UpdateDocumentsInBatchesAsync(movies, 2);
             foreach (var u in updates)
             {
                 u.UpdateId.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForPendingUpdate(u.UpdateId);
+                await index.WaitForPendingUpdateAsync(u.UpdateId);
             }
 
             // Assert movies have genre after update
-            var docs = (await index.GetDocuments<Movie>()).ToList();
+            var docs = (await index.GetDocumentsAsync<Movie>()).ToList();
             foreach (var movie in docs)
             {
                 movie.Genre.Should().NotBeNull();
@@ -212,8 +212,8 @@ namespace Meilisearch.Tests
             index.PrimaryKey.Should().BeNull();
 
             // Add the documents
-            var update = await index.UpdateDocuments(new[] { new { Key = "1", Name = "Ironman" } }, "key");
-            await index.WaitForPendingUpdate(update.UpdateId);
+            var update = await index.UpdateDocumentsAsync(new[] { new { Key = "1", Name = "Ironman" } }, "key");
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
 
             // Check the primary key has been set
@@ -225,7 +225,7 @@ namespace Meilisearch.Tests
         public async Task GetOneExistingDocumentWithStringId()
         {
             Index index = await this.fixture.SetUpBasicIndex("GetOneExistingDocumentWithStringIdTest");
-            var documents = await index.GetDocument<Movie>("10");
+            var documents = await index.GetDocumentAsync<Movie>("10");
             documents.Id.Should().Be("10");
         }
 
@@ -233,7 +233,7 @@ namespace Meilisearch.Tests
         public async Task GetOneExistingDocumentWithIntegerId()
         {
             Index index = await this.fixture.SetUpBasicIndexWithIntId("GetOneExistingDocumentWithIntegerIdTest");
-            var documents = await index.GetDocument<MovieWithIntId>(10);
+            var documents = await index.GetDocumentAsync<MovieWithIntId>(10);
             documents.Id.Should().Be(10);
         }
 
@@ -241,7 +241,7 @@ namespace Meilisearch.Tests
         public async Task GetMultipleExistingDocuments()
         {
             Index index = await this.fixture.SetUpBasicIndex("GetMultipleExistingDocumentTest");
-            var documents = await index.GetDocuments<Movie>();
+            var documents = await index.GetDocumentsAsync<Movie>();
             Assert.Equal(7, documents.Count());
             documents.First().Id.Should().Be("10");
             documents.Last().Id.Should().Be("16");
@@ -251,7 +251,7 @@ namespace Meilisearch.Tests
         public async Task GetMultipleExistingDocumentsWithLimit()
         {
             Index index = await this.fixture.SetUpBasicIndex("GetMultipleExistingDocumentWithLimitTest");
-            var documents = await index.GetDocuments<Movie>(new DocumentQuery() { Limit = 2 });
+            var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery() { Limit = 2 });
             Assert.Equal(2, documents.Count());
             documents.First().Id.Should().Be("10");
             documents.Last().Id.Should().Be("11");
@@ -263,14 +263,14 @@ namespace Meilisearch.Tests
             Index index = await this.fixture.SetUpBasicIndex("DeleteOneExistingDocumentWithStringIdTest");
 
             // Delete the document
-            UpdateStatus update = await index.DeleteOneDocument("11");
+            UpdateStatus update = await index.DeleteOneDocumentAsync("11");
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Check the document has been deleted
-            var docs = await index.GetDocuments<Movie>();
+            var docs = await index.GetDocumentsAsync<Movie>();
             Assert.Equal(6, docs.Count());
-            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<Movie>("11"));
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<Movie>("11"));
             Assert.Equal("document_not_found", ex.Code);
         }
 
@@ -280,14 +280,14 @@ namespace Meilisearch.Tests
             Index index = await this.fixture.SetUpBasicIndexWithIntId("DeleteOneExistingDocumentWithIntIdTest");
 
             // Delete the document
-            UpdateStatus update = await index.DeleteOneDocument(11);
+            UpdateStatus update = await index.DeleteOneDocumentAsync(11);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Check the document has been deleted
-            var docs = await index.GetDocuments<MovieWithIntId>();
+            var docs = await index.GetDocumentsAsync<MovieWithIntId>();
             Assert.Equal(6, docs.Count());
-            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<MovieWithIntId>(11));
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<MovieWithIntId>(11));
             Assert.Equal("document_not_found", ex.Code);
         }
 
@@ -297,19 +297,19 @@ namespace Meilisearch.Tests
             Index index = await this.fixture.SetUpBasicIndex("DeleteMultipleDocumentsWithStringIdTest");
 
             // Delete the documents
-            UpdateStatus update = await index.DeleteDocuments(new[] { "12", "13", "14" });
+            UpdateStatus update = await index.DeleteDocumentsAsync(new[] { "12", "13", "14" });
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Check the documents have been deleted
-            var docs = await index.GetDocuments<Movie>();
+            var docs = await index.GetDocumentsAsync<Movie>();
             Assert.Equal(4, docs.Count());
             MeilisearchApiError ex;
-            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<Movie>("12"));
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<Movie>("12"));
             Assert.Equal("document_not_found", ex.Code);
-            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<Movie>("13"));
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<Movie>("13"));
             Assert.Equal("document_not_found", ex.Code);
-            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<Movie>("14"));
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<Movie>("14"));
             Assert.Equal("document_not_found", ex.Code);
         }
 
@@ -319,19 +319,19 @@ namespace Meilisearch.Tests
             Index index = await this.fixture.SetUpBasicIndexWithIntId("DeleteMultipleDocumentsWithIntegerIdTest");
 
             // Delete the documents
-            UpdateStatus update = await index.DeleteDocuments(new[] { 12, 13, 14 });
+            UpdateStatus update = await index.DeleteDocumentsAsync(new[] { 12, 13, 14 });
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Check the documents have been deleted
-            var docs = await index.GetDocuments<MovieWithIntId>();
+            var docs = await index.GetDocumentsAsync<MovieWithIntId>();
             Assert.Equal(4, docs.Count());
             MeilisearchApiError ex;
-            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<MovieWithIntId>("12"));
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<MovieWithIntId>("12"));
             Assert.Equal("document_not_found", ex.Code);
-            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<MovieWithIntId>("13"));
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<MovieWithIntId>("13"));
             Assert.Equal("document_not_found", ex.Code);
-            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocument<MovieWithIntId>("14"));
+            ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<MovieWithIntId>("14"));
             Assert.Equal("document_not_found", ex.Code);
         }
 
@@ -341,12 +341,12 @@ namespace Meilisearch.Tests
             Index index = await this.fixture.SetUpBasicIndex("DeleteAllExistingDocumentsTest");
 
             // Delete all the documents
-            UpdateStatus update = await index.DeleteAllDocuments();
+            UpdateStatus update = await index.DeleteAllDocumentsAsync();
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(update.UpdateId);
+            await index.WaitForPendingUpdateAsync(update.UpdateId);
 
             // Check all the documents have been deleted
-            var docs = await index.GetDocuments<Movie>();
+            var docs = await index.GetDocumentsAsync<Movie>();
             docs.Should().BeEmpty();
         }
     }

--- a/tests/Meilisearch.Tests/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/IndexFixture.cs
@@ -30,10 +30,10 @@ namespace Meilisearch.Tests
                 new Movie { Id = "15", Name = "Spider-Man", Genre = "Action" },
                 new Movie { Id = "16", Name = "Amélie Poulain", Genre = "French movie" },
             };
-            UpdateStatus update = await index.AddDocuments(movies);
+            UpdateStatus update = await index.AddDocumentsAsync(movies);
 
             // Check the documents have been added
-            UpdateStatus finalUpdateStatus = await index.WaitForPendingUpdate(update.UpdateId);
+            UpdateStatus finalUpdateStatus = await index.WaitForPendingUpdateAsync(update.UpdateId);
             if (finalUpdateStatus.Status != "processed")
             {
                 throw new Exception("The documents were not added during SetUpBasicIndex. Impossible to run the tests.");
@@ -55,10 +55,10 @@ namespace Meilisearch.Tests
                 new MovieWithIntId { Id = 15, Name = "Spider-Man", Genre = "Action" },
                 new MovieWithIntId { Id = 16, Name = "Amélie Poulain", Genre = "French movie" },
             };
-            UpdateStatus update = await index.AddDocuments(movies);
+            UpdateStatus update = await index.AddDocumentsAsync(movies);
 
             // Check the documents have been added
-            UpdateStatus finalUpdateStatus = await index.WaitForPendingUpdate(update.UpdateId);
+            UpdateStatus finalUpdateStatus = await index.WaitForPendingUpdateAsync(update.UpdateId);
             if (finalUpdateStatus.Status != "processed")
             {
                 throw new Exception("The documents were not added during SetUpBasicIndexWithIntId. Impossible to run the tests.");
@@ -84,10 +84,10 @@ namespace Meilisearch.Tests
                 new Movie { Id = "17", Name = "Mission Impossible", Genre = "Action" },
                 new Movie { Id = "1344", Name = "The Hobbit", Genre = "sci fi" },
             };
-            UpdateStatus update = await index.AddDocuments(movies);
+            UpdateStatus update = await index.AddDocumentsAsync(movies);
 
             // Check the documents have been added
-            UpdateStatus finalUpdateStatus = await index.WaitForPendingUpdate(update.UpdateId);
+            UpdateStatus finalUpdateStatus = await index.WaitForPendingUpdateAsync(update.UpdateId);
             if (finalUpdateStatus.Status != "processed")
             {
                 throw new Exception("The documents were not added during SetUpIndexForFaceting. Impossible to run the tests.");
@@ -98,10 +98,10 @@ namespace Meilisearch.Tests
             {
                 FilterableAttributes = new string[] { "genre" },
             };
-            update = await index.UpdateSettings(settings);
+            update = await index.UpdateSettingsAsync(settings);
 
             // Check the settings have been added
-            finalUpdateStatus = await index.WaitForPendingUpdate(update.UpdateId);
+            finalUpdateStatus = await index.WaitForPendingUpdateAsync(update.UpdateId);
             if (finalUpdateStatus.Status != "processed")
             {
                 throw new Exception("The settings were not added during SetUpIndexForFaceting. Impossible to run the tests.");
@@ -112,10 +112,10 @@ namespace Meilisearch.Tests
 
         public async Task DeleteAllIndexes()
         {
-            var indexes = await this.DefaultClient.GetAllIndexes();
+            var indexes = await this.DefaultClient.GetAllIndexesAsync();
             foreach (var index in indexes)
             {
-                await index.Delete();
+                await index.DeleteAsync();
             }
         }
 

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -29,7 +29,7 @@ namespace Meilisearch.Tests
         public async Task BasicIndexCreation()
         {
             var indexUid = "BasicIndexCreationTest";
-            var index = await this.defaultClient.CreateIndex(indexUid);
+            var index = await this.defaultClient.CreateIndexAsync(indexUid);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().BeNull();
         }
@@ -38,7 +38,7 @@ namespace Meilisearch.Tests
         public async Task IndexCreationWithPrimaryKey()
         {
             var indexUid = "IndexCreationWithPrimaryKeyTest";
-            var index = await this.defaultClient.CreateIndex(indexUid, this.defaultPrimaryKey);
+            var index = await this.defaultClient.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().Be(this.defaultPrimaryKey);
         }
@@ -50,7 +50,7 @@ namespace Meilisearch.Tests
             var index = this.defaultClient.Index(indexUid);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().BeNull();
-            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.defaultClient.GetIndex(indexUid));
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.defaultClient.GetIndexAsync(indexUid));
             Assert.Equal("index_not_found", ex.Code);
         }
 
@@ -59,13 +59,13 @@ namespace Meilisearch.Tests
         {
             Meilisearch.Index index;
             var indexUid = "IndexMethodUsageOnExistingIndexTest";
-            index = await this.defaultClient.CreateIndex(indexUid);
+            index = await this.defaultClient.CreateIndexAsync(indexUid);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().BeNull();
             index = this.defaultClient.Index(indexUid);
             index.Uid.Should().Be(indexUid);
 
-            var document = await index.AddDocuments(new[] { new Movie { Id = "1", Name = "Batman" } });
+            var document = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
 
             document.UpdateId.Should().BeGreaterOrEqualTo(0);
         }
@@ -74,7 +74,7 @@ namespace Meilisearch.Tests
         public async Task IndexFetchExistingIndexPrimaryKey()
         {
             var indexUid = "IndexFetchExistingIndexPrimaryKeyTest";
-            var createIndex = await this.defaultClient.CreateIndex(indexUid, this.defaultPrimaryKey);
+            var createIndex = await this.defaultClient.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
             var indexObject = this.defaultClient.Index(indexUid);
             Assert.Equal(createIndex.Uid, indexObject.Uid);
             createIndex.PrimaryKey.Should().Be(this.defaultPrimaryKey);
@@ -87,8 +87,8 @@ namespace Meilisearch.Tests
         public async Task IndexAlreadyExistsError()
         {
             var indexUid = "IndexAlreadyExistsErrorTest";
-            var index = await this.defaultClient.CreateIndex(indexUid, this.defaultPrimaryKey);
-            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.defaultClient.CreateIndex(indexUid, this.defaultPrimaryKey));
+            var index = await this.defaultClient.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.defaultClient.CreateIndexAsync(indexUid, this.defaultPrimaryKey));
             Assert.Equal("index_already_exists", ex.Code);
         }
 
@@ -96,9 +96,9 @@ namespace Meilisearch.Tests
         public async Task UpdateIndex()
         {
             var updatedPrimaryKey = "UpdateIndexTest";
-            await this.defaultClient.GetOrCreateIndex(updatedPrimaryKey);
+            await this.defaultClient.GetOrCreateIndexAsync(updatedPrimaryKey);
             var primarykey = "MovieId" + new Random().Next();
-            var modifiedIndex = await this.defaultClient.UpdateIndex(updatedPrimaryKey, primarykey);
+            var modifiedIndex = await this.defaultClient.UpdateIndexAsync(updatedPrimaryKey, primarykey);
             modifiedIndex.PrimaryKey.Should().Be(primarykey);
         }
 
@@ -106,7 +106,7 @@ namespace Meilisearch.Tests
         public async Task IndexNameWrongFormattedError()
         {
             var indexUid = "Wrong UID";
-            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.defaultClient.CreateIndex(indexUid));
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.defaultClient.CreateIndexAsync(indexUid));
             Assert.Equal("invalid_index_uid", ex.Code);
         }
 
@@ -114,8 +114,8 @@ namespace Meilisearch.Tests
         public async Task GetAllRawIndexes()
         {
             var indexUid = "GetAllRawIndexesTest";
-            await this.defaultClient.CreateIndex(indexUid, this.defaultPrimaryKey);
-            var indexes = await this.defaultClient.GetAllRawIndexes();
+            await this.defaultClient.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
+            var indexes = await this.defaultClient.GetAllRawIndexesAsync();
             indexes.Count().Should().BeGreaterOrEqualTo(1);
             var index = indexes.First();
             Assert.Equal(index.GetProperty("uid").GetString(), indexUid);
@@ -127,8 +127,8 @@ namespace Meilisearch.Tests
         public async Task GetAllExistingIndexes()
         {
             var indexUid = "GetAllExistingIndexesTest";
-            await this.defaultClient.CreateIndex(indexUid, this.defaultPrimaryKey);
-            var indexes = await this.defaultClient.GetAllIndexes();
+            await this.defaultClient.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
+            var indexes = await this.defaultClient.GetAllIndexesAsync();
             indexes.Count().Should().BeGreaterOrEqualTo(1);
         }
 
@@ -136,8 +136,8 @@ namespace Meilisearch.Tests
         public async Task GetOneExistingIndex()
         {
             var indexUid = "GetOneExistingIndexTest";
-            await this.defaultClient.CreateIndex(indexUid, this.defaultPrimaryKey);
-            var index = await this.defaultClient.GetIndex(indexUid);
+            await this.defaultClient.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
+            var index = await this.defaultClient.GetIndexAsync(indexUid);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().Be(this.defaultPrimaryKey);
             index.CreatedAt.Should().BeCloseTo(DateTimeOffset.Now, TimeSpan.FromSeconds(10));
@@ -148,7 +148,7 @@ namespace Meilisearch.Tests
         public async Task GetAnNonExistingIndex()
         {
             var indexUid = "GetAnNonExistingIndexTest";
-            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.defaultClient.GetIndex(indexUid));
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.defaultClient.GetIndexAsync(indexUid));
             Assert.Equal("index_not_found", ex.Code);
         }
 
@@ -156,7 +156,7 @@ namespace Meilisearch.Tests
         public async Task GetOrCreateIndexIfIndexDoesNotExist()
         {
             var indexUid = "GetOrCreateIndexIfIndexDoesNotExistTest";
-            var index = await this.defaultClient.GetOrCreateIndex(indexUid);
+            var index = await this.defaultClient.GetOrCreateIndexAsync(indexUid);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().BeNull();
         }
@@ -165,8 +165,8 @@ namespace Meilisearch.Tests
         public async Task GetOrCreateIndexIfIndexAlreadyExists()
         {
             var indexUid = "GetOrCreateIndexIfIndexAlreadyExistsTest";
-            await this.defaultClient.GetOrCreateIndex(indexUid);
-            var index = await this.defaultClient.GetOrCreateIndex(indexUid);
+            await this.defaultClient.GetOrCreateIndexAsync(indexUid);
+            var index = await this.defaultClient.GetOrCreateIndexAsync(indexUid);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().BeNull();
         }
@@ -175,8 +175,8 @@ namespace Meilisearch.Tests
         public async Task GetOrCreateIndexWithPrimaryKey()
         {
             var indexUid = "GetOrCreateIndexWithPrimaryKeyTest";
-            await this.defaultClient.GetOrCreateIndex(indexUid, this.defaultPrimaryKey);
-            var index = await this.defaultClient.GetOrCreateIndex(indexUid, this.defaultPrimaryKey);
+            await this.defaultClient.GetOrCreateIndexAsync(indexUid, this.defaultPrimaryKey);
+            var index = await this.defaultClient.GetOrCreateIndexAsync(indexUid, this.defaultPrimaryKey);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().Be(this.defaultPrimaryKey);
         }
@@ -185,7 +185,7 @@ namespace Meilisearch.Tests
         public async Task FetchPrimaryKey()
         {
             var indexUid = "FetchPrimaryKeyTest";
-            var index = await this.defaultClient.CreateIndex(indexUid, this.defaultPrimaryKey);
+            var index = await this.defaultClient.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().Be(this.defaultPrimaryKey);
             await index.FetchPrimaryKey();
@@ -195,9 +195,9 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task UpdatePrimaryKey()
         {
-            var index = await this.defaultClient.GetOrCreateIndex("UpdatePrimaryKeyTest");
+            var index = await this.defaultClient.GetOrCreateIndexAsync("UpdatePrimaryKeyTest");
             var primarykey = "MovieId" + new Random().Next();
-            var modifiedIndex = await index.Update(primarykey);
+            var modifiedIndex = await index.UpdateAsync(primarykey);
             modifiedIndex.PrimaryKey.Should().Be(primarykey);
             modifiedIndex.CreatedAt.Should().BeCloseTo(DateTimeOffset.Now, TimeSpan.FromSeconds(10));
             modifiedIndex.UpdatedAt.Should().BeCloseTo(DateTimeOffset.Now, TimeSpan.FromSeconds(10));
@@ -206,8 +206,8 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task GetStats()
         {
-            var index = await this.defaultClient.GetOrCreateIndex("GetStatsTests");
-            var stats = await index.GetStats();
+            var index = await this.defaultClient.GetOrCreateIndexAsync("GetStatsTests");
+            var stats = await index.GetStatsAsync();
             stats.Should().NotBeNull();
         }
 
@@ -215,10 +215,10 @@ namespace Meilisearch.Tests
         public async Task WhenIndexExists_DeleteIfExists_ShouldReturnTrue()
         {
             var indexUid = "DeleteIndexTestUid";
-            var index = await this.defaultClient.GetOrCreateIndex(indexUid);
+            var index = await this.defaultClient.GetOrCreateIndexAsync(indexUid);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().BeNull();
-            var deleted = await index.DeleteIfExists();
+            var deleted = await index.DeleteIfExistsAsync();
             deleted.Should().BeTrue();
         }
 
@@ -226,12 +226,12 @@ namespace Meilisearch.Tests
         public async Task WhenIndexNoLongerExists_DeleteIfExists_ShouldReturnFalse()
         {
             var indexUid = "DeleteIndexTestUid";
-            var index = await this.defaultClient.GetOrCreateIndex(indexUid);
+            var index = await this.defaultClient.GetOrCreateIndexAsync(indexUid);
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().BeNull();
-            var deleted = await index.DeleteIfExists();
+            var deleted = await index.DeleteIfExistsAsync();
             deleted.Should().BeTrue();
-            var deletedAgain = await index.DeleteIfExists();
+            var deletedAgain = await index.DeleteIfExistsAsync();
             deletedAgain.Should().BeFalse();
         }
 
@@ -242,7 +242,7 @@ namespace Meilisearch.Tests
             var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
             MeilisearchClient ms = new MeilisearchClient(httpClient);
 
-            var rawIndex = await ms.GetRawIndex("BasicIndex");
+            var rawIndex = await ms.GetRawIndexAsync("BasicIndex");
 
             rawIndex.GetProperty("uid").GetString().Should().Be("BasicIndex");
         }

--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -31,14 +31,14 @@ namespace Meilisearch.Tests
         {
             var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
             var client = new MeilisearchClient(httpClient);
-            var meilisearchversion = await client.GetVersion();
+            var meilisearchversion = await client.GetVersionAsync();
             meilisearchversion.Version.Should().NotBeNullOrEmpty();
         }
 
         [Fact]
         public async Task GetVersionWithDefaultClient()
         {
-            var meilisearchversion = await this.defaultClient.GetVersion();
+            var meilisearchversion = await this.defaultClient.GetVersionAsync();
             meilisearchversion.Version.Should().NotBeNullOrEmpty();
         }
 
@@ -48,10 +48,10 @@ namespace Meilisearch.Tests
             var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
             MeilisearchClient ms = new MeilisearchClient(httpClient);
             var indexUid = "BasicUsageOfCustomClientTest";
-            Meilisearch.Index index = await ms.CreateIndex(indexUid);
-            var updateStatus = await index.AddDocuments(new[] { new Movie { Id = "1", Name = "Batman" } });
+            Meilisearch.Index index = await ms.CreateIndexAsync(indexUid);
+            var updateStatus = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
             updateStatus.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForPendingUpdate(updateStatus.UpdateId);
+            await index.WaitForPendingUpdateAsync(updateStatus.UpdateId);
             index.FetchPrimaryKey().Should().Equals("id"); // Check the JSON has been well serialized and the primary key is not equal to "Id"
         }
 
@@ -61,8 +61,8 @@ namespace Meilisearch.Tests
             var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
             MeilisearchClient ms = new MeilisearchClient(httpClient);
             var indexUid = "ErrorHandlerOfCustomClientTest";
-            var index = await ms.CreateIndex(indexUid, this.defaultPrimaryKey);
-            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => ms.CreateIndex(indexUid, this.defaultPrimaryKey));
+            var index = await ms.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => ms.CreateIndexAsync(indexUid, this.defaultPrimaryKey));
             Assert.Equal("index_already_exists", ex.Code);
         }
 
@@ -76,7 +76,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CreateDumps()
         {
-            var dumpResponse = await this.defaultClient.CreateDump();
+            var dumpResponse = await this.defaultClient.CreateDumpAsync();
 
             dumpResponse.Status.Should().Be("in_progress");
             Assert.Matches("\\d+-\\d+", dumpResponse.Uid);
@@ -85,10 +85,10 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task GetDumpStatusById()
         {
-            var dump = await this.defaultClient.CreateDump();
+            var dump = await this.defaultClient.CreateDumpAsync();
             Assert.NotNull(dump);
 
-            var dumpStatus = await this.defaultClient.GetDumpStatus(dump.Uid);
+            var dumpStatus = await this.defaultClient.GetDumpStatusAsync(dump.Uid);
 
             dumpStatus.Status.Should().BeOneOf("done", "in_progress");
             Assert.Equal(dump.Uid, dumpStatus.Uid);
@@ -97,7 +97,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task Health()
         {
-            var health = await this.defaultClient.Health();
+            var health = await this.defaultClient.HealthAsync();
             health.Status.Should().Be("available");
         }
 
@@ -105,14 +105,14 @@ namespace Meilisearch.Tests
         public async Task HealthWithBadUrl()
         {
             var client = new MeilisearchClient("http://wrongurl:1234", "masterKey");
-            MeilisearchCommunicationError ex = await Assert.ThrowsAsync<MeilisearchCommunicationError>(() => client.Health());
+            MeilisearchCommunicationError ex = await Assert.ThrowsAsync<MeilisearchCommunicationError>(() => client.HealthAsync());
             Assert.Equal("CommunicationError", ex.Message);
         }
 
         [Fact]
         public async Task IsHealthy()
         {
-            var health = await this.defaultClient.IsHealthy();
+            var health = await this.defaultClient.IsHealthyAsync();
             health.Should().BeTrue();
         }
 
@@ -120,7 +120,7 @@ namespace Meilisearch.Tests
         public async Task IsHealthyWithBadUrl()
         {
             var client = new MeilisearchClient("http://wrongurl:1234", "masterKey");
-            var health = await client.IsHealthy();
+            var health = await client.IsHealthyAsync();
             health.Should().BeFalse();
         }
 
@@ -138,8 +138,8 @@ namespace Meilisearch.Tests
             var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
             MeilisearchClient ms = new MeilisearchClient(httpClient);
             var indexUid = "DeleteIndexTest";
-            var index = await ms.CreateIndex(indexUid, this.defaultPrimaryKey);
-            var deletedResult = await ms.DeleteIndex(indexUid);
+            var index = await ms.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
+            var deletedResult = await ms.DeleteIndexAsync(indexUid);
             deletedResult.Should().BeTrue();
         }
 
@@ -149,7 +149,7 @@ namespace Meilisearch.Tests
             var httpClient = ClientFactory.Instance.CreateClient<MeilisearchClient>();
             MeilisearchClient ms = new MeilisearchClient(httpClient);
             var indexUid = "DeleteIndexIfExistsTest";
-            var index = await ms.CreateIndex(indexUid, this.defaultPrimaryKey);
+            var index = await ms.CreateIndexAsync(indexUid, this.defaultPrimaryKey);
             var deletedResult = await ms.DeleteIndexIfExists(indexUid);
             deletedResult.Should().BeTrue();
         }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -32,7 +32,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task BasicSearch()
         {
-            var movies = await this.basicIndex.Search<Movie>("man");
+            var movies = await this.basicIndex.SearchAsync<Movie>("man");
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Name.Should().NotBeEmpty();
             movies.Hits.ElementAt(1).Name.Should().NotBeEmpty();
@@ -41,7 +41,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task BasicSearchWithNoQuery()
         {
-            var movies = await this.basicIndex.Search<Movie>(null);
+            var movies = await this.basicIndex.SearchAsync<Movie>(null);
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Id.Should().NotBeNull();
             movies.Hits.First().Name.Should().NotBeNull();
@@ -50,7 +50,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task BasicSearchWithEmptyQuery()
         {
-            var movies = await this.basicIndex.Search<Movie>(string.Empty);
+            var movies = await this.basicIndex.SearchAsync<Movie>(string.Empty);
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Id.Should().NotBeNull();
             movies.Hits.First().Name.Should().NotBeNull();
@@ -59,7 +59,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithLimit()
         {
-            var movies = await this.basicIndex.Search<Movie>(
+            var movies = await this.basicIndex.SearchAsync<Movie>(
                 "man",
                 new SearchQuery { Limit = 1 });
             movies.Hits.Should().NotBeEmpty();
@@ -76,11 +76,11 @@ namespace Meilisearch.Tests
             {
                 FilterableAttributes = new string[] { "name" },
             };
-            UpdateStatus update = await this.basicIndex.UpdateSettings(newFilters);
+            UpdateStatus update = await this.basicIndex.UpdateSettingsAsync(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
+            await this.basicIndex.WaitForPendingUpdateAsync(update.UpdateId);
 
-            var movies = await this.basicIndex.Search<FormattedMovie>(
+            var movies = await this.basicIndex.SearchAsync<FormattedMovie>(
                 "man",
                 new SearchQuery { AttributesToHighlight = new string[] { "name" } });
             movies.Hits.Should().NotBeEmpty();
@@ -93,7 +93,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithNoQuery()
         {
-            var movies = await this.basicIndex.Search<FormattedMovie>(
+            var movies = await this.basicIndex.SearchAsync<FormattedMovie>(
                 null,
                 new SearchQuery { AttributesToHighlight = new string[] { "name" } });
             movies.Hits.Should().NotBeEmpty();
@@ -106,7 +106,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithEmptyQuery()
         {
-            var movies = await this.basicIndex.Search<FormattedMovie>(
+            var movies = await this.basicIndex.SearchAsync<FormattedMovie>(
                 string.Empty,
                 new SearchQuery { AttributesToHighlight = new string[] { "name" } });
             movies.Hits.Should().NotBeEmpty();
@@ -119,7 +119,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithMultipleOptions()
         {
-            var movies = await this.basicIndex.Search<FormattedMovie>(
+            var movies = await this.basicIndex.SearchAsync<FormattedMovie>(
                 "man",
                 new SearchQuery
                 {
@@ -140,7 +140,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithFilter()
         {
-            var movies = await this.indexForFaceting.Search<Movie>(
+            var movies = await this.indexForFaceting.SearchAsync<Movie>(
                 null,
                 new SearchQuery
                 {
@@ -158,7 +158,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithFilterWithSpaces()
         {
-            var movies = await this.indexForFaceting.Search<Movie>(
+            var movies = await this.indexForFaceting.SearchAsync<Movie>(
                 null,
                 new SearchQuery
                 {
@@ -174,7 +174,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithFilterArray()
         {
-            var movies = await this.indexForFaceting.Search<Movie>(
+            var movies = await this.indexForFaceting.SearchAsync<Movie>(
                 null,
                 new SearchQuery
                 {
@@ -192,7 +192,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithFilterMultipleArray()
         {
-            var movies = await this.indexForFaceting.Search<Movie>(
+            var movies = await this.indexForFaceting.SearchAsync<Movie>(
                 null,
                 new SearchQuery
                 {
@@ -214,11 +214,11 @@ namespace Meilisearch.Tests
             {
                 FilterableAttributes = new string[] { "id" },
             };
-            UpdateStatus update = await this.indexWithIntId.UpdateSettings(newFilters);
+            UpdateStatus update = await this.indexWithIntId.UpdateSettingsAsync(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await this.indexWithIntId.WaitForPendingUpdate(update.UpdateId);
+            await this.indexWithIntId.WaitForPendingUpdateAsync(update.UpdateId);
 
-            var movies = await this.indexWithIntId.Search<MovieWithIntId>(
+            var movies = await this.indexWithIntId.SearchAsync<MovieWithIntId>(
                 null,
                 new SearchQuery
                 {
@@ -239,11 +239,11 @@ namespace Meilisearch.Tests
             {
                 FilterableAttributes = new string[] { "genre", "id" },
             };
-            UpdateStatus update = await this.indexWithIntId.UpdateSettings(newFilters);
+            UpdateStatus update = await this.indexWithIntId.UpdateSettingsAsync(newFilters);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await this.indexWithIntId.WaitForPendingUpdate(update.UpdateId);
+            await this.indexWithIntId.WaitForPendingUpdateAsync(update.UpdateId);
 
-            var movies = await this.indexWithIntId.Search<MovieWithIntId>(
+            var movies = await this.indexWithIntId.SearchAsync<MovieWithIntId>(
                 null,
                 new SearchQuery
                 {
@@ -260,7 +260,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithPhraseSearch()
         {
-            var movies = await this.indexForFaceting.Search<Movie>("coco \"harry\"");
+            var movies = await this.indexForFaceting.SearchAsync<Movie>("coco \"harry\"");
             movies.Hits.Should().NotBeEmpty();
             movies.FacetsDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
@@ -272,7 +272,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithFacetsDistribution()
         {
-            var movies = await this.indexForFaceting.Search<Movie>(
+            var movies = await this.indexForFaceting.SearchAsync<Movie>(
                 null,
                 new SearchQuery
                 {
@@ -293,11 +293,11 @@ namespace Meilisearch.Tests
             {
                 SortableAttributes = new string[] { "name" },
             };
-            UpdateStatus update = await this.basicIndex.UpdateSettings(newSortable);
+            UpdateStatus update = await this.basicIndex.UpdateSettingsAsync(newSortable);
             update.UpdateId.Should().BeGreaterOrEqualTo(0);
-            await this.basicIndex.WaitForPendingUpdate(update.UpdateId);
+            await this.basicIndex.WaitForPendingUpdateAsync(update.UpdateId);
 
-            var movies = await this.basicIndex.Search<Movie>(
+            var movies = await this.basicIndex.SearchAsync<Movie>(
                 "man",
                 new SearchQuery
                 {

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -1,6 +1,7 @@
 namespace Meilisearch.Tests
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using FluentAssertions;
     using Xunit;
@@ -39,11 +40,11 @@ namespace Meilisearch.Tests
             };
         }
 
-        private delegate Task<TValue> IndexGetMethod<TValue>();
+        private delegate Task<TValue> IndexGetMethod<TValue>(CancellationToken cancellationToken = default);
 
-        private delegate Task<UpdateStatus> IndexUpdateMethod<TValue>(TValue newValue);
+        private delegate Task<UpdateStatus> IndexUpdateMethod<TValue>(TValue newValue, CancellationToken cancellationToken = default);
 
-        private delegate Task<UpdateStatus> IndexResetMethod();
+        private delegate Task<UpdateStatus> IndexResetMethod(CancellationToken cancellationToken = default);
 
         public async Task InitializeAsync()
         {
@@ -56,7 +57,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task GetSettings()
         {
-            await this.AssertGetEquality(this.index.GetSettings, this.defaultSettings);
+            await this.AssertGetEquality(this.index.GetSettingsAsync, this.defaultSettings);
         }
 
         [Fact]
@@ -68,9 +69,9 @@ namespace Meilisearch.Tests
                 StopWords = new string[] { "of", "the" },
                 DistinctAttribute = "name",
             };
-            await this.AssertUpdateSuccess(this.index.UpdateSettings, newSettings);
-            await this.AssertGetInequality(this.index.GetSettings, newSettings); // fields omitted in newSettings shouldn't have changed
-            await this.AssertGetEquality(this.index.GetSettings, SettingsWithDefaultedNullFields(newSettings, this.defaultSettings));
+            await this.AssertUpdateSuccess(this.index.UpdateSettingsAsync, newSettings);
+            await this.AssertGetInequality(this.index.GetSettingsAsync, newSettings); // fields omitted in newSettings shouldn't have changed
+            await this.AssertGetEquality(this.index.GetSettingsAsync, SettingsWithDefaultedNullFields(newSettings, this.defaultSettings));
         }
 
         [Fact]
@@ -87,22 +88,22 @@ namespace Meilisearch.Tests
                     { "harry potter", new string[] { "hp" } },
                 },
             };
-            await this.AssertUpdateSuccess(this.index.UpdateSettings, newSettingsOne);
+            await this.AssertUpdateSuccess(this.index.UpdateSettingsAsync, newSettingsOne);
 
             var expectedSettingsOne = SettingsWithDefaultedNullFields(newSettingsOne, this.defaultSettings);
-            await this.AssertGetInequality(this.index.GetSettings, newSettingsOne); // fields omitted in newSettingsOne shouldn't have changed
-            await this.AssertGetEquality(this.index.GetSettings, expectedSettingsOne);
+            await this.AssertGetInequality(this.index.GetSettingsAsync, newSettingsOne); // fields omitted in newSettingsOne shouldn't have changed
+            await this.AssertGetEquality(this.index.GetSettingsAsync, expectedSettingsOne);
 
             // Second update: this one should not overwritten StopWords and DistinctAttribute.
             var newSettingsTwo = new Settings
             {
                 SearchableAttributes = new string[] { "name" },
             };
-            await this.AssertUpdateSuccess(this.index.UpdateSettings, newSettingsTwo);
+            await this.AssertUpdateSuccess(this.index.UpdateSettingsAsync, newSettingsTwo);
 
             var expectedSettingsTwo = SettingsWithDefaultedNullFields(newSettingsTwo, expectedSettingsOne);
-            await this.AssertGetInequality(this.index.GetSettings, newSettingsTwo); // fields omitted in newSettingsTwo shouldn't have changed
-            await this.AssertGetEquality(this.index.GetSettings, expectedSettingsTwo);
+            await this.AssertGetInequality(this.index.GetSettingsAsync, newSettingsTwo); // fields omitted in newSettingsTwo shouldn't have changed
+            await this.AssertGetEquality(this.index.GetSettingsAsync, expectedSettingsTwo);
         }
 
         [Fact]
@@ -117,193 +118,193 @@ namespace Meilisearch.Tests
                 RankingRules = new string[] { "typo" },
                 FilterableAttributes = new string[] { "genre" },
             };
-            await this.AssertUpdateSuccess(this.index.UpdateSettings, newSettings);
-            await this.AssertGetInequality(this.index.GetSettings, newSettings); // fields omitted in newSettings shouldn't have changed
-            await this.AssertGetEquality(this.index.GetSettings, SettingsWithDefaultedNullFields(newSettings, this.defaultSettings));
+            await this.AssertUpdateSuccess(this.index.UpdateSettingsAsync, newSettings);
+            await this.AssertGetInequality(this.index.GetSettingsAsync, newSettings); // fields omitted in newSettings shouldn't have changed
+            await this.AssertGetEquality(this.index.GetSettingsAsync, SettingsWithDefaultedNullFields(newSettings, this.defaultSettings));
 
-            await this.AssertResetSuccess(this.index.ResetSettings);
-            await this.AssertGetEquality(this.index.GetSettings, this.defaultSettings);
+            await this.AssertResetSuccess(this.index.ResetSettingsAsync);
+            await this.AssertGetEquality(this.index.GetSettingsAsync, this.defaultSettings);
         }
 
         [Fact]
         public async Task GetDisplayedAttributes()
         {
-            await this.AssertGetEquality(this.index.GetDisplayedAttributes, this.defaultSettings.DisplayedAttributes);
+            await this.AssertGetEquality(this.index.GetDisplayedAttributesAsync, this.defaultSettings.DisplayedAttributes);
         }
 
         [Fact]
         public async Task UpdateDisplayedAttributes()
         {
             IEnumerable<string> newDisplayedAttributes = new string[] { "name", "genre" };
-            await this.AssertUpdateSuccess(this.index.UpdateDisplayedAttributes, newDisplayedAttributes);
-            await this.AssertGetEquality(this.index.GetDisplayedAttributes, newDisplayedAttributes);
+            await this.AssertUpdateSuccess(this.index.UpdateDisplayedAttributesAsync, newDisplayedAttributes);
+            await this.AssertGetEquality(this.index.GetDisplayedAttributesAsync, newDisplayedAttributes);
         }
 
         [Fact]
         public async Task ResetDisplayedAttributes()
         {
             IEnumerable<string> newDisplayedAttributes = new string[] { "name", "genre" };
-            await this.AssertUpdateSuccess(this.index.UpdateDisplayedAttributes, newDisplayedAttributes);
-            await this.AssertGetEquality(this.index.GetDisplayedAttributes, newDisplayedAttributes);
+            await this.AssertUpdateSuccess(this.index.UpdateDisplayedAttributesAsync, newDisplayedAttributes);
+            await this.AssertGetEquality(this.index.GetDisplayedAttributesAsync, newDisplayedAttributes);
 
-            await this.AssertResetSuccess(this.index.ResetDisplayedAttributes);
-            await this.AssertGetEquality(this.index.GetDisplayedAttributes, this.defaultSettings.DisplayedAttributes);
+            await this.AssertResetSuccess(this.index.ResetDisplayedAttributesAsync);
+            await this.AssertGetEquality(this.index.GetDisplayedAttributesAsync, this.defaultSettings.DisplayedAttributes);
         }
 
         [Fact]
         public async Task GetDistinctAttribute()
         {
-            await this.AssertGetEquality(this.index.GetDistinctAttribute, this.defaultSettings.DistinctAttribute);
+            await this.AssertGetEquality(this.index.GetDistinctAttributeAsync, this.defaultSettings.DistinctAttribute);
         }
 
         [Fact]
         public async Task UpdateDistinctAttribute()
         {
             var newDistinctAttribute = "name";
-            await this.AssertUpdateSuccess(this.index.UpdateDistinctAttribute, newDistinctAttribute);
-            await this.AssertGetEquality(this.index.GetDistinctAttribute, newDistinctAttribute);
+            await this.AssertUpdateSuccess(this.index.UpdateDistinctAttributeAsync, newDistinctAttribute);
+            await this.AssertGetEquality(this.index.GetDistinctAttributeAsync, newDistinctAttribute);
         }
 
         [Fact]
         public async Task ResetDistinctAttribute()
         {
             var newDistinctAttribute = "name";
-            await this.AssertUpdateSuccess(this.index.UpdateDistinctAttribute, newDistinctAttribute);
-            await this.AssertGetEquality(this.index.GetDistinctAttribute, newDistinctAttribute);
+            await this.AssertUpdateSuccess(this.index.UpdateDistinctAttributeAsync, newDistinctAttribute);
+            await this.AssertGetEquality(this.index.GetDistinctAttributeAsync, newDistinctAttribute);
 
-            await this.AssertResetSuccess(this.index.ResetDistinctAttribute);
-            await this.AssertGetEquality(this.index.GetDistinctAttribute, this.defaultSettings.DistinctAttribute);
+            await this.AssertResetSuccess(this.index.ResetDistinctAttributeAsync);
+            await this.AssertGetEquality(this.index.GetDistinctAttributeAsync, this.defaultSettings.DistinctAttribute);
         }
 
         [Fact]
         public async Task GetFilterableAttributes()
         {
-            await this.AssertGetEquality(this.index.GetFilterableAttributes, this.defaultSettings.FilterableAttributes);
+            await this.AssertGetEquality(this.index.GetFilterableAttributesAsync, this.defaultSettings.FilterableAttributes);
         }
 
         [Fact]
         public async Task UpdateFilterableAttributes()
         {
             var newFilterableAttributes = new string[] { "name", "genre" };
-            await this.AssertUpdateSuccess(this.index.UpdateFilterableAttributes, newFilterableAttributes);
-            await this.AssertGetEquality(this.index.GetFilterableAttributes, newFilterableAttributes);
+            await this.AssertUpdateSuccess(this.index.UpdateFilterableAttributesAsync, newFilterableAttributes);
+            await this.AssertGetEquality(this.index.GetFilterableAttributesAsync, newFilterableAttributes);
         }
 
         [Fact]
         public async Task ResetFilterableAttributes()
         {
             var newFilterableAttributes = new string[] { "name", "genre" };
-            await this.AssertUpdateSuccess(this.index.UpdateFilterableAttributes, newFilterableAttributes);
-            await this.AssertGetEquality(this.index.GetFilterableAttributes, newFilterableAttributes);
+            await this.AssertUpdateSuccess(this.index.UpdateFilterableAttributesAsync, newFilterableAttributes);
+            await this.AssertGetEquality(this.index.GetFilterableAttributesAsync, newFilterableAttributes);
 
-            await this.AssertResetSuccess(this.index.ResetFilterableAttributes);
-            await this.AssertGetEquality(this.index.GetFilterableAttributes, this.defaultSettings.FilterableAttributes);
+            await this.AssertResetSuccess(this.index.ResetFilterableAttributesAsync);
+            await this.AssertGetEquality(this.index.GetFilterableAttributesAsync, this.defaultSettings.FilterableAttributes);
         }
 
         [Fact]
         public async Task GetRankingRules()
         {
-            await this.AssertGetEquality(this.index.GetRankingRules, this.defaultSettings.RankingRules);
+            await this.AssertGetEquality(this.index.GetRankingRulesAsync, this.defaultSettings.RankingRules);
         }
 
         [Fact]
         public async Task UpdateRankingRules()
         {
             var newRankingRules = new string[] { "words", "typo" };
-            await this.AssertUpdateSuccess(this.index.UpdateRankingRules, newRankingRules);
-            await this.AssertGetEquality(this.index.GetRankingRules, newRankingRules);
+            await this.AssertUpdateSuccess(this.index.UpdateRankingRulesAsync, newRankingRules);
+            await this.AssertGetEquality(this.index.GetRankingRulesAsync, newRankingRules);
         }
 
         [Fact]
         public async Task ResetRankingRules()
         {
             var newRankingRules = new string[] { "words", "typo" };
-            await this.AssertUpdateSuccess(this.index.UpdateRankingRules, newRankingRules);
-            await this.AssertGetEquality(this.index.GetRankingRules, newRankingRules);
+            await this.AssertUpdateSuccess(this.index.UpdateRankingRulesAsync, newRankingRules);
+            await this.AssertGetEquality(this.index.GetRankingRulesAsync, newRankingRules);
 
-            await this.AssertResetSuccess(this.index.ResetRankingRules);
-            await this.AssertGetEquality(this.index.GetRankingRules, this.defaultSettings.RankingRules);
+            await this.AssertResetSuccess(this.index.ResetRankingRulesAsync);
+            await this.AssertGetEquality(this.index.GetRankingRulesAsync, this.defaultSettings.RankingRules);
         }
 
         [Fact]
         public async Task GetSearchableAttributes()
         {
-            await this.AssertGetEquality(this.index.GetSearchableAttributes, this.defaultSettings.SearchableAttributes);
+            await this.AssertGetEquality(this.index.GetSearchableAttributesAsync, this.defaultSettings.SearchableAttributes);
         }
 
         [Fact]
         public async Task UpdateSearchableAttributes()
         {
             var newSearchableAttributes = new string[] { "name", "genre" };
-            await this.AssertUpdateSuccess(this.index.UpdateSearchableAttributes, newSearchableAttributes);
-            await this.AssertGetEquality(this.index.GetSearchableAttributes, newSearchableAttributes);
+            await this.AssertUpdateSuccess(this.index.UpdateSearchableAttributesAsync, newSearchableAttributes);
+            await this.AssertGetEquality(this.index.GetSearchableAttributesAsync, newSearchableAttributes);
         }
 
         [Fact]
         public async Task ResetSearchableAttributes()
         {
             var newSearchableAttributes = new string[] { "name", "genre" };
-            await this.AssertUpdateSuccess(this.index.UpdateSearchableAttributes, newSearchableAttributes);
-            await this.AssertGetEquality(this.index.GetSearchableAttributes, newSearchableAttributes);
+            await this.AssertUpdateSuccess(this.index.UpdateSearchableAttributesAsync, newSearchableAttributes);
+            await this.AssertGetEquality(this.index.GetSearchableAttributesAsync, newSearchableAttributes);
 
-            await this.AssertResetSuccess(this.index.ResetSearchableAttributes);
-            await this.AssertGetEquality(this.index.GetSearchableAttributes, this.defaultSettings.SearchableAttributes);
+            await this.AssertResetSuccess(this.index.ResetSearchableAttributesAsync);
+            await this.AssertGetEquality(this.index.GetSearchableAttributesAsync, this.defaultSettings.SearchableAttributes);
         }
 
         [Fact]
         public async Task GetSortableAttributes()
         {
-            await this.AssertGetEquality(this.index.GetSortableAttributes, this.defaultSettings.SortableAttributes);
+            await this.AssertGetEquality(this.index.GetSortableAttributesAsync, this.defaultSettings.SortableAttributes);
         }
 
         [Fact]
         public async Task UpdateSortableAttributes()
         {
             var newSortableAttributes = new string[] { "name", "genre" };
-            await this.AssertUpdateSuccess(this.index.UpdateSortableAttributes, newSortableAttributes);
-            await this.AssertGetEquality(this.index.GetSortableAttributes, newSortableAttributes);
+            await this.AssertUpdateSuccess(this.index.UpdateSortableAttributesAsync, newSortableAttributes);
+            await this.AssertGetEquality(this.index.GetSortableAttributesAsync, newSortableAttributes);
         }
 
         [Fact]
         public async Task ResetSortableAttributes()
         {
             var newSortableAttributes = new string[] { "name", "genre" };
-            await this.AssertUpdateSuccess(this.index.UpdateSortableAttributes, newSortableAttributes);
-            await this.AssertGetEquality(this.index.GetSortableAttributes, newSortableAttributes);
+            await this.AssertUpdateSuccess(this.index.UpdateSortableAttributesAsync, newSortableAttributes);
+            await this.AssertGetEquality(this.index.GetSortableAttributesAsync, newSortableAttributes);
 
-            await this.AssertResetSuccess(this.index.ResetSortableAttributes);
-            await this.AssertGetEquality(this.index.GetSortableAttributes, this.defaultSettings.SortableAttributes);
+            await this.AssertResetSuccess(this.index.ResetSortableAttributesAsync);
+            await this.AssertGetEquality(this.index.GetSortableAttributesAsync, this.defaultSettings.SortableAttributes);
         }
 
         [Fact]
         public async Task GetStopWords()
         {
-            await this.AssertGetEquality(this.index.GetStopWords, this.defaultSettings.StopWords);
+            await this.AssertGetEquality(this.index.GetStopWordsAsync, this.defaultSettings.StopWords);
         }
 
         [Fact]
         public async Task UpdateStopWords()
         {
             var newStopWords = new string[] { "the", "and", "of" };
-            await this.AssertUpdateSuccess(this.index.UpdateStopWords, newStopWords);
-            await this.AssertGetEquality(this.index.GetStopWords, newStopWords);
+            await this.AssertUpdateSuccess(this.index.UpdateStopWordsAsync, newStopWords);
+            await this.AssertGetEquality(this.index.GetStopWordsAsync, newStopWords);
         }
 
         [Fact]
         public async Task ResetStopWords()
         {
             var newStopWords = new string[] { "the", "and", "of" };
-            await this.AssertUpdateSuccess(this.index.UpdateStopWords, newStopWords);
-            await this.AssertGetEquality(this.index.GetStopWords, newStopWords);
+            await this.AssertUpdateSuccess(this.index.UpdateStopWordsAsync, newStopWords);
+            await this.AssertGetEquality(this.index.GetStopWordsAsync, newStopWords);
 
-            await this.AssertResetSuccess(this.index.ResetStopWords);
-            await this.AssertGetEquality(this.index.GetStopWords, this.defaultSettings.StopWords);
+            await this.AssertResetSuccess(this.index.ResetStopWordsAsync);
+            await this.AssertGetEquality(this.index.GetStopWordsAsync, this.defaultSettings.StopWords);
         }
 
         [Fact]
         public async Task GetSynonyms()
         {
-            await this.AssertGetEquality(this.index.GetSynonyms, this.defaultSettings.Synonyms);
+            await this.AssertGetEquality(this.index.GetSynonymsAsync, this.defaultSettings.Synonyms);
         }
 
         [Fact]
@@ -314,8 +315,8 @@ namespace Meilisearch.Tests
                 { "hp", new string[] { "harry potter" } },
                 { "harry potter", new string[] { "hp" } },
             };
-            await this.AssertUpdateSuccess(this.index.UpdateSynonyms, newSynonyms);
-            await this.AssertGetEquality(this.index.GetSynonyms, newSynonyms);
+            await this.AssertUpdateSuccess(this.index.UpdateSynonymsAsync, newSynonyms);
+            await this.AssertGetEquality(this.index.GetSynonymsAsync, newSynonyms);
         }
 
         [Fact]
@@ -326,11 +327,11 @@ namespace Meilisearch.Tests
                 { "hp", new string[] { "harry potter" } },
                 { "harry potter", new string[] { "hp" } },
             };
-            await this.AssertUpdateSuccess(this.index.UpdateSynonyms, newSynonyms);
-            await this.AssertGetEquality(this.index.GetSynonyms, newSynonyms);
+            await this.AssertUpdateSuccess(this.index.UpdateSynonymsAsync, newSynonyms);
+            await this.AssertGetEquality(this.index.GetSynonymsAsync, newSynonyms);
 
-            await this.AssertResetSuccess(this.index.ResetSynonyms);
-            await this.AssertGetEquality(this.index.GetSynonyms, this.defaultSettings.Synonyms);
+            await this.AssertResetSuccess(this.index.ResetSynonymsAsync);
+            await this.AssertGetEquality(this.index.GetSynonymsAsync, this.defaultSettings.Synonyms);
         }
 
         private static Settings SettingsWithDefaultedNullFields(Settings inputSettings, Settings defaultSettings)
@@ -363,7 +364,7 @@ namespace Meilisearch.Tests
         private async Task AssertUpdateStatusProcessed(UpdateStatus updateStatus)
         {
             updateStatus.UpdateId.Should().BeGreaterThan(0);
-            var updateWaitResponse = await this.index.WaitForPendingUpdate(updateStatus.UpdateId);
+            var updateWaitResponse = await this.index.WaitForPendingUpdateAsync(updateStatus.UpdateId);
             updateWaitResponse.Status.Should().BeEquivalentTo("processed");
         }
 

--- a/tests/Meilisearch.Tests/UpdateStatusTests.cs
+++ b/tests/Meilisearch.Tests/UpdateStatusTests.cs
@@ -27,16 +27,16 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task GetAllUpdateStatus()
         {
-            await this.index.AddDocuments(new[] { new Movie { Id = "1" } });
-            var allUpdates = await this.index.GetAllUpdateStatus();
+            await this.index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
+            var allUpdates = await this.index.GetAllUpdateStatusAsync();
             allUpdates.Count().Should().BeGreaterOrEqualTo(1);
         }
 
         [Fact]
         public async Task GetOneUpdateStatus()
         {
-            var status = await this.index.AddDocuments(new[] { new Movie { Id = "2" } });
-            UpdateStatus individualStatus = await this.index.GetUpdateStatus(status.UpdateId);
+            var status = await this.index.AddDocumentsAsync(new[] { new Movie { Id = "2" } });
+            UpdateStatus individualStatus = await this.index.GetUpdateStatusAsync(status.UpdateId);
             individualStatus.Should().NotBeNull();
             individualStatus.UpdateId.Should().BeGreaterOrEqualTo(0);
             individualStatus.Status.Should().NotBeNull();
@@ -45,8 +45,8 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task DefaultWaitForPendingUpdate()
         {
-            var status = await this.index.AddDocuments(new[] { new Movie { Id = "3" } });
-            var response = await this.index.WaitForPendingUpdate(status.UpdateId);
+            var status = await this.index.AddDocumentsAsync(new[] { new Movie { Id = "3" } });
+            var response = await this.index.WaitForPendingUpdateAsync(status.UpdateId);
             Assert.Equal(response.UpdateId, status.UpdateId);
             Assert.Equal("processed", response.Status);
         }
@@ -54,8 +54,8 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomWaitForPendingUpdate()
         {
-            var status = await this.index.AddDocuments(new[] { new Movie { Id = "4" } });
-            var response = await this.index.WaitForPendingUpdate(status.UpdateId, 10000.0, 20);
+            var status = await this.index.AddDocumentsAsync(new[] { new Movie { Id = "4" } });
+            var response = await this.index.WaitForPendingUpdateAsync(status.UpdateId, 10000.0, 20);
             Assert.Equal(response.UpdateId, status.UpdateId);
             Assert.Equal("processed", response.Status);
         }
@@ -63,8 +63,8 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task WaitForPendingUpdateWithException()
         {
-            var status = await this.index.AddDocuments(new[] { new Movie { Id = "5" } });
-            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => this.index.WaitForPendingUpdate(status.UpdateId, 0.0, 20));
+            var status = await this.index.AddDocumentsAsync(new[] { new Movie { Id = "5" } });
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => this.index.WaitForPendingUpdateAsync(status.UpdateId, 0.0, 20));
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #196, #181

Renamed all async methods with an `Async` suffix to match .net coding style.
All async methods now contains an optional `CancellationToken` parameter.
All async calls are using `ConfigureAwait(false)`

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Another pair of eyes could be necessary to check nothing is missing !
