### PR TITLE
Client refactor with new api names for JSON format

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -133,7 +133,7 @@ getting_started_add_documents_md: |-
               var movies = JsonSerializer.Deserialize<IEnumerable<Movie>>(jsonString, options);
 
               var index = client.Index("movies");
-              await index.AddDocumentsAsync<Movie>(movies);
+              await index.AddDocumentsJsonAsync<Movie>(movies);
           }
       }
   }
@@ -164,7 +164,7 @@ getting_started_add_meteorites: |-
   var meteorites = JsonSerializer.Deserialize<IEnumerable<Meteorite>>(jsonString, options);
 
   var index = client.Index("meteorites");
-  await index.AddDocumentsAsync<Meteorite>(meteorites);
+  await index.AddDocumentsJsonAsync<Meteorite>(meteorites);
 getting_started_update_rankingRules: |-
   await client.Index("movies").UpdateRankingRulesAsync(new string[] {
     "exactness",
@@ -256,7 +256,7 @@ landing_getting_started_1: |-
       new Movie { Id = "6", Title = "Philadelphia" }
   };
 
-  var task = await client.Index("movies").AddDocumentsAsync<Movie>(documents);
+  var task = await client.Index("movies").AddDocumentsJsonAsync<Movie>(documents);
 post_dump_1: |-
 get_dump_status_1: |-
 phrase_search_1: |-
@@ -304,7 +304,7 @@ geosearch_guide_sort_usage_2: |-
 document_guide_create_index_primary_key: |-
   TaskInfo task = await client.CreateIndexAsync("movies", "reference_number");
 document_guide_add_document_primary_key: |-
-  await index.AddDocumentsAsync(
+  await index.AddDocumentsJsonAsync(
     new[] {
         new Movie {
             ReferenceNumber: 287947,

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ namespace GettingStarted
             };
 
             // If the index 'movies' does not exist, Meilisearch creates it when you first add the documents.
-            var task = await index.AddDocumentsAsync<Movie>(documents); // # => { "uid": 0 }
+            var task = await index.AddDocumentsJsonAsync<Movie>(documents); // # => { "uid": 0 }
         }
     }
 }
@@ -222,8 +222,8 @@ var index = await client.GetIndexAsync("movies");
 #### Add or Update Documents <!-- omit in toc -->
 
 ```c#
-var task = await index.AddDocumentsAsync(new Movie[] { new Movie { Id = "1", Title = "Carol" } } );
-var task = await index.UpdateDocumentsAsync(new Movie[] { new Movie { Id = "1", Title = "Carol" } } );
+var task = await index.AddDocumentsJsonAsync(new Movie[] { new Movie { Id = "1", Title = "Carol" } } );
+var task = await index.UpdateDocumentsJsonAsync(new Movie[] { new Movie { Id = "1", Title = "Carol" } } );
 ```
 
 The returned `task` is a `TaskInfo` that can access to `Uid` to get the status of the task.

--- a/src/Meilisearch/Extensions/HttpExtensions.cs
+++ b/src/Meilisearch/Extensions/HttpExtensions.cs
@@ -13,22 +13,6 @@ namespace Meilisearch.Extensions
     public static class HttpExtensions
     {
         /// <summary>
-        /// Sends JSON payload using POST without "charset-utf-8" as Content-Type.
-        /// </summary>
-        /// <param name="client">HttpClient.</param>
-        /// <param name="uri">Endpoint.</param>
-        /// <param name="body">Body sent.</param>
-        /// <param name="cancellationToken">The cancellation token for this call.</param>
-        /// <typeparam name="T">Type of the body to send.</typeparam>
-        /// <returns>Returns the HTTP response from the Meilisearch server.</returns>
-        public static async Task<HttpResponseMessage> PostJsonCustomAsync<T>(this HttpClient client, string uri, T body, CancellationToken cancellationToken = default)
-        {
-            var payload = PrepareJsonPayload(body);
-
-            return await client.PostAsync(uri, payload, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Sends JSON payload using POST without "charset-utf-8" as Content-Type and using JSON serializer options.
         /// </summary>
         /// <param name="client">HttpClient.</param>
@@ -43,22 +27,6 @@ namespace Meilisearch.Extensions
             var payload = PrepareJsonPayload(body, options);
 
             return await client.PostAsync(uri, payload, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Sends JSON payload using PUT without "charset-utf-8" as Content-Type.
-        /// </summary>
-        /// <param name="client">HttpClient.</param>
-        /// <param name="uri">Endpoint.</param>
-        /// <param name="body">Body sent.</param>
-        /// <param name="cancellationToken">The cancellation token for this call.</param>
-        /// <typeparam name="T">Type of the body to send.</typeparam>
-        /// <returns>Returns the HTTP response from the Meilisearch server.</returns>
-        public static async Task<HttpResponseMessage> PutJsonCustomAsync<T>(this HttpClient client, string uri, T body, CancellationToken cancellationToken = default)
-        {
-            var payload = PrepareJsonPayload(body);
-
-            return await client.PutAsync(uri, payload, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Meilisearch/HttpContents/JsonHttpContent.cs
+++ b/src/Meilisearch/HttpContents/JsonHttpContent.cs
@@ -11,7 +11,7 @@ namespace Meilisearch.HttpContents
     /// <summary>
     /// Send and receive HTTP content as JSON.
     /// </summary>
-    public class JsonHttpContent : HttpContent
+    internal class JsonHttpContent : HttpContent
     {
         private readonly JsonSerializerOptions jsonSerializerOptions;
         private readonly object values;

--- a/src/Meilisearch/HttpContents/JsonHttpContent.cs
+++ b/src/Meilisearch/HttpContents/JsonHttpContent.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Meilisearch.HttpContents
+{
+    /// <summary>
+    /// Send and receive HTTP content as JSON.
+    /// </summary>
+    public class JsonHttpContent : HttpContent
+    {
+        private readonly JsonSerializerOptions jsonSerializerOptions;
+        private readonly object values;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonHttpContent"/> class.
+        /// </summary>
+        /// <param name="values">Values to be serialized.</param>
+        /// <param name="jsonSerializerOptions">Override default JsonSerializerOptions.</param>
+        /// <exception cref="ArgumentNullException">Thrown if values is null.</exception>
+        public JsonHttpContent(object values, JsonSerializerOptions jsonSerializerOptions = null)
+        {
+            if (values is null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
+            this.values = values;
+
+            this.jsonSerializerOptions = jsonSerializerOptions ?? Constants.JsonSerializerOptionsWriteNulls;
+            this.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        }
+
+        /// <inheritdoc/>
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            await JsonSerializer.SerializeAsync(stream, this.values, this.jsonSerializerOptions).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+}

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Meilisearch.Extensions;
+using Meilisearch.HttpContents;
 
 namespace Meilisearch
 {
@@ -19,9 +19,8 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document. Even though documents are schemaless in Meilisearch, making it typed helps in compile time.</typeparam>
         /// <returns>Returns the task info.</returns>
-        public async Task<TaskInfo> AddDocumentsAsync<T>(IEnumerable<T> documents, string primaryKey = default, CancellationToken cancellationToken = default)
+        public async Task<TaskInfo> AddDocumentsJsonAsync<T>(IEnumerable<T> documents, string primaryKey = default, CancellationToken cancellationToken = default)
         {
-            HttpResponseMessage responseMessage;
             var uri = $"indexes/{Uid}/documents";
 
             if (primaryKey != default)
@@ -29,7 +28,8 @@ namespace Meilisearch
                 uri = $"{uri}?{new { primaryKey = primaryKey }.ToQueryString()}";
             }
 
-            responseMessage = await _http.PostJsonCustomAsync(uri, documents, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var content = new JsonHttpContent(documents);
+            var responseMessage = await _http.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
@@ -42,12 +42,12 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document. Even though documents are schemaless in Meilisearch, making it typed helps in compile time.</typeparam>
         /// <returns>Returns the task list.</returns>
-        public async Task<IEnumerable<TaskInfo>> AddDocumentsInBatchesAsync<T>(IEnumerable<T> documents, int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<TaskInfo>> AddDocumentsJsonInBatchesAsync<T>(IEnumerable<T> documents, int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var tasks = new List<TaskInfo>();
             foreach (var chunk in documents.GetChunks(batchSize))
             {
-                tasks.Add(await AddDocumentsAsync(chunk, primaryKey, cancellationToken).ConfigureAwait(false));
+                tasks.Add(await AddDocumentsJsonAsync(chunk, primaryKey, cancellationToken).ConfigureAwait(false));
             }
 
             return tasks;
@@ -61,9 +61,8 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of document. Even though documents are schemaless in Meilisearch, making it typed helps in compile time.</typeparam>
         /// <returns>Returns the task list.</returns>
-        public async Task<TaskInfo> UpdateDocumentsAsync<T>(IEnumerable<T> documents, string primaryKey = default, CancellationToken cancellationToken = default)
+        public async Task<TaskInfo> UpdateDocumentsJsonAsync<T>(IEnumerable<T> documents, string primaryKey = default, CancellationToken cancellationToken = default)
         {
-            HttpResponseMessage responseMessage;
             var uri = $"indexes/{Uid}/documents";
 
             if (primaryKey != default)
@@ -71,8 +70,8 @@ namespace Meilisearch
                 uri = $"{uri}?{new { primaryKey = primaryKey }.ToQueryString()}";
             }
 
-            responseMessage = await _http.PutJsonCustomAsync(uri, documents, cancellationToken).ConfigureAwait(false);
-
+            var content = new JsonHttpContent(documents);
+            var responseMessage = await _http.PutAsync(uri, content, cancellationToken).ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
@@ -85,12 +84,12 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document. Even though documents are schemaless in Meilisearch, making it typed helps in compile time.</typeparam>
         /// <returns>Returns the task list.</returns>
-        public async Task<IEnumerable<TaskInfo>> UpdateDocumentsInBatchesAsync<T>(IEnumerable<T> documents, int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<TaskInfo>> UpdateDocumentsJsonInBatchesAsync<T>(IEnumerable<T> documents, int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var tasks = new List<TaskInfo>();
             foreach (var chunk in documents.GetChunks(batchSize))
             {
-                tasks.Add(await UpdateDocumentsAsync(chunk, primaryKey, cancellationToken).ConfigureAwait(false));
+                tasks.Add(await UpdateDocumentsJsonAsync(chunk, primaryKey, cancellationToken).ConfigureAwait(false));
             }
 
             return tasks;

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -23,14 +25,24 @@ namespace Meilisearch.Tests
 
         public Task DisposeAsync() => Task.CompletedTask;
 
-        [Fact]
-        public async Task BasicDocumentsAddition()
+        [Theory]
+        [InlineData("json")]
+        public async Task BasicDocumentsAddition(string format)
         {
-            var indexUID = "BasicDocumentsAdditionTest";
+            var indexUID = $"BasicDocumentsAdditionTest_{format}";
             var index = _client.Index(indexUID);
 
             // Add the documents
-            var task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+            TaskInfo task;
+            switch (format)
+            {
+                case "json":
+                    task = await index.AddDocumentsJsonAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+                    break;
+                default:
+                    throw new IndexOutOfRangeException($"Unsupported format: {format}");
+            }
+
             task.Uid.Should().BeGreaterOrEqualTo(0);
             await index.WaitForTaskAsync(task.Uid);
 
@@ -41,10 +53,11 @@ namespace Meilisearch.Tests
             docs.First().Genre.Should().BeNull();
         }
 
-        [Fact]
-        public async Task BasicDocumentsAdditionInBatches()
+        [Theory]
+        [InlineData("json")]
+        public async Task BasicDocumentsAdditionInBatches(string format)
         {
-            var indexUID = "BasicDocumentsAdditionInBatchesTest";
+            var indexUID = $"BasicDocumentsAdditionInBatchesTest_{format}";
             var index = _client.Index(indexUID);
 
             // Add the documents
@@ -56,7 +69,17 @@ namespace Meilisearch.Tests
                 new Movie { Id = "4", Name = "Interstellar" },
                 new Movie { Id = "5", Name = "Titanic" },
             };
-            var tasks = await index.AddDocumentsInBatchesAsync(movies, 2);
+
+            IEnumerable<TaskInfo> tasks;
+            switch (format)
+            {
+                case "json":
+                    tasks = await index.AddDocumentsJsonInBatchesAsync(movies, 2);
+                    break;
+                default:
+                    throw new IndexOutOfRangeException($"Unsupported format: {format}");
+            }
+
             foreach (var u in tasks)
             {
                 u.Uid.Should().BeGreaterOrEqualTo(0);
@@ -71,17 +94,26 @@ namespace Meilisearch.Tests
             Assert.Equal("Taxi Driver", docs.ElementAt(2).Name);
         }
 
-        [Fact]
-        public async Task BasicDocumentsAdditionWithAlreadyCreatedIndex()
+        [Theory]
+        [InlineData("json")]
+        public async Task BasicDocumentsAdditionWithAlreadyCreatedIndex(string format)
         {
-            var indexUid = "BasicDocumentsAdditionWithAlreadyCreatedIndexTest";
+            var indexUid = $"BasicDocumentsAdditionWithAlreadyCreatedIndexTest_{format}";
             var task = await _client.CreateIndexAsync(indexUid);
             task.Uid.Should().BeGreaterOrEqualTo(0);
             await _client.Index(indexUid).WaitForTaskAsync(task.Uid);
 
             // Add the documents
             var index = _client.Index(indexUid);
-            task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+            switch (format)
+            {
+                case "json":
+                    task = await index.AddDocumentsJsonAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
+
             task.Uid.Should().BeGreaterOrEqualTo(0);
             await index.WaitForTaskAsync(task.Uid);
 
@@ -92,37 +124,64 @@ namespace Meilisearch.Tests
             docs.First().Genre.Should().BeNull();
         }
 
-        [Fact]
-        public async Task BasicDocumentsAdditionWithTimeoutError()
+        [Theory]
+        [InlineData("json")]
+        public async Task BasicDocumentsAdditionWithTimeoutError(string format)
         {
-            var indexUID = "BasicDocumentsAdditionWithTimeoutError";
+            var indexUID = $"BasicDocumentsAdditionWithTimeoutError_{format}";
             var index = _client.Index(indexUID);
 
             // Add the documents
-            var task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+            TaskInfo task;
+            switch (format)
+            {
+                case "json":
+                    task = await index.AddDocumentsJsonAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
             await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForTaskAsync(task.Uid, 0));
         }
 
-        [Fact]
-        public async Task BasicDocumentsAdditionWithTimeoutErrorByInterval()
+        [Theory]
+        [InlineData("json")]
+        public async Task BasicDocumentsAdditionWithTimeoutErrorByInterval(string format)
         {
-            var indexUID = "BasicDocumentsAdditionWithTimeoutErrorByIntervalTest";
+            var indexUID = $"BasicDocumentsAdditionWithTimeoutErrorByIntervalTest_{format}";
             var index = _client.Index(indexUID);
 
             // Add the documents
-            var task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+            TaskInfo task;
+            switch (format)
+            {
+                case "json":
+                    task = await index.AddDocumentsJsonAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
             await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForTaskAsync(task.Uid, 0, 10));
         }
 
-        [Fact]
-        public async Task DocumentsAdditionWithPrimaryKey()
+        [Theory]
+        [InlineData("json")]
+        public async Task DocumentsAdditionWithPrimaryKey(string format)
         {
-            var indexUid = "DocumentsAdditionWithPrimaryKeyTest";
+            var indexUid = $"DocumentsAdditionWithPrimaryKeyTest_{format}";
             var index = _client.Index(indexUid);
             index.PrimaryKey.Should().BeNull();
 
             // Add the documents
-            var task = await index.AddDocumentsAsync(new[] { new { Key = "1", Name = "Ironman" } }, "key");
+            TaskInfo task;
+            switch (format)
+            {
+                case "json":
+                    task = await index.AddDocumentsJsonAsync(new[] { new { Key = "1", Name = "Ironman" } }, "key");
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
             await index.WaitForTaskAsync(task.Uid);
             task.Uid.Should().BeGreaterOrEqualTo(0);
 
@@ -131,23 +190,40 @@ namespace Meilisearch.Tests
             Assert.Equal("key", index.PrimaryKey);
         }
 
-        [Fact]
-        public async Task BasicDocumentsUpdate()
+        [Theory]
+        [InlineData("json")]
+        public async Task BasicDocumentsUpdate(string format)
         {
-            var indexUID = "BasicDocumentsUpdateTest";
+            var indexUID = $"BasicDocumentsUpdateTest_{format}";
             var index = _client.Index(indexUID);
 
             // Add the documents
-            var task = await index.AddDocumentsAsync(new[]
+            TaskInfo task;
+            switch (format)
             {
-                new Movie { Id = "1", Name = "Batman", Genre = "Action" },
-                new Movie { Id = "2", Name = "Superman" },
-            });
+                case "json":
+                    task = await index.AddDocumentsJsonAsync(new[]
+                    {
+                        new Movie { Id = "1", Name = "Batman", Genre = "Action" },
+                        new Movie { Id = "2", Name = "Superman" },
+                    });
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
             task.Uid.Should().BeGreaterOrEqualTo(0);
             await index.WaitForTaskAsync(task.Uid);
 
             // Update the documents
-            task = await index.UpdateDocumentsAsync(new[] { new Movie { Id = "1", Name = "Ironman" } });
+            switch (format)
+            {
+                case "json":
+                    task = await index.UpdateDocumentsJsonAsync(new[] { new Movie { Id = "1", Name = "Ironman" } });
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
+
             task.Uid.Should().BeGreaterOrEqualTo(0);
             await index.WaitForTaskAsync(task.Uid);
 
@@ -162,10 +238,11 @@ namespace Meilisearch.Tests
             docs.ElementAt(1).Genre.Should().BeNull();
         }
 
-        [Fact]
-        public async Task BasicDocumentsUpdateInBatches()
+        [Theory]
+        [InlineData("json")]
+        public async Task BasicDocumentsUpdateInBatches(string format)
         {
-            var indexUID = "BasicDocumentsUpdateInBatchesTest";
+            var indexUID = $"BasicDocumentsUpdateInBatchesTest_{format}";
             var index = _client.Index(indexUID);
 
             // Add the documents
@@ -177,7 +254,17 @@ namespace Meilisearch.Tests
                 new Movie { Id = "4", Name = "Interstellar" },
                 new Movie { Id = "5", Name = "Titanic" },
             };
-            var tasks = await index.AddDocumentsInBatchesAsync(movies, 2);
+
+            IEnumerable<TaskInfo> tasks;
+            switch (format)
+            {
+                case "json":
+                    tasks = await index.AddDocumentsJsonInBatchesAsync(movies, 2);
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
+
             foreach (var u in tasks)
             {
                 u.Uid.Should().BeGreaterOrEqualTo(0);
@@ -192,7 +279,14 @@ namespace Meilisearch.Tests
                 new Movie { Id = "4", Name = "Interstellar", Genre = "Sci-Fi" },
                 new Movie { Id = "5", Name = "Titanic", Genre = "Drama" },
             };
-            tasks = await index.UpdateDocumentsInBatchesAsync(movies, 2);
+            switch (format)
+            {
+                case "json":
+                    tasks = await index.UpdateDocumentsJsonInBatchesAsync(movies, 2);
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
             foreach (var u in tasks)
             {
                 u.Uid.Should().BeGreaterOrEqualTo(0);
@@ -208,16 +302,25 @@ namespace Meilisearch.Tests
             }
         }
 
-        [Fact]
-        public async Task DocumentsUpdateWithPrimaryKey()
+        [Theory]
+        [InlineData("json")]
+        public async Task DocumentsUpdateWithPrimaryKey(string format)
         {
-            var indexUid = "DocumentsUpdateWithPrimaryKeyTest";
+            var indexUid = $"DocumentsUpdateWithPrimaryKeyTest_{format}";
             var index = _client.Index(indexUid);
             index.PrimaryKey.Should().BeNull();
 
             // Add the documents
-            var task = await index.UpdateDocumentsAsync(new[] { new { Key = "1", Name = "Ironman" } }, "key");
-            await index.WaitForTaskAsync(task.Uid);
+            TaskInfo task;
+            switch (format)
+            {
+                case "json":
+                    task = await index.UpdateDocumentsJsonAsync(new[] { new { Key = "1", Name = "Ironman" } }, "key");
+                    break;
+                default:
+                    throw new System.IndexOutOfRangeException($"Unsupported format: {format}");
+            }
+            task = await index.WaitForTaskAsync(task.Uid);
             task.Uid.Should().BeGreaterOrEqualTo(0);
 
             // Check the primary key has been set

--- a/tests/Meilisearch.Tests/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/IndexFixture.cs
@@ -54,7 +54,7 @@ namespace Meilisearch.Tests
                 new Movie { Id = "15", Name = "Spider-Man", Genre = "Action" },
                 new Movie { Id = "16", Name = "Amélie Poulain", Genre = "French movie" },
             };
-            var task = await index.AddDocumentsAsync(movies);
+            var task = await index.AddDocumentsJsonAsync(movies);
 
             // Check the documents have been added
             var finishedTask = await index.WaitForTaskAsync(task.Uid);
@@ -79,7 +79,7 @@ namespace Meilisearch.Tests
                 new MovieWithIntId { Id = 15, Name = "Spider-Man", Genre = "Action" },
                 new MovieWithIntId { Id = 16, Name = "Amélie Poulain", Genre = "French movie" },
             };
-            var task = await index.AddDocumentsAsync(movies);
+            var task = await index.AddDocumentsJsonAsync(movies);
 
             // Check the documents have been added
             var finishedTask = await index.WaitForTaskAsync(task.Uid);
@@ -108,7 +108,7 @@ namespace Meilisearch.Tests
                 new Movie { Id = "17", Name = "Mission Impossible", Genre = "Action" },
                 new Movie { Id = "1344", Name = "The Hobbit", Genre = "sci fi" },
             };
-            var task = await index.AddDocumentsAsync(movies);
+            var task = await index.AddDocumentsJsonAsync(movies);
 
             // Check the documents have been added
             var finishedTask = await index.WaitForTaskAsync(task.Uid);
@@ -182,7 +182,7 @@ namespace Meilisearch.Tests
                     Info = new MovieInfo { Comment = "talks about hapiness", ReviewNb = 800 }
                 },
             };
-            var task = await index.AddDocumentsAsync(movies);
+            var task = await index.AddDocumentsJsonAsync(movies);
 
             // Check the documents have been added
             var finishedTask = await index.WaitForTaskAsync(task.Uid);

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -66,7 +66,7 @@ namespace Meilisearch.Tests
             index.Uid.Should().Be(indexUid);
             index.PrimaryKey.Should().BeNull();
 
-            var document = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+            var document = await index.AddDocumentsJsonAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
             document.Uid.Should().BeGreaterOrEqualTo(0);
         }
 

--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -51,7 +51,7 @@ namespace Meilisearch.Tests
             await _defaultClient.Index(indexUid).WaitForTaskAsync(task.Uid);
 
             var index = _defaultClient.Index(indexUid);
-            task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
+            task = await index.AddDocumentsJsonAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
             task.Uid.Should().BeGreaterOrEqualTo(0);
             await index.WaitForTaskAsync(task.Uid);
 

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -28,7 +28,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task GetAllTaskInfo()
         {
-            await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
+            await _index.AddDocumentsJsonAsync(new[] { new Movie { Id = "1" } });
             var taskResponse = await _index.GetTasksAsync();
             var tasks = taskResponse.Results;
             tasks.Count().Should().BeGreaterOrEqualTo(1);
@@ -37,7 +37,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task GetOneTaskInfo()
         {
-            var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "2" } });
+            var task = await _index.AddDocumentsJsonAsync(new[] { new Movie { Id = "2" } });
             var fetchedTask = await _index.GetTaskAsync(task.Uid);
             fetchedTask.Should().NotBeNull();
             fetchedTask.Uid.Should().BeGreaterOrEqualTo(0);
@@ -47,7 +47,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task DefaultWaitForTask()
         {
-            var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "3" } });
+            var task = await _index.AddDocumentsJsonAsync(new[] { new Movie { Id = "3" } });
             var finishedTask = await _index.WaitForTaskAsync(task.Uid);
             Assert.Equal(finishedTask.Uid, task.Uid);
             Assert.Equal("succeeded", finishedTask.Status);
@@ -56,7 +56,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomWaitForTask()
         {
-            var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "4" } });
+            var task = await _index.AddDocumentsJsonAsync(new[] { new Movie { Id = "4" } });
             var finishedTask = await _index.WaitForTaskAsync(task.Uid, 10000.0, 20);
             Assert.Equal(finishedTask.Uid, task.Uid);
             Assert.Equal("succeeded", finishedTask.Status);
@@ -65,7 +65,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task WaitForTaskWithException()
         {
-            var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "5" } });
+            var task = await _index.AddDocumentsJsonAsync(new[] { new Movie { Id = "5" } });
             await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => _index.WaitForTaskAsync(task.Uid, 0.0, 20));
         }
     }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This PR partially fixes #182 for JSON format

[BREAKING CHANGES]
`AddDocumentsAsync` is now `AddDocumentsJsonAsync`
`AddDocumentsInBatchesAsync` is now `AddDocumentsJsonInBatchesAsync`

`UpdateDocumentsAsync` is now `UpdateDocumentsJsonAsync`
`UpdateDocumentsInBatchesAsync` is now `UpdateDocumentsJsonInBatchesAsync`

The README and code samples have been updated to reflect the changes.

The test infrastructure has been updated to easily leverage it when we will add `NDJSON` and `CSV`.

I introduce a `JsonHttpContent`, this allow to remove some custom code from HttpExtensions (more will be removed later) and easily follow what Adding and Updating functions are doing.

Let me know if things are not clear, this PR is a bit big.

