### PR TITLE
Apply search changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -238,7 +238,7 @@ faceted_search_filter_1: |-
 faceted_search_facets_distribution_1: |-
   SearchQuery filters = new SearchQuery()
   {
-      FacetsDistribution = new string[] { "genres" }
+      Facets = new string[] { "genres" }
   };
 
   SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Batman", filters);

--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -75,16 +75,16 @@ namespace Meilisearch
         public string HighlightPostTag { get; set; }
 
         /// <summary>
-        /// Gets or sets the facets distribution for the query.
+        /// Gets or sets the facets for the query.
         /// </summary>
-        [JsonPropertyName("facetsDistribution")]
-        public IEnumerable<string> FacetsDistribution { get; set; }
+        [JsonPropertyName("facets")]
+        public IEnumerable<string> Facets { get; set; }
 
         /// <summary>
-        /// Gets or sets matches. It defines whether an object that contains information about the matches should be returned or not.
+        /// Gets or sets showMatchesPosition. It defines whether an object that contains information about the matches should be returned or not.
         /// </summary>
-        [JsonPropertyName("matches")]
-        public bool? Matches { get; set; }
+        [JsonPropertyName("showMatchesPosition")]
+        public bool? ShowMatchesPosition { get; set; }
 
         /// <summary>
         /// Gets or sets the sorted attributes.

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -29,23 +29,13 @@ namespace Meilisearch
         public string Query { get; set; }
 
         /// <summary>
-        /// Gets or sets the facets distribution.
+        /// Gets or sets the facet distribution.
         /// </summary>
-        public Dictionary<string, Dictionary<string, int>> FacetsDistribution { get; set; }
+        public Dictionary<string, Dictionary<string, int>> FacetDistribution { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the facets distribution is exhaustive or not.
+        /// Gets or sets the estimated total number of hits returned by the search.
         /// </summary>
-        public bool ExhaustiveFacetsCount { get; set; }
-
-        /// <summary>
-        /// Gets or sets the nbHits returned by the search.
-        /// </summary>
-        public int NbHits { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the nbHits number returned by the search is exhaustive or not.
-        /// </summary>
-        public bool ExhaustiveNbHits { get; set; }
+        public int EstimatedTotalHits { get; set; }
     }
 }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -152,7 +152,7 @@ namespace Meilisearch.Tests
                     Filter = "genre = SF",
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("12", movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
@@ -170,7 +170,7 @@ namespace Meilisearch.Tests
                     Filter = "genre = 'sci fi'",
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
             Assert.Equal("1344", movies.Hits.First().Id);
             Assert.Equal("The Hobbit", movies.Hits.First().Name);
@@ -186,7 +186,7 @@ namespace Meilisearch.Tests
                     Filter = new string[] { "genre = SF" },
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("12", movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
@@ -204,7 +204,7 @@ namespace Meilisearch.Tests
                     Filter = new string[][] { new string[] { "genre = SF", "genre = SF" }, new string[] { "genre = SF" } },
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("12", movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
@@ -230,7 +230,7 @@ namespace Meilisearch.Tests
                     Filter = "id = 12",
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
             Assert.Equal(12, movies.Hits.First().Id);
             Assert.Equal("Star Wars", movies.Hits.First().Name);
@@ -255,7 +255,7 @@ namespace Meilisearch.Tests
                     Filter = "genre = SF AND id > 12",
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
             Assert.Equal(13, movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
@@ -267,7 +267,7 @@ namespace Meilisearch.Tests
         {
             var movies = await _indexForFaceting.SearchAsync<Movie>("coco \"harry\"");
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
             Assert.Equal("13", movies.Hits.First().Id);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
@@ -275,20 +275,20 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
-        public async Task CustomSearchWithFacetsDistribution()
+        public async Task CustomSearchWithFacetDistribution()
         {
             var movies = await _indexForFaceting.SearchAsync<Movie>(
                 null,
                 new SearchQuery
                 {
-                    FacetsDistribution = new string[] { "genre" },
+                    Facets = new string[] { "genre" },
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().NotBeEmpty();
-            movies.FacetsDistribution["genre"].Should().NotBeEmpty();
-            Assert.Equal(3, movies.FacetsDistribution["genre"]["Action"]);
-            Assert.Equal(2, movies.FacetsDistribution["genre"]["SF"]);
-            Assert.Equal(1, movies.FacetsDistribution["genre"]["French movie"]);
+            movies.FacetDistribution.Should().NotBeEmpty();
+            movies.FacetDistribution["genre"].Should().NotBeEmpty();
+            Assert.Equal(3, movies.FacetDistribution["genre"]["Action"]);
+            Assert.Equal(2, movies.FacetDistribution["genre"]["SF"]);
+            Assert.Equal(1, movies.FacetDistribution["genre"]["French movie"]);
         }
 
         [Fact]
@@ -309,7 +309,7 @@ namespace Meilisearch.Tests
                     Sort = new string[] { "name:asc" },
                 });
             movies.Hits.Should().NotBeEmpty();
-            movies.FacetsDistribution.Should().BeNull();
+            movies.FacetDistribution.Should().BeNull();
             Assert.Equal(2, movies.Hits.Count());
             Assert.Equal("14", movies.Hits.First().Id);
         }


### PR DESCRIPTION
Breaking because enforces the users to use Meilisearch v0.28.0

- Rename `nbHits` response parameter to `estimatedTotalHits`.
- Delete `exhaustiveNbHits` response parameter.
- Delete `exhaustiveFacetsCount` response parameter.
- `matches` request parameter is renamed `showMatchesPosition`.
- `_matchesInfo` response parameter is renamed `_matchesPosition`.
- `facetsDistribution` request parameter is renamed `facets`.
- `facetsDistribution` response parameter is renamed `facetDistribution`.