### PR TITLE
Use `Authorization` header instead of `X-Meili-API-Key`

### DIFF
--- a/src/Meilisearch/Extensions/HttpExtensions.cs
+++ b/src/Meilisearch/Extensions/HttpExtensions.cs
@@ -1,6 +1,7 @@
 namespace Meilisearch.Extensions
 {
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Text;
     using System.Text.Json;
     using System.Threading;
@@ -61,7 +62,7 @@ namespace Meilisearch.Extensions
         }
 
         /// <summary>
-        /// Add the API Key to the X-Meili-API-Key header.
+        /// Add the API Key to the Authorization header.
         /// </summary>
         /// <param name="client">HttpClient.</param>
         /// <param name="apiKey">API Key.</param>
@@ -69,7 +70,7 @@ namespace Meilisearch.Extensions
         {
             if (!string.IsNullOrEmpty(apiKey))
             {
-                client.DefaultRequestHeaders.Add("X-Meili-API-Key", apiKey);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
             }
         }
 

--- a/tests/Meilisearch.Tests/ClientFactory.cs
+++ b/tests/Meilisearch.Tests/ClientFactory.cs
@@ -2,6 +2,7 @@ namespace Meilisearch.Tests
 {
     using System;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using HttpClientFactoryLite;
 
     public class ClientFactory
@@ -15,7 +16,7 @@ namespace Meilisearch.Tests
                         .ConfigureHttpClient(p =>
                             {
                                 p.BaseAddress = new Uri("http://localhost:7700/");
-                                p.DefaultRequestHeaders.Add("X-Meili-API-Key", "masterKey");
+                                p.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "masterKey");
                             })
                         .ConfigurePrimaryHttpMessageHandler(() => new MeilisearchMessageHandler(new HttpClientHandler())));
                     return httpClientFactory;


### PR DESCRIPTION
According to v0.25.0, MeiliSearch will use
```
Authorization: Bearer <API key>
```

instead of 
```
X-Meili-API-key: <API key>
```

Tests are failing because of the other changes regarding v0.25.0