### PR TITLE
Create a GetChunks extension method for batches

### DIFF
--- a/src/Meilisearch/Extensions/EnumerableExtensions.cs
+++ b/src/Meilisearch/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Meilisearch.Extensions
+namespace Meilisearch.Extensions
 {
     using System;
     using System.Collections.Generic;

--- a/src/Meilisearch/Extensions/EnumerableExtensions.cs
+++ b/src/Meilisearch/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,42 @@
+﻿namespace Meilisearch.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Extensions methods for IEnumerable.
+    /// </summary>
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Returns chunks of a list.
+        /// </summary>
+        /// <param name="fullList">The list to split.</param>
+        /// <param name="chunkSize">Size of the chunks.</param>
+        /// <typeparam name="T">Type of objects in the list.</typeparam>
+        /// <returns>List of chunks.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if fullList is null.</exception>
+        /// <exception cref="ArgumentException">Throw if chunkSize is lower than 1.</exception>
+        public static IEnumerable<IEnumerable<T>> GetChunks<T>(this IEnumerable<T> fullList, int chunkSize)
+        {
+            if (fullList is null)
+            {
+                throw new ArgumentNullException(nameof(fullList));
+            }
+
+            if (chunkSize < 1)
+            {
+                throw new ArgumentException("chunkSize value must be greater than 0", nameof(chunkSize));
+            }
+
+            int total = fullList.Count();
+            int sent = 0;
+            while (sent < total)
+            {
+                yield return fullList.Skip(sent).Take(chunkSize);
+                sent += chunkSize;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This pull request is here to make code a little bit easier to follow for batches.

For exemple if we look at `AddDocumentsInBatchesAsync` we have this two piece of code.

https://github.com/meilisearch/meilisearch-dotnet/blob/3f14f432a658deb8a83ab505179b34559e9c1252/src/Meilisearch/Index.cs#L152-L161

https://github.com/meilisearch/meilisearch-dotnet/blob/3f14f432a658deb8a83ab505179b34559e9c1252/src/Meilisearch/Index.cs#L732-L745

To follow the code we have to start 159 with a call to the second snippet. We go to the second snippet where we do so computation to get chunks, then we call a function and we have to go up to the first snippet and see what is happening with this local function.

With this refactoring the `AddDocumentsInBatchesAsync` is self explaining.

The second snippet is now replaced by an extension method that returns a chunk on demand.

With the new code you see what the method is doing on first read

https://github.com/meilisearch/meilisearch-dotnet/blob/4264a71913db643356c128670de09122b6c7e7f4/src/Meilisearch/Index.cs#L152-L161

This is a part from a previous PR #213. I will make several from #213 because there is too much things in this one.