### PR TITLE
Make SearchResult an immutable object

### DIFF
--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Meilisearch
 {
@@ -8,19 +9,19 @@ namespace Meilisearch
     /// <typeparam name="T">Hit type.</typeparam>
     public class SearchResult<T>
     {
-        public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int nbHits, bool exhaustiveNbHits,
-            IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetsDistribution, bool exhaustiveFacetsCount,
-            int processingTimeMs, string query)
+        public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int estimatedNbHits,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
+            int processingTimeMs, string query,
+            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion)
         {
             Hits = hits;
             Offset = offset;
             Limit = limit;
-            NbHits = nbHits;
-            ExhaustiveNbHits = exhaustiveNbHits;
-            FacetsDistribution = facetsDistribution;
-            ExhaustiveFacetsCount = exhaustiveFacetsCount;
+            EstimatedNbHits = estimatedNbHits;
+            FacetDistribution = facetDistribution;
             ProcessingTimeMs = processingTimeMs;
             Query = query;
+            MatchesPostion = matchesPostion;
         }
 
         /// <summary>
@@ -41,22 +42,12 @@ namespace Meilisearch
         /// <summary>
         /// Total number of matches.
         /// </summary>
-        public int NbHits { get; }
-
-        /// <summary>
-        /// Whether nbHits is exhaustive.
-        /// </summary>
-        public bool ExhaustiveNbHits { get; }
+        public int EstimatedNbHits { get; }
 
         /// <summary>
         /// Returns the number of documents matching the current search query for each given facet.
         /// </summary>
-        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> FacetsDistribution { get; }
-
-        /// <summary>
-        /// Whether facetsDistribution is exhaustive.
-        /// </summary>
-        public bool ExhaustiveFacetsCount { get; }
+        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> FacetDistribution { get; }
 
         /// <summary>
         /// Processing time of the query.
@@ -67,5 +58,32 @@ namespace Meilisearch
         /// Query originating the response.
         /// </summary>
         public string Query { get; }
+
+        /// <summary>
+        /// Contains the location of each occurrence of queried terms across all fields.
+        /// </summary>
+        [JsonPropertyName("_matchesPosition")]
+        public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
+    }
+
+    public class MatchPosition
+    {
+        public MatchPosition(int start, int length)
+        {
+            Start = start;
+            Length = length;
+        }
+
+        /// <summary>
+        /// The beginning of a matching term within a field.
+        /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
+        /// </summary>
+        public int Start { get; }
+
+        /// <summary>
+        /// The length of a matching term within a field.
+        /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
+        /// </summary>
+        public int Length { get; }
     }
 }

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -8,44 +8,64 @@ namespace Meilisearch
     /// <typeparam name="T">Hit type.</typeparam>
     public class SearchResult<T>
     {
-        /// <summary>
-        /// Gets or sets the total count of search results.
-        /// </summary>
-        public IEnumerable<T> Hits { get; set; }
+        public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int nbHits, bool exhaustiveNbHits,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetsDistribution, bool exhaustiveFacetsCount,
+            int processingTimeMs, string query)
+        {
+            Hits = hits;
+            Offset = offset;
+            Limit = limit;
+            NbHits = nbHits;
+            ExhaustiveNbHits = exhaustiveNbHits;
+            FacetsDistribution = facetsDistribution;
+            ExhaustiveFacetsCount = exhaustiveFacetsCount;
+            ProcessingTimeMs = processingTimeMs;
+            Query = query;
+        }
 
         /// <summary>
-        /// Gets or sets the offset of the initial search.
+        /// Results of the query.
         /// </summary>
-        public int Offset { get; set; }
+        public IReadOnlyCollection<T> Hits { get; }
 
         /// <summary>
-        /// Gets or sets the limit of the initial search.
+        /// Number of documents skipped.
         /// </summary>
-        public int Limit { get; set; }
+        public int Offset { get; }
 
         /// <summary>
-        /// Gets or sets the query sent.
+        /// Number of documents to take.
         /// </summary>
-        public string Query { get; set; }
+        public int Limit { get; }
 
         /// <summary>
-        /// Gets or sets the facets distribution.
+        /// Total number of matches.
         /// </summary>
-        public Dictionary<string, Dictionary<string, int>> FacetsDistribution { get; set; }
+        public int NbHits { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the facets distribution is exhaustive or not.
+        /// Whether nbHits is exhaustive.
         /// </summary>
-        public bool ExhaustiveFacetsCount { get; set; }
+        public bool ExhaustiveNbHits { get; }
 
         /// <summary>
-        /// Gets or sets the nbHits returned by the search.
+        /// Returns the number of documents matching the current search query for each given facet.
         /// </summary>
-        public int NbHits { get; set; }
+        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> FacetsDistribution { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the nbHits number returned by the search is exhaustive or not.
+        /// Whether facetsDistribution is exhaustive.
         /// </summary>
-        public bool ExhaustiveNbHits { get; set; }
+        public bool ExhaustiveFacetsCount { get; }
+
+        /// <summary>
+        /// Processing time of the query.
+        /// </summary>
+        public int ProcessingTimeMs { get; }
+
+        /// <summary>
+        /// Query originating the response.
+        /// </summary>
+        public string Query { get; }
     }
 }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -152,7 +152,7 @@ namespace Meilisearch.Tests
                     Filter = "genre = SF",
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("12", movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
@@ -170,7 +170,7 @@ namespace Meilisearch.Tests
                     Filter = "genre = 'sci fi'",
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
             Assert.Equal("1344", movies.Hits.First().Id);
             Assert.Equal("The Hobbit", movies.Hits.First().Name);
@@ -186,7 +186,7 @@ namespace Meilisearch.Tests
                     Filter = new string[] { "genre = SF" },
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("12", movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
@@ -204,7 +204,7 @@ namespace Meilisearch.Tests
                     Filter = new string[][] { new string[] { "genre = SF", "genre = SF" }, new string[] { "genre = SF" } },
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("12", movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
@@ -230,7 +230,7 @@ namespace Meilisearch.Tests
                     Filter = "id = 12",
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
             Assert.Equal(12, movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
@@ -255,7 +255,7 @@ namespace Meilisearch.Tests
                     Filter = "genre = SF AND id > 12",
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
             Assert.Equal(13, movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
@@ -267,7 +267,7 @@ namespace Meilisearch.Tests
         {
             var movies = await _indexForFaceting.SearchAsync<Movie>("coco \"harry\"");
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
             Assert.Equal("13", movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
@@ -284,11 +284,11 @@ namespace Meilisearch.Tests
                     FacetsDistribution = new string[] { "genre" },
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().NotBeEmpty();
-            movies.FacetsDistribution["genre"].Should().NotBeEmpty();
-            Assert.Equal(3, movies.FacetsDistribution["genre"]["Action"]);
-            Assert.Equal(2, movies.FacetsDistribution["genre"]["SF"]);
-            Assert.Equal(1, movies.FacetsDistribution["genre"]["French movie"]);
+            movies.FacetDistribution.Should().NotBeEmpty();
+            movies.FacetDistribution["genre"].Should().NotBeEmpty();
+            Assert.Equal(3, movies.FacetDistribution["genre"]["Action"]);
+            Assert.Equal(2, movies.FacetDistribution["genre"]["SF"]);
+            Assert.Equal(1, movies.FacetDistribution["genre"]["French movie"]);
         }
 
         [Fact]
@@ -309,7 +309,7 @@ namespace Meilisearch.Tests
                     Sort = new string[] { "name:asc" },
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("14", movies.Hits.First().Id);
         }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This PR continues to reduce public API surface and make sure we map the payload sent by Meilisearch.

- Documentation have been updated
- Properties are read only and ordered like in the documentation
- `IEnumerable` are now `IReadOnlyCollection` 
- Added `ProcessingTimeMs` property

Why `IEnumerable` to `IReadOnlyCollection` : 
https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/guidelines-for-collections?redirectedfrom=MSDN

> DO use ReadOnlyCollection<T>, a subclass of ReadOnlyCollection<T>, or in rare cases IEnumerable<T> for properties or return values representing read-only collections.

This will also avoid the warning message about multiple evaluation due to potential deferred execution and avoid to use the `.ToList()`.
