### PR TITLE
Update version for the next release (v0.10.2)

### DIFF
--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>MeiliSearch</PackageId>
-        <Version>0.10.1</Version>
+        <Version>0.10.2</Version>
         <Description>.NET wrapper for Meilisearch, an open-source search engine</Description>
         <RepositoryUrl>https://github.com/meilisearch/meilisearch-dotnet</RepositoryUrl>
         <PackageTags>meilisearch;dotnet;sdk;search-engine;search;instant-search</PackageTags>


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.27.0 🎉 
Check out the changelog of [Meilisearch v0.27.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0) for more information about the changes.

## 🚀 Enhancements

- Add new methods for the new typo tolerance settings (#263) @brunoocasali
`GetTypoToleranceAsync()` 
`UpdateTypoToleranceAsync(TypoTolerance typoTolerance)`  
`ResetTypoTolerance()`  
- Ensure nested field support (#260) @brunoocasali 
- Add new search parameters `highlightPreTag`, `highlightPostTag` and `cropMarker` (#258) @brunoocasali 