### PR TITLE
Add new search parameters highlightPreTag, highlightPostTag and cropMarker

### DIFF
--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -57,6 +57,24 @@ namespace Meilisearch
         public IEnumerable<string> AttributesToHighlight { get; set; }
 
         /// <summary>
+        /// Gets or sets the crop marker to apply before and/or after cropped part selected within an attribute defined in `attributesToCrop` parameter.
+        /// </summary>
+        [JsonPropertyName("cropMarker")]
+        public string CropMarker { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tag to put before the highlighted query terms.
+        /// </summary>
+        [JsonPropertyName("highlightPreTag")]
+        public string HighlightPreTag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tag to put after the highlighted query terms.
+        /// </summary>
+        [JsonPropertyName("highlightPostTag")]
+        public string HighlightPostTag { get; set; }
+
+        /// <summary>
         /// Gets or sets the facets distribution for the query.
         /// </summary>
         [JsonPropertyName("facetsDistribution")]

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -311,5 +311,46 @@ namespace Meilisearch.Tests
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("14", movies.Hits.First().Id);
         }
+
+        [Fact]
+        public async Task CustomSearchWithCroppingParameters()
+        {
+            var movies = await _basicIndex.SearchAsync<FormattedMovie>(
+                "man",
+                new SearchQuery { CropLength = 1, AttributesToCrop = new string[] { "*" } }
+            );
+
+            Assert.NotEmpty(movies.Hits);
+            Assert.Equal("…Man", movies.Hits.First()._Formatted.Name);
+        }
+
+        [Fact]
+        public async Task CustomSearchWithCropMarker()
+        {
+            var movies = await _basicIndex.SearchAsync<FormattedMovie>(
+                "man",
+                new SearchQuery { CropLength = 1, AttributesToCrop = new string[] { "*" }, CropMarker = "[…] " }
+            );
+
+            Assert.NotEmpty(movies.Hits);
+            Assert.Equal("[…] Man", movies.Hits.First()._Formatted.Name);
+        }
+
+        [Fact]
+        public async Task CustomSearchWithCustomHighlightTags()
+        {
+            var movies = await _basicIndex.SearchAsync<FormattedMovie>(
+                "man",
+                new SearchQuery
+                {
+                    AttributesToHighlight = new string[] { "*" },
+                    HighlightPreTag = "<mark>",
+                    HighlightPostTag = "</mark>"
+                }
+            );
+
+            Assert.NotEmpty(movies.Hits);
+            Assert.Equal("Iron <mark>Man</mark>", movies.Hits.First()._Formatted.Name);
+        }
     }
 }


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2214 new search parameters are introduced:

- `highlightPreTag`
- `highlightPostTag`
- `cropMarker`

This PR adds tests to ensure the new parameters are working.