### PR TITLE
Feature/Add a way to use package version programmatically

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: "3.1.x"
     - name: Meilisearch (latest version) setup with Docker
       run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key=masterKey
     - name: Install dependencies
@@ -38,6 +38,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: "3.1.x"
     - name: Install dotnet-format
       run: dotnet tool install -g dotnet-format
     - name: Check with dotnet-format

--- a/src/Meilisearch/Version.cs
+++ b/src/Meilisearch/Version.cs
@@ -11,7 +11,7 @@ namespace Meilisearch
         /// <returns>Returns a formatted version.</returns>
         public string GetQualifiedVersion()
         {
-            return $"Meilisearch (v{this.GetVersion()})";
+            return $"Meilisearch .NET (v{this.GetVersion()})";
         }
 
         /// <summary>

--- a/src/Meilisearch/Version.cs
+++ b/src/Meilisearch/Version.cs
@@ -1,0 +1,26 @@
+namespace Meilisearch
+{
+    /// <summary>
+    /// Information regarding an API key for the Meilisearch server.
+    /// </summary>
+    public class Version
+    {
+        /// <summary>
+        /// Extracts version from Meilisearch.csproj.
+        /// </summary>
+        /// <returns>Returns a formatted version.</returns>
+        public string GetQualifiedVersion()
+        {
+            return $"Meilisearch (v{this.GetVersion()})";
+        }
+
+        /// <summary>
+        /// Extracts the "major.minor.build" version from Meilisearch.csproj.
+        /// </summary>
+        /// <returns>Returns a version from the GetType as String.</returns>
+        public string GetVersion()
+        {
+            return this.GetType().Assembly.GetName().Version.ToString(3);
+        }
+    }
+}

--- a/tests/Meilisearch.Tests/VersionTests.cs
+++ b/tests/Meilisearch.Tests/VersionTests.cs
@@ -1,0 +1,43 @@
+namespace Meilisearch.Tests
+{
+    using System.IO;
+    using System.Xml;
+    using Xunit;
+
+    public class VersionTests
+    {
+        private Version version;
+
+        public VersionTests()
+        {
+            this.version = new Version();
+        }
+
+        [Fact]
+        public void GetQualifiedVersion()
+        {
+            var qualifiedVersion = this.version.GetQualifiedVersion();
+            var version = this.version.GetVersion();
+
+            Assert.Equal(qualifiedVersion, $"Meilisearch (v{version})");
+        }
+
+        [Fact]
+        public void GetSimpleVersionFromCsprojFile()
+        {
+            // get the current version defined in the csproj file
+            var xmldoc = new XmlDocument();
+            var currentDir = Directory.GetParent(Directory.GetCurrentDirectory()).FullName;
+            var path = Path.Combine(currentDir, @"../../../../src/Meilisearch/Meilisearch.csproj");
+            xmldoc.Load(path);
+            var mgr = new XmlNamespaceManager(xmldoc.NameTable);
+            mgr.AddNamespace("x", "http://schemas.microsoft.com/developer/msbuild/2003");
+            var versionFromCsproj = xmldoc.FirstChild.FirstChild.SelectSingleNode("Version").InnerText;
+
+            var value = this.version.GetVersion();
+
+            Assert.NotNull(value);
+            Assert.Equal(versionFromCsproj, value);
+        }
+    }
+}

--- a/tests/Meilisearch.Tests/VersionTests.cs
+++ b/tests/Meilisearch.Tests/VersionTests.cs
@@ -19,7 +19,7 @@ namespace Meilisearch.Tests
             var qualifiedVersion = this.version.GetQualifiedVersion();
             var version = this.version.GetVersion();
 
-            Assert.Equal(qualifiedVersion, $"Meilisearch (v{version})");
+            Assert.Equal(qualifiedVersion, $"Meilisearch .NET (v{version})");
         }
 
         [Fact]


### PR DESCRIPTION
- Create the `Version` class
- Load the current version from the csproj data through the `GetType>Assembly>GetName>Version` (I don’t really know if this could have some potential of not working in some cases, let me know that).


> The Github Action for some reason stopped working, I fixed the version of the .net in order to fix the problem.

Related to https://github.com/meilisearch/integration-guides/issues/150