### PR TITLE
Remove all warnings during compile time

### DIFF
--- a/src/Meilisearch/Extensions/HttpExtensions.cs
+++ b/src/Meilisearch/Extensions/HttpExtensions.cs
@@ -78,9 +78,9 @@ namespace Meilisearch.Extensions
             if (options == null)
             {
                 options = new JsonSerializerOptions();
+                options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
             }
 
-            options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
             var payload = new StringContent(JsonSerializer.Serialize(body, options), Encoding.UTF8, "application/json");
             payload.Headers.ContentType.CharSet = string.Empty;
 

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -381,9 +381,7 @@ namespace Meilisearch
                 body.Q = query;
             }
 
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
-
-            var responseMessage = await this.http.PostAsJsonAsync<SearchQuery>($"/indexes/{this.Uid}/search", body, options, cancellationToken: cancellationToken)
+            var responseMessage = await this.http.PostAsJsonAsync<SearchQuery>($"/indexes/{this.Uid}/search", body, MeilisearchClient.Options, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<SearchResult<T>>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -439,9 +437,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateSettingsAsync(Settings settings, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<Settings>($"/indexes/{this.Uid}/settings", settings, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<Settings>($"/indexes/{this.Uid}/settings", settings, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -476,9 +473,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateDisplayedAttributesAsync(IEnumerable<string> displayedAttributes, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes", displayedAttributes, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes", displayedAttributes, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -514,9 +510,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateDistinctAttributeAsync(string distinctAttribute, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<string>($"/indexes/{this.Uid}/settings/distinct-attribute", distinctAttribute, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<string>($"/indexes/{this.Uid}/settings/distinct-attribute", distinctAttribute, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -552,9 +547,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateFilterableAttributesAsync(IEnumerable<string> filterableAttributes, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/filterable-attributes", filterableAttributes, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/filterable-attributes", filterableAttributes, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -590,9 +584,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateRankingRulesAsync(IEnumerable<string> rankingRules, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/ranking-rules", rankingRules, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/ranking-rules", rankingRules, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -628,9 +621,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateSearchableAttributesAsync(IEnumerable<string> searchableAttributes, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/searchable-attributes", searchableAttributes, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/searchable-attributes", searchableAttributes, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
@@ -667,9 +659,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateSortableAttributesAsync(IEnumerable<string> sortableAttributes, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/sortable-attributes", sortableAttributes, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/sortable-attributes", sortableAttributes, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -706,9 +697,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateStopWordsAsync(IEnumerable<string> stopWords, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/stop-words", stopWords, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/stop-words", stopWords, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -744,9 +734,8 @@ namespace Meilisearch
         /// <returns>Returns the updateID of the asynchronous task.</returns>
         public async Task<UpdateStatus> UpdateSynonymsAsync(Dictionary<string, IEnumerable<string>> synonyms, CancellationToken cancellationToken = default)
         {
-            JsonSerializerOptions options = new JsonSerializerOptions { IgnoreNullValues = true };
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<Dictionary<string, IEnumerable<string>>>($"/indexes/{this.Uid}/settings/synonyms", synonyms, options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<Dictionary<string, IEnumerable<string>>>($"/indexes/{this.Uid}/settings/synonyms", synonyms, MeilisearchClient.Options, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -381,7 +381,7 @@ namespace Meilisearch
                 body.Q = query;
             }
 
-            var responseMessage = await this.http.PostAsJsonAsync<SearchQuery>($"/indexes/{this.Uid}/search", body, MeilisearchClient.Options, cancellationToken: cancellationToken)
+            var responseMessage = await this.http.PostAsJsonAsync<SearchQuery>($"/indexes/{this.Uid}/search", body, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<SearchResult<T>>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -438,7 +438,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateSettingsAsync(Settings settings, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<Settings>($"/indexes/{this.Uid}/settings", settings, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<Settings>($"/indexes/{this.Uid}/settings", settings, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -474,7 +474,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateDisplayedAttributesAsync(IEnumerable<string> displayedAttributes, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes", displayedAttributes, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/displayed-attributes", displayedAttributes, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -511,7 +511,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateDistinctAttributeAsync(string distinctAttribute, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<string>($"/indexes/{this.Uid}/settings/distinct-attribute", distinctAttribute, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<string>($"/indexes/{this.Uid}/settings/distinct-attribute", distinctAttribute, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -548,7 +548,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateFilterableAttributesAsync(IEnumerable<string> filterableAttributes, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/filterable-attributes", filterableAttributes, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/filterable-attributes", filterableAttributes, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -585,7 +585,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateRankingRulesAsync(IEnumerable<string> rankingRules, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/ranking-rules", rankingRules, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/ranking-rules", rankingRules, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -622,7 +622,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateSearchableAttributesAsync(IEnumerable<string> searchableAttributes, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/searchable-attributes", searchableAttributes, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/searchable-attributes", searchableAttributes, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
@@ -660,7 +660,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateSortableAttributesAsync(IEnumerable<string> sortableAttributes, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/sortable-attributes", sortableAttributes, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/sortable-attributes", sortableAttributes, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -698,7 +698,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateStopWordsAsync(IEnumerable<string> stopWords, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/stop-words", stopWords, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<IEnumerable<string>>($"/indexes/{this.Uid}/settings/stop-words", stopWords, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
@@ -735,7 +735,7 @@ namespace Meilisearch
         public async Task<UpdateStatus> UpdateSynonymsAsync(Dictionary<string, IEnumerable<string>> synonyms, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage =
-                await this.http.PostAsJsonAsync<Dictionary<string, IEnumerable<string>>>($"/indexes/{this.Uid}/settings/synonyms", synonyms, MeilisearchClient.Options, cancellationToken: cancellationToken)
+                await this.http.PostAsJsonAsync<Dictionary<string, IEnumerable<string>>>($"/indexes/{this.Uid}/settings/synonyms", synonyms, MeilisearchClient.JsonSerializerOptions, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<UpdateStatus>(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -19,8 +19,7 @@ namespace Meilisearch
         /// <summary>
         /// JsonSerializer options used when serializing objects.
         /// </summary>
-        public static readonly JsonSerializerOptions Options = new JsonSerializerOptions
-            { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+        public static readonly JsonSerializerOptions Options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
 
         private readonly HttpClient http;
 

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -19,7 +19,11 @@ namespace Meilisearch
         /// <summary>
         /// JsonSerializer options used when serializing objects.
         /// </summary>
-        public static readonly JsonSerializerOptions Options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+        public static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
 
         private readonly HttpClient http;
 
@@ -84,7 +88,7 @@ namespace Meilisearch
         public async Task<Index> CreateIndexAsync(string uid, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             Index index = new Index(uid, primaryKey);
-            var response = await this.http.PostJsonCustomAsync("/indexes", index, Options, cancellationToken: cancellationToken)
+            var response = await this.http.PostJsonCustomAsync("/indexes", index, JsonSerializerOptions, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             return index.WithHttpClient(this.http);

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -6,6 +6,7 @@ namespace Meilisearch
     using System.Net.Http;
     using System.Net.Http.Json;
     using System.Text.Json;
+    using System.Text.Json.Serialization;
     using System.Threading;
     using System.Threading.Tasks;
     using Meilisearch.Extensions;
@@ -15,6 +16,12 @@ namespace Meilisearch
     /// </summary>
     public class MeilisearchClient
     {
+        /// <summary>
+        /// JsonSerializer options used when serializing objects.
+        /// </summary>
+        public static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+            { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
         private readonly HttpClient http;
 
         /// <summary>
@@ -78,8 +85,7 @@ namespace Meilisearch
         public async Task<Index> CreateIndexAsync(string uid, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             Index index = new Index(uid, primaryKey);
-            var options = new JsonSerializerOptions { IgnoreNullValues = true };
-            var response = await this.http.PostJsonCustomAsync("/indexes", index, options, cancellationToken: cancellationToken)
+            var response = await this.http.PostJsonCustomAsync("/indexes", index, Options, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             return index.WithHttpClient(this.http);

--- a/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
+++ b/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
@@ -8,7 +8,7 @@ namespace Meilisearch.Tests
         [Theory]
         [InlineData("simple")]
         [InlineData("com pl <->& ex")]
-        void QueryStringsAreEqualsForPrimaryKey(string key)
+        public void QueryStringsAreEqualsForPrimaryKey(string key)
         {
             string uri = "/indexes/myindex/documents";
             var o = new { primaryKey = key };
@@ -17,7 +17,6 @@ namespace Meilisearch.Tests
             string actual = $"{uri}?{o.ToQueryString()}";
             Assert.Equal(expected, actual);
         }
-
 
         [Theory]
         [InlineData(null, null, "")]
@@ -28,7 +27,7 @@ namespace Meilisearch.Tests
         [InlineData(1, null, "attr")]
         [InlineData(null, 2, "attr")]
         [InlineData(1, 2, "attr")]
-        void QueryStringsAreEqualsForDocumentQuery(int? offset, int? limit, string attributesToRetrieve)
+        public void QueryStringsAreEqualsForDocumentQuery(int? offset, int? limit, string attributesToRetrieve)
         {
             string uri = "/indexes/myindex/documents";
             var dq = new DocumentQuery { Offset = offset, Limit = limit, AttributesToRetrieve = attributesToRetrieve };


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This pull requests removes all compile time warnings.

Most of them were due to the deprecated property `IgnoreNullValues` in `JsonSerializerOptions` : https://docs.microsoft.com/fr-fr/dotnet/api/system.text.json.jsonserializeroptions.ignorenullvalues?view=net-6.0

Since all options are the same, I created a static one in `MeilisearchClient` and reuse it when needed. The client will allocate less.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to MeiliSearch!
