### PR TITLE
Add methods regarding API keys

### DIFF
--- a/src/Meilisearch/Key.cs
+++ b/src/Meilisearch/Key.cs
@@ -1,0 +1,47 @@
+namespace Meilisearch
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Information regarding an API key for the MeiliSearch server.
+    /// </summary>
+    public class Key
+    {
+        /// <summary>
+        /// Gets or sets unique identifier of the API key.
+        /// </summary>
+        [JsonPropertyName("key")]
+        public string KeyUid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the API key.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of actions available for the API key.
+        /// </summary>
+        public IEnumerable<string> Actions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of indexes the API key can access.
+        /// </summary>
+        public IEnumerable<string> Indexes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date when the API key expires.
+        /// </summary>
+        public string ExpiresAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date when the API key was created.
+        /// </summary>
+        public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date when the API key was updated.
+        /// </summary>
+        public string UpdatedAt { get; set; }
+    }
+}

--- a/src/Meilisearch/TaskInfo.cs
+++ b/src/Meilisearch/TaskInfo.cs
@@ -3,7 +3,7 @@ namespace Meilisearch
     using System.Collections.Generic;
 
     /// <summary>
-    /// Update Status of the actions done.
+    /// Information of the regarding a task.
     /// </summary>
     public class TaskInfo
     {

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -29,6 +29,7 @@ namespace Meilisearch.Tests
         {
             var keyResponse = await this.client.GetKeysAsync();
             var keys = keyResponse.Results;
+
             keys.Count().Should().BeGreaterOrEqualTo(2);
         }
 

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -9,8 +9,6 @@ namespace Meilisearch.Tests
     public class KeyTests : IAsyncLifetime
     {
         private IndexFixture fixture;
-        private Key searchKey;
-        private Key adminKey;
         private MeilisearchClient client;
 
         public KeyTests(IndexFixture fixture)

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -1,0 +1,121 @@
+namespace Meilisearch.Tests
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Xunit;
+
+    [Collection("Sequential")]
+    public class KeyTests : IAsyncLifetime
+    {
+        private IndexFixture fixture;
+        private Key searchKey;
+        private Key adminKey;
+        private MeilisearchClient client;
+
+        public KeyTests(IndexFixture fixture)
+        {
+            this.fixture = fixture;
+            this.client = fixture.DefaultClient;
+        }
+
+        public async Task InitializeAsync()
+        {
+            await this.fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        [Fact]
+        public async Task GetAllKeys()
+        {
+            var keyResponse = await this.client.GetKeysAsync();
+            var keys = keyResponse.Results;
+            keys.Count().Should().BeGreaterOrEqualTo(2);
+        }
+
+        [Fact]
+        public async Task GetOneKeyUsingKeyUid()
+        {
+            var keyResponse = await this.client.GetKeysAsync();
+            var keys = keyResponse.Results;
+            var firstKey = keys.First();
+
+            var fetchedKey = await this.client.GetKeyAsync(firstKey.KeyUid);
+
+            fetchedKey.KeyUid.Should().Equals(firstKey.KeyUid);
+            fetchedKey.Description.Should().Equals(firstKey.Description);
+            fetchedKey.Indexes.Should().Equals(firstKey.Indexes);
+            fetchedKey.Actions.Should().Equals(firstKey.Actions);
+            fetchedKey.ExpiresAt.Should().Equals(firstKey.ExpiresAt);
+            fetchedKey.CreatedAt.Should().Equals(firstKey.CreatedAt);
+            fetchedKey.UpdatedAt.Should().Equals(firstKey.UpdatedAt);
+        }
+
+        [Fact]
+        public async Task CreateOneKey()
+        {
+            Key keyOptions = new Key
+            {
+                Description = "Key to add document to all indexes.",
+                Actions = new string[] { "documents.add" },
+                Indexes = new string[] { "*" },
+                ExpiresAt = "2042-04-02T00:42:42Z"
+            };
+            Key createdKey = await this.client.CreateKeyAsync(keyOptions);
+            var createdKeyUid = createdKey.KeyUid;
+            var fetchedKey = await this.client.GetKeyAsync(createdKeyUid);
+
+            fetchedKey.KeyUid.Should().Equals(createdKey.KeyUid);
+            fetchedKey.Description.Should().Equals(createdKey.Description);
+            fetchedKey.Indexes.Should().Equals(createdKey.Indexes);
+            fetchedKey.Actions.Should().Equals(createdKey.Actions);
+            fetchedKey.ExpiresAt.Should().Equals(createdKey.ExpiresAt);
+            fetchedKey.CreatedAt.Should().Equals(createdKey.CreatedAt);
+            fetchedKey.UpdatedAt.Should().Equals(createdKey.UpdatedAt);
+        }
+
+        [Fact]
+        public async Task CreateOneKeyWithNullExpiresAt()
+        {
+            Key keyOptions = new Key
+            {
+                Description = "Key to add document to all indexes.",
+                Actions = new string[] { "documents.add" },
+                Indexes = new string[] { "*" },
+                ExpiresAt = null
+            };
+            Key createdKey = await this.client.CreateKeyAsync(keyOptions);
+            var createdKeyUid = createdKey.KeyUid;
+            var fetchedKey = await this.client.GetKeyAsync(createdKeyUid);
+
+            fetchedKey.KeyUid.Should().Equals(createdKey.KeyUid);
+            fetchedKey.Description.Should().Equals(createdKey.Description);
+            fetchedKey.Indexes.Should().Equals(createdKey.Indexes);
+            fetchedKey.Actions.Should().Equals(createdKey.Actions);
+            fetchedKey.ExpiresAt.Should().Equals(createdKey.ExpiresAt);
+            fetchedKey.CreatedAt.Should().Equals(createdKey.CreatedAt);
+            fetchedKey.UpdatedAt.Should().Equals(createdKey.UpdatedAt);
+        }
+
+        [Fact]
+        public async Task DeleteOneKey()
+        {
+            Key keyOptions = new Key
+            {
+                Description = "Key to delete document to all indexes.",
+                Actions = new string[] { "documents.delete" },
+                Indexes = new string[] { "*" },
+                ExpiresAt = null
+            };
+            Key createdKey = await this.client.CreateKeyAsync(keyOptions);
+            var createdKeyUid = createdKey.KeyUid;
+
+            var success = await this.client.DeleteKeyAsync(createdKeyUid);
+            success.Should().BeTrue();
+
+            MeilisearchApiError ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => this.client.GetKeyAsync(createdKeyUid));
+            Assert.Equal("api_key_not_found", ex.Code);
+        }
+    }
+}


### PR DESCRIPTION
Add the following methods
- `client.CreateKeyAsync()`
- `client.GetKeyAsync()`
- `client.GetKeysAsync()`
- `client.DeleteKeyAsync()`

⚠️ I did not add `client.UpdateKeysAsync()` because `Http.PatchAsync()` method does not exist for our .Net version
