### PR TITLE
Use DateTime when the property is related to a Date

### DIFF
--- a/src/Meilisearch/Key.cs
+++ b/src/Meilisearch/Key.cs
@@ -1,5 +1,6 @@
 namespace Meilisearch
 {
+    using System;
     using System.Collections.Generic;
     using System.Text.Json.Serialization;
 
@@ -32,16 +33,16 @@ namespace Meilisearch
         /// <summary>
         /// Gets or sets the date when the API key expires.
         /// </summary>
-        public string ExpiresAt { get; set; }
+        public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
         /// Gets or sets the date when the API key was created.
         /// </summary>
-        public string CreatedAt { get; set; }
+        public DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the date when the API key was updated.
         /// </summary>
-        public string UpdatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
     }
 }

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -30,6 +30,7 @@ namespace Meilisearch.Tests
         {
             var keyResponse = await this.client.GetKeysAsync();
             var keys = keyResponse.Results;
+
             keys.Count().Should().BeGreaterOrEqualTo(2);
         }
 
@@ -105,7 +106,7 @@ namespace Meilisearch.Tests
                 Description = "Key to delete document to all indexes.",
                 Actions = new string[] { "documents.delete" },
                 Indexes = new string[] { "*" },
-                ExpiresAt = DateTime.Parse("2042-04-02T00:42:42Z"),
+                ExpiresAt = null,
             };
             Key createdKey = await this.client.CreateKeyAsync(keyOptions);
             var createdKeyUid = createdKey.KeyUid;

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -1,5 +1,6 @@
 namespace Meilisearch.Tests
 {
+    using System;
     using System.Linq;
     using System.Threading.Tasks;
     using FluentAssertions;
@@ -29,7 +30,6 @@ namespace Meilisearch.Tests
         {
             var keyResponse = await this.client.GetKeysAsync();
             var keys = keyResponse.Results;
-
             keys.Count().Should().BeGreaterOrEqualTo(2);
         }
 
@@ -59,7 +59,7 @@ namespace Meilisearch.Tests
                 Description = "Key to add document to all indexes.",
                 Actions = new string[] { "documents.add" },
                 Indexes = new string[] { "*" },
-                ExpiresAt = "2042-04-02T00:42:42Z",
+                ExpiresAt = DateTime.Parse("2042-04-02T00:42:42Z"),
             };
             Key createdKey = await this.client.CreateKeyAsync(keyOptions);
             var createdKeyUid = createdKey.KeyUid;
@@ -105,7 +105,7 @@ namespace Meilisearch.Tests
                 Description = "Key to delete document to all indexes.",
                 Actions = new string[] { "documents.delete" },
                 Indexes = new string[] { "*" },
-                ExpiresAt = null,
+                ExpiresAt = DateTime.Parse("2042-04-02T00:42:42Z"),
             };
             Key createdKey = await this.client.CreateKeyAsync(keyOptions);
             var createdKeyUid = createdKey.KeyUid;


### PR DESCRIPTION
This commit will make date property use a Datetime instead of string.

# Pull Request

## What does this PR do?
Fixes #224 https://github.com/meilisearch/meilisearch-dotnet/issues/224

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to MeiliSearch!
