### PR TITLE
Apply tasks changes

### DIFF
--- a/src/Meilisearch/Index.Tasks.cs
+++ b/src/Meilisearch/Index.Tasks.cs
@@ -11,9 +11,9 @@ namespace Meilisearch
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the operations status.</returns>
-        public async Task<Result<IEnumerable<TaskInfo>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskRessource>>> GetTasksAsync(CancellationToken cancellationToken = default)
         {
-            return await TaskEndpoint().GetIndexTasksAsync(Uid, cancellationToken).ConfigureAwait(false);
+            return await TaskEndpoint().GetTasksAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -22,9 +22,9 @@ namespace Meilisearch
         /// <param name="taskUid">Uid of the task.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the tasks.</returns>
-        public async Task<TaskInfo> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
+        public async Task<TaskRessource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
         {
-            return await TaskEndpoint().GetIndexTaskAsync(Uid, taskUid, cancellationToken).ConfigureAwait(false);
+            return await TaskEndpoint().GetTaskAsync(taskUid, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Meilisearch
         /// <param name="intervalMs">Interval in millisecond between each check.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info of finished task.</returns>
-        public async Task<TaskInfo> WaitForTaskAsync(
+        public async Task<TaskRessource> WaitForTaskAsync(
             int taskUid,
             double timeoutMs = 5000.0,
             int intervalMs = 50,

--- a/src/Meilisearch/Index.Tasks.cs
+++ b/src/Meilisearch/Index.Tasks.cs
@@ -11,7 +11,7 @@ namespace Meilisearch
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the operations status.</returns>
-        public async Task<TasksResults<IEnumerable<TaskRessource>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(CancellationToken cancellationToken = default)
         {
             return await TaskEndpoint().GetTasksAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -22,7 +22,7 @@ namespace Meilisearch
         /// <param name="taskUid">Uid of the task.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the tasks.</returns>
-        public async Task<TaskRessource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
+        public async Task<TaskResource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
         {
             return await TaskEndpoint().GetTaskAsync(taskUid, cancellationToken).ConfigureAwait(false);
         }
@@ -35,7 +35,7 @@ namespace Meilisearch
         /// <param name="intervalMs">Interval in millisecond between each check.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info of finished task.</returns>
-        public async Task<TaskRessource> WaitForTaskAsync(
+        public async Task<TaskResource> WaitForTaskAsync(
             int taskUid,
             double timeoutMs = 5000.0,
             int intervalMs = 50,

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -182,7 +182,7 @@ namespace Meilisearch
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of tasks.</returns>
-        public async Task<Result<IEnumerable<TaskInfo>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<Result<IEnumerable<TaskRessource>>> GetTasksAsync(CancellationToken cancellationToken = default)
         {
             return await TaskEndpoint().GetTasksAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -193,7 +193,7 @@ namespace Meilisearch
         /// <param name="taskUid">Unique identifier of the task.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Return the task.</returns>
-        public async Task<TaskInfo> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
+        public async Task<TaskRessource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
         {
             return await TaskEndpoint().GetTaskAsync(taskUid, cancellationToken).ConfigureAwait(false);
         }
@@ -206,7 +206,7 @@ namespace Meilisearch
         /// <param name="intervalMs">Interval in millisecond between each check.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info of finished task.</returns>
-        public async Task<TaskInfo> WaitForTaskAsync(
+        public async Task<TaskRessource> WaitForTaskAsync(
             int taskUid,
             double timeoutMs = 5000.0,
             int intervalMs = 50,

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -182,7 +182,7 @@ namespace Meilisearch
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of tasks.</returns>
-        public async Task<Result<IEnumerable<TaskRessource>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<Result<IEnumerable<TaskResource>>> GetTasksAsync(CancellationToken cancellationToken = default)
         {
             return await TaskEndpoint().GetTasksAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -193,7 +193,7 @@ namespace Meilisearch
         /// <param name="taskUid">Unique identifier of the task.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Return the task.</returns>
-        public async Task<TaskRessource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
+        public async Task<TaskResource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
         {
             return await TaskEndpoint().GetTaskAsync(taskUid, cancellationToken).ConfigureAwait(false);
         }
@@ -206,7 +206,7 @@ namespace Meilisearch
         /// <param name="intervalMs">Interval in millisecond between each check.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info of finished task.</returns>
-        public async Task<TaskRessource> WaitForTaskAsync(
+        public async Task<TaskResource> WaitForTaskAsync(
             int taskUid,
             double timeoutMs = 5000.0,
             int intervalMs = 50,

--- a/src/Meilisearch/ResourceResults.cs
+++ b/src/Meilisearch/ResourceResults.cs
@@ -7,16 +7,16 @@ namespace Meilisearch
     /// When returning a list, Meilisearch stores the data in the "results" field, to allow better pagination.
     /// </summary>
     /// <typeparam name="T">Type of the Meilisearch server object. Ex: keys, indexes, ...</typeparam>
-    public class TasksResults<T> : Result<T>
+    public class ResourceResults<T> : Result<T>
     {
         /// <summary>
-        /// Gets or sets from size.
+        /// Gets or sets offset size.
         /// </summary>
-        public int? From { get; set; }
+        public int Offset { get; set; }
 
         /// <summary>
-        /// Gets or sets next size.
+        /// Gets or sets total size.
         /// </summary>
-        public int? Next { get; set; }
+        public int Total { get; set; }
     }
 }

--- a/src/Meilisearch/Result.cs
+++ b/src/Meilisearch/Result.cs
@@ -11,5 +11,10 @@ namespace Meilisearch
         /// Gets or sets the "results" field.
         /// </summary>
         public T Results { get; set; }
+
+        /// <summary>
+        /// Gets or sets limit size.
+        /// </summary>
+        public int? Limit { get; set; }
     }
 }

--- a/src/Meilisearch/TaskEndpoint.cs
+++ b/src/Meilisearch/TaskEndpoint.cs
@@ -19,9 +19,9 @@ namespace Meilisearch
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the tasks.</returns>
-        public async Task<TasksResults<IEnumerable<TaskRessource>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskRessource>>>("tasks", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskResource>>>("tasks", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -31,9 +31,9 @@ namespace Meilisearch
         /// <param name="taskUid">Uid of the index.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task.</returns>
-        public async Task<TaskRessource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
+        public async Task<TaskResource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<TaskRessource>($"tasks/{taskUid}", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<TaskResource>($"tasks/{taskUid}", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -43,9 +43,9 @@ namespace Meilisearch
         /// <param name="indexUid">Uid of the index.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of tasks of an index.</returns>
-        public async Task<TasksResults<IEnumerable<TaskRessource>>> GetIndexTasksAsync(string indexUid, CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskResource>>> GetIndexTasksAsync(string indexUid, CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskRessource>>>($"tasks?indexUid={indexUid}", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskResource>>>($"tasks?indexUid={indexUid}", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -57,7 +57,7 @@ namespace Meilisearch
         /// <param name="intervalMs">Interval in millisecond between each check.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info of finished task.</returns>
-        public async Task<TaskRessource> WaitForTaskAsync(
+        public async Task<TaskResource> WaitForTaskAsync(
             int taskUid,
             double timeoutMs = 5000.0,
             int intervalMs = 50,

--- a/src/Meilisearch/TaskEndpoint.cs
+++ b/src/Meilisearch/TaskEndpoint.cs
@@ -19,9 +19,9 @@ namespace Meilisearch
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the tasks.</returns>
-        public async Task<Result<IEnumerable<TaskInfo>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskRessource>>> GetTasksAsync(CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<Result<IEnumerable<TaskInfo>>>("tasks", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskRessource>>>("tasks", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -31,9 +31,9 @@ namespace Meilisearch
         /// <param name="taskUid">Uid of the index.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task.</returns>
-        public async Task<TaskInfo> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
+        public async Task<TaskRessource> GetTaskAsync(int taskUid, CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<TaskInfo>($"tasks/{taskUid}", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<TaskRessource>($"tasks/{taskUid}", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -43,22 +43,10 @@ namespace Meilisearch
         /// <param name="indexUid">Uid of the index.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of tasks of an index.</returns>
-        public async Task<Result<IEnumerable<TaskInfo>>> GetIndexTasksAsync(string indexUid, CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskRessource>>> GetIndexTasksAsync(string indexUid, CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<Result<IEnumerable<TaskInfo>>>($"indexes/{indexUid}/tasks", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskRessource>>>($"tasks?indexUid={indexUid}", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Get one task from an index.
-        /// </summary>
-        /// <param name="indexUid">Uid of the index.</param>
-        /// <param name="taskUid">Uid of the task.</param>
-        /// <param name="cancellationToken">The cancellation token for this call.</param>
-        /// <returns>Return the task of the index.</returns>
-        public async Task<TaskInfo> GetIndexTaskAsync(string indexUid, int taskUid, CancellationToken cancellationToken = default)
-        {
-            return await _http.GetFromJsonAsync<TaskInfo>($"indexes/{indexUid}/tasks/{taskUid}", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -69,7 +57,7 @@ namespace Meilisearch
         /// <param name="intervalMs">Interval in millisecond between each check.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info of finished task.</returns>
-        public async Task<TaskInfo> WaitForTaskAsync(
+        public async Task<TaskRessource> WaitForTaskAsync(
             int taskUid,
             double timeoutMs = 5000.0,
             int intervalMs = 50,

--- a/src/Meilisearch/TaskInfo.cs
+++ b/src/Meilisearch/TaskInfo.cs
@@ -41,8 +41,7 @@ namespace Meilisearch
         public TaskInfoStatus Status { get; }
 
         /// <summary>
-        /// The type of task. Possible values are indexCreation, indexUpdate, indexDeletion,
-        /// documentAdditionOrUpdate, documentDeletion, settingsUpdate.
+        /// The type of task.
         /// </summary>
         public TaskInfoType Type { get; }
 

--- a/src/Meilisearch/TaskResource.cs
+++ b/src/Meilisearch/TaskResource.cs
@@ -7,9 +7,9 @@ namespace Meilisearch
     /// <summary>
     /// Information of the regarding a task.
     /// </summary>
-    public class TaskRessource
+    public class TaskResource
     {
-        public TaskRessource(int uid, string? indexUid, TaskInfoStatus status, TaskInfoType type,
+        public TaskResource(int uid, string? indexUid, TaskInfoStatus status, TaskInfoType type,
             Dictionary<string, object> details, Dictionary<string, string> error, string duration, DateTime enqueuedAt,
             DateTime? startedAt, DateTime? finishedAt)
         {
@@ -41,15 +41,14 @@ namespace Meilisearch
         public TaskInfoStatus Status { get; }
 
         /// <summary>
-        /// The type of task. Possible values are indexCreation, indexUpdate, indexDeletion,
-        /// documentAdditionOrUpdate, documentDeletion, settingsUpdate.
+        /// The type of task.
         /// </summary>
         public TaskInfoType Type { get; }
 
         /// <summary>
         /// Detailed information on the task payload.
         /// </summary>
-        public Dictionary<string, object> Details { get; }
+        public Dictionary<string, dynamic> Details { get; }
 
         /// <summary>
         /// Error details and context. Only present when a task has the failed status.

--- a/src/Meilisearch/TaskRessource.cs
+++ b/src/Meilisearch/TaskRessource.cs
@@ -7,13 +7,13 @@ namespace Meilisearch
     /// <summary>
     /// Information of the regarding a task.
     /// </summary>
-    public class TaskInfo
+    public class TaskRessource
     {
-        public TaskInfo(int taskUid, string? indexUid, TaskInfoStatus status, TaskInfoType type,
+        public TaskRessource(int uid, string? indexUid, TaskInfoStatus status, TaskInfoType type,
             Dictionary<string, object> details, Dictionary<string, string> error, string duration, DateTime enqueuedAt,
             DateTime? startedAt, DateTime? finishedAt)
         {
-            TaskUid = taskUid;
+            Uid = uid;
             IndexUid = indexUid;
             Status = status;
             Type = type;
@@ -28,7 +28,7 @@ namespace Meilisearch
         /// <summary>
         /// The unique sequential identifier of the task.
         /// </summary>
-        public int TaskUid { get; }
+        public int Uid { get; }
 
         /// <summary>
         /// The unique index identifier.
@@ -75,26 +75,5 @@ namespace Meilisearch
         /// The date and time when the task finished processing, whether failed or succeeded, in RFC 3339 format.
         /// </summary>
         public DateTime? FinishedAt { get; }
-    }
-
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public enum TaskInfoStatus
-    {
-        Enqueued,
-        Processing,
-        Succeeded,
-        Failed
-    }
-
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public enum TaskInfoType
-    {
-        IndexCreation,
-        IndexUpdate,
-        IndexDeletion,
-        DocumentAdditionOrUpdate,
-        DocumentDeletion,
-        SettingsUpdate,
-        DumpCreation
     }
 }

--- a/src/Meilisearch/TasksResults.cs
+++ b/src/Meilisearch/TasksResults.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Meilisearch
+{
+    /// <summary>
+    /// Generic result class for ressources.
+    /// When returning a list, Meilisearch stores the data in the "results" field, to allow better pagination.
+    /// </summary>
+    /// <typeparam name="T">Type of the Meilisearch server object. Ex: keys, indexes, ...</typeparam>
+    public class TasksResults<T> : Result<T>
+    {
+        /// <summary>
+        /// Gets or sets from size.
+        /// </summary>
+        public int? From { get; set; }
+
+        /// <summary>
+        /// Gets or sets next size.
+        /// </summary>
+        public int? Next { get; set; }
+    }
+}

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -32,8 +32,8 @@ namespace Meilisearch.Tests
 
             // Add the documents
             var task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been added
             var docs = await index.GetDocumentsAsync<Movie>();
@@ -50,8 +50,8 @@ namespace Meilisearch.Tests
 
             var jsonDocuments = await File.ReadAllTextAsync(Datasets.SmallMoviesJson);
             var task = await index.AddDocumentsJsonAsync(jsonDocuments);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been added
             var docs = (await index.GetDocumentsAsync<DatasetSmallMovie>()).ToList();
@@ -70,8 +70,8 @@ namespace Meilisearch.Tests
 
             var csvDocuments = await File.ReadAllTextAsync(Datasets.SongsCsv);
             var task = await index.AddDocumentsCsvAsync(csvDocuments);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been added
             var docs = (await index.GetDocumentsAsync<DatasetSong>()).ToList();
@@ -90,8 +90,8 @@ namespace Meilisearch.Tests
 
             var ndjsonDocuments = await File.ReadAllTextAsync(Datasets.SongsNdjson);
             var task = await index.AddDocumentsNdjsonAsync(ndjsonDocuments);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been added
             var docs = (await index.GetDocumentsAsync<DatasetSong>()).ToList();
@@ -120,8 +120,8 @@ namespace Meilisearch.Tests
             var tasks = await index.AddDocumentsInBatchesAsync(movies, 2);
             foreach (var u in tasks)
             {
-                u.Uid.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForTaskAsync(u.Uid);
+                u.TaskUid.Should().BeGreaterOrEqualTo(0);
+                await index.WaitForTaskAsync(u.TaskUid);
             }
 
             // Check the documents have been added (one movie from each batch)
@@ -143,8 +143,8 @@ namespace Meilisearch.Tests
             Assert.Equal(2, tasks.Count());
             foreach (var u in tasks)
             {
-                u.Uid.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForTaskAsync(u.Uid);
+                u.TaskUid.Should().BeGreaterOrEqualTo(0);
+                await index.WaitForTaskAsync(u.TaskUid);
             }
 
             // Check the documents have been added from first chunk
@@ -171,8 +171,8 @@ namespace Meilisearch.Tests
             Assert.Equal(2, tasks.Count());
             foreach (var u in tasks)
             {
-                u.Uid.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForTaskAsync(u.Uid);
+                u.TaskUid.Should().BeGreaterOrEqualTo(0);
+                await index.WaitForTaskAsync(u.TaskUid);
             }
 
             // Check the documents have been added from first chunk
@@ -193,14 +193,14 @@ namespace Meilisearch.Tests
         {
             var indexUid = "BasicDocumentsAdditionWithAlreadyCreatedIndexTest";
             var task = await _client.CreateIndexAsync(indexUid);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await _client.Index(indexUid).WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _client.Index(indexUid).WaitForTaskAsync(task.TaskUid);
 
             // Add the documents
             var index = _client.Index(indexUid);
             task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been added
             var docs = await index.GetDocumentsAsync<Movie>();
@@ -217,7 +217,7 @@ namespace Meilisearch.Tests
 
             // Add the documents
             var task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
-            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForTaskAsync(task.Uid, 0));
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForTaskAsync(task.TaskUid, 0));
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace Meilisearch.Tests
 
             // Add the documents
             var task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
-            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForTaskAsync(task.Uid, 0, 10));
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => index.WaitForTaskAsync(task.TaskUid, 0, 10));
         }
 
         [Fact]
@@ -240,8 +240,8 @@ namespace Meilisearch.Tests
 
             // Add the documents
             var task = await index.AddDocumentsAsync(new[] { new { Key = "1", Name = "Ironman" } }, "key");
-            await index.WaitForTaskAsync(task.Uid);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
 
             // Check the primary key has been set
             await index.FetchPrimaryKey();
@@ -260,13 +260,13 @@ namespace Meilisearch.Tests
                 new Movie { Id = "1", Name = "Batman", Genre = "Action" },
                 new Movie { Id = "2", Name = "Superman" },
             });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Update the documents
             task = await index.UpdateDocumentsAsync(new[] { new Movie { Id = "1", Name = "Ironman" } });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been updated and added
             var docs = await index.GetDocumentsAsync<Movie>();
@@ -290,14 +290,14 @@ namespace Meilisearch.Tests
             {
                 new DatasetSmallMovie { Id = "287947", Title = "NOT A TITLE", Genre = "NO GENRE" },
             });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Update the documents
             var jsonDocuments = await File.ReadAllTextAsync(Datasets.SmallMoviesJson);
             task = await index.UpdateDocumentsJsonAsync(jsonDocuments);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been updated and added
             var doc = await index.GetDocumentAsync<DatasetSmallMovie>("287947");
@@ -317,14 +317,14 @@ namespace Meilisearch.Tests
             {
                 new DatasetSong { Id = "702481615", Title = "NOT A TITLE", Genre = "NO GENRE" },
             });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Update the documents
             var csvDocuments = await File.ReadAllTextAsync(Datasets.SongsCsv);
             task = await index.UpdateDocumentsCsvAsync(csvDocuments);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been updated and added
             var doc = await index.GetDocumentAsync<DatasetSmallMovie>("702481615");
@@ -344,14 +344,14 @@ namespace Meilisearch.Tests
             {
                 new DatasetSong { Id = "412559401", Title = "NOT A TITLE", Genre = "NO GENRE" },
             });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Update the documents
             var ndjsonDocuments = await File.ReadAllTextAsync(Datasets.SongsNdjson);
             task = await index.UpdateDocumentsNdjsonAsync(ndjsonDocuments);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been updated and added
             var doc = await index.GetDocumentAsync<DatasetSmallMovie>("412559401");
@@ -378,8 +378,8 @@ namespace Meilisearch.Tests
             var tasks = await index.AddDocumentsInBatchesAsync(movies, 2);
             foreach (var u in tasks)
             {
-                u.Uid.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForTaskAsync(u.Uid);
+                u.TaskUid.Should().BeGreaterOrEqualTo(0);
+                await index.WaitForTaskAsync(u.TaskUid);
             }
 
             movies = new Movie[]
@@ -393,8 +393,8 @@ namespace Meilisearch.Tests
             tasks = await index.UpdateDocumentsInBatchesAsync(movies, 2);
             foreach (var u in tasks)
             {
-                u.Uid.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForTaskAsync(u.Uid);
+                u.TaskUid.Should().BeGreaterOrEqualTo(0);
+                await index.WaitForTaskAsync(u.TaskUid);
             }
 
             // Assert movies have genre after updating
@@ -418,15 +418,15 @@ namespace Meilisearch.Tests
                 new DatasetSong { Id = "702481615", Title = "NOT A TITLE", Genre = "NO GENRE" },
                 new DatasetSong { Id = "128391318", Title = "NOT A TITLE", Genre = "NO GENRE" },
             });
-            await index.WaitForTaskAsync(task.Uid);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             var csvDocuments = await File.ReadAllTextAsync(Datasets.SongsCsv);
             var tasks = (await index.UpdateDocumentsCsvInBatchesAsync(csvDocuments, 250)).ToList();
             Assert.Equal(2, tasks.Count());
             foreach (var u in tasks)
             {
-                u.Uid.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForTaskAsync(u.Uid);
+                u.TaskUid.Should().BeGreaterOrEqualTo(0);
+                await index.WaitForTaskAsync(u.TaskUid);
             }
 
             // Check the documents have been added from first chunk
@@ -454,15 +454,15 @@ namespace Meilisearch.Tests
                 new DatasetSong { Id = "412559401", Title = "NOT A TITLE", Genre = "NO GENRE" },
                 new DatasetSong { Id = "276177902", Title = "NOT A TITLE", Genre = "NO GENRE" },
             });
-            await index.WaitForTaskAsync(task.Uid);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             var ndjsonDocuments = await File.ReadAllTextAsync(Datasets.SongsNdjson);
             var tasks = (await index.UpdateDocumentsNdjsonInBatchesAsync(ndjsonDocuments, 150)).ToList();
             Assert.Equal(2, tasks.Count());
             foreach (var u in tasks)
             {
-                u.Uid.Should().BeGreaterOrEqualTo(0);
-                await index.WaitForTaskAsync(u.Uid);
+                u.TaskUid.Should().BeGreaterOrEqualTo(0);
+                await index.WaitForTaskAsync(u.TaskUid);
             }
 
             // Check the documents have been added from first chunk
@@ -487,8 +487,8 @@ namespace Meilisearch.Tests
 
             // Add the documents
             var task = await index.UpdateDocumentsAsync(new[] { new { Key = "1", Name = "Ironman" } }, "key");
-            await index.WaitForTaskAsync(task.Uid);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
 
             // Check the primary key has been set
             await index.FetchPrimaryKey();
@@ -538,8 +538,8 @@ namespace Meilisearch.Tests
 
             // Delete the document
             var task = await index.DeleteOneDocumentAsync("11");
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the document has been deleted
             var docs = await index.GetDocumentsAsync<Movie>();
@@ -555,8 +555,8 @@ namespace Meilisearch.Tests
 
             // Delete the document
             var task = await index.DeleteOneDocumentAsync(11);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the document has been deleted
             var docs = await index.GetDocumentsAsync<MovieWithIntId>();
@@ -572,8 +572,8 @@ namespace Meilisearch.Tests
 
             // Delete the documents
             var task = await index.DeleteDocumentsAsync(new[] { "12", "13", "14" });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been deleted
             var docs = await index.GetDocumentsAsync<Movie>();
@@ -594,8 +594,8 @@ namespace Meilisearch.Tests
 
             // Delete the documents
             var task = await index.DeleteDocumentsAsync(new[] { 12, 13, 14 });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been deleted
             var docs = await index.GetDocumentsAsync<MovieWithIntId>();
@@ -616,8 +616,8 @@ namespace Meilisearch.Tests
 
             // Delete all the documents
             var task = await index.DeleteAllDocumentsAsync();
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check all the documents have been deleted
             var docs = await index.GetDocumentsAsync<Movie>();

--- a/tests/Meilisearch.Tests/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/IndexFixture.cs
@@ -32,7 +32,7 @@ namespace Meilisearch.Tests
             var task = await DefaultClient.CreateIndexAsync(indexUid, primaryKey);
 
             // Check the index has been created
-            var finishedTask = await DefaultClient.WaitForTaskAsync(task.Uid);
+            var finishedTask = await DefaultClient.WaitForTaskAsync(task.TaskUid);
             if (finishedTask.Status != TaskInfoStatus.Succeeded)
             {
                 throw new Exception("The index was not created in SetUpEmptyIndex. Impossible to run the tests.");
@@ -57,7 +57,7 @@ namespace Meilisearch.Tests
             var task = await index.AddDocumentsAsync(movies);
 
             // Check the documents have been added
-            var finishedTask = await index.WaitForTaskAsync(task.Uid);
+            var finishedTask = await index.WaitForTaskAsync(task.TaskUid);
             if (finishedTask.Status != TaskInfoStatus.Succeeded)
             {
                 throw new Exception("The documents were not added during SetUpBasicIndex. Impossible to run the tests.");
@@ -82,7 +82,7 @@ namespace Meilisearch.Tests
             var task = await index.AddDocumentsAsync(movies);
 
             // Check the documents have been added
-            var finishedTask = await index.WaitForTaskAsync(task.Uid);
+            var finishedTask = await index.WaitForTaskAsync(task.TaskUid);
             if (finishedTask.Status != TaskInfoStatus.Succeeded)
             {
                 throw new Exception("The documents were not added during SetUpBasicIndexWithIntId. Impossible to run the tests.");
@@ -111,7 +111,7 @@ namespace Meilisearch.Tests
             var task = await index.AddDocumentsAsync(movies);
 
             // Check the documents have been added
-            var finishedTask = await index.WaitForTaskAsync(task.Uid);
+            var finishedTask = await index.WaitForTaskAsync(task.TaskUid);
             if (finishedTask.Status != TaskInfoStatus.Succeeded)
             {
                 throw new Exception("The documents were not added during SetUpIndexForFaceting. Impossible to run the tests.");
@@ -125,7 +125,7 @@ namespace Meilisearch.Tests
             task = await index.UpdateSettingsAsync(settings);
 
             // Check the settings have been added
-            finishedTask = await index.WaitForTaskAsync(task.Uid);
+            finishedTask = await index.WaitForTaskAsync(task.TaskUid);
             if (finishedTask.Status != TaskInfoStatus.Succeeded)
             {
                 throw new Exception("The settings were not added during SetUpIndexForFaceting. Impossible to run the tests.");
@@ -185,7 +185,7 @@ namespace Meilisearch.Tests
             var task = await index.AddDocumentsAsync(movies);
 
             // Check the documents have been added
-            var finishedTask = await index.WaitForTaskAsync(task.Uid);
+            var finishedTask = await index.WaitForTaskAsync(task.TaskUid);
             if (finishedTask.Status != TaskInfoStatus.Succeeded)
             {
                 throw new Exception("The documents were not added during SetUpIndexForNestedSearch. Impossible to run the tests.");

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -67,7 +67,7 @@ namespace Meilisearch.Tests
             index.PrimaryKey.Should().BeNull();
 
             var document = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
-            document.Uid.Should().BeGreaterOrEqualTo(0);
+            document.TaskUid.Should().BeGreaterOrEqualTo(0);
         }
 
         [Fact]
@@ -91,10 +91,10 @@ namespace Meilisearch.Tests
 
             await _client.CreateIndexAsync(indexUid, _defaultPrimaryKey);
             var task = await _client.CreateIndexAsync(indexUid, _defaultPrimaryKey);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            var finishedTask = await _client.Index(indexUid).WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            var finishedTask = await _client.Index(indexUid).WaitForTaskAsync(task.TaskUid);
 
-            Assert.Equal(task.Uid, finishedTask.Uid);
+            Assert.Equal(task.TaskUid, finishedTask.Uid);
             Assert.Equal(indexUid, finishedTask.IndexUid);
             Assert.Equal(TaskInfoStatus.Failed, finishedTask.Status);
             var error = finishedTask.Error;
@@ -111,8 +111,8 @@ namespace Meilisearch.Tests
             await _fixture.SetUpEmptyIndex(indexUid);
 
             var task = await _client.UpdateIndexAsync(indexUid, primarykey);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await _client.Index(indexUid).WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _client.Index(indexUid).WaitForTaskAsync(task.TaskUid);
 
             var index = await _client.GetIndexAsync(indexUid);
             index.PrimaryKey.Should().Be(primarykey);
@@ -193,8 +193,8 @@ namespace Meilisearch.Tests
             await _fixture.SetUpEmptyIndex(indexUid);
 
             var task = await _client.Index(indexUid).UpdateAsync(primarykey);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await _client.Index(indexUid).WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _client.Index(indexUid).WaitForTaskAsync(task.TaskUid);
 
             var index = await _client.GetIndexAsync(indexUid);
             index.PrimaryKey.Should().Be(primarykey);

--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -47,13 +47,13 @@ namespace Meilisearch.Tests
             var indexUid = "BasicUsageOfCustomClientTest";
 
             var task = await _fixture.ClientWithCustomHttpClient.CreateIndexAsync(indexUid);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await _defaultClient.Index(indexUid).WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _defaultClient.Index(indexUid).WaitForTaskAsync(task.TaskUid);
 
             var index = _defaultClient.Index(indexUid);
             task = await index.AddDocumentsAsync(new[] { new Movie { Id = "1", Name = "Batman" } });
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await index.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the JSON has been well serialized and the primary key is equal to "id"
             Assert.Equal("id", await index.FetchPrimaryKey());
@@ -132,8 +132,8 @@ namespace Meilisearch.Tests
             var indexUid = "DeleteIndexTest";
             await _fixture.ClientWithCustomHttpClient.CreateIndexAsync(indexUid, _defaultPrimaryKey);
             var task = await _fixture.ClientWithCustomHttpClient.DeleteIndexAsync(indexUid);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            var finishedTask = await _defaultClient.Index(indexUid).WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            var finishedTask = await _defaultClient.Index(indexUid).WaitForTaskAsync(task.TaskUid);
             Assert.Equal(TaskInfoStatus.Succeeded, finishedTask.Status);
         }
     }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -80,8 +80,8 @@ namespace Meilisearch.Tests
                 FilterableAttributes = new string[] { "name" },
             };
             var task = await _basicIndex.UpdateSettingsAsync(newFilters);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await _basicIndex.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _basicIndex.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _basicIndex.SearchAsync<FormattedMovie>(
                 "man",
@@ -220,8 +220,8 @@ namespace Meilisearch.Tests
                 FilterableAttributes = new string[] { "id" },
             };
             var task = await _indexWithIntId.UpdateSettingsAsync(newFilters);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await _indexWithIntId.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _indexWithIntId.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _indexWithIntId.SearchAsync<MovieWithIntId>(
                 null,
@@ -245,8 +245,8 @@ namespace Meilisearch.Tests
                 FilterableAttributes = new string[] { "genre", "id" },
             };
             var task = await _indexWithIntId.UpdateSettingsAsync(newFilters);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await _indexWithIntId.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _indexWithIntId.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _indexWithIntId.SearchAsync<MovieWithIntId>(
                 null,
@@ -299,8 +299,8 @@ namespace Meilisearch.Tests
                 SortableAttributes = new string[] { "name" },
             };
             var task = await _basicIndex.UpdateSettingsAsync(newSortable);
-            task.Uid.Should().BeGreaterOrEqualTo(0);
-            await _basicIndex.WaitForTaskAsync(task.Uid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _basicIndex.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _basicIndex.SearchAsync<Movie>(
                 "man",
@@ -370,7 +370,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithinNestedDocumentsWithSearchableAttributesSettings()
         {
             var task = await _nestedIndex.UpdateSearchableAttributesAsync(new string[] { "name", "info.comment" });
-            await _nestedIndex.WaitForTaskAsync(task.Uid);
+            await _nestedIndex.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("rich");
 
@@ -384,9 +384,9 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithinNestedDocumentsWithSearchableAndSortableAttributesSettings()
         {
             var searchTask = await _nestedIndex.UpdateSearchableAttributesAsync(new string[] { "name", "info.comment" });
-            await _nestedIndex.WaitForTaskAsync(searchTask.Uid);
+            await _nestedIndex.WaitForTaskAsync(searchTask.TaskUid);
             var sortTask = await _nestedIndex.UpdateSortableAttributesAsync(new string[] { "info.reviewNb" });
-            await _nestedIndex.WaitForTaskAsync(sortTask.Uid);
+            await _nestedIndex.WaitForTaskAsync(sortTask.TaskUid);
 
             var query = new SearchQuery { Sort = new string[] { "info.reviewNb:desc" } };
             var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("", query);

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -468,9 +468,9 @@ namespace Meilisearch.Tests
 
         private async Task AssertTaskInfoSucceeded(TaskInfo task)
         {
-            task.Uid.Should().BeGreaterThan(0);
-            task = await _index.WaitForTaskAsync(task.Uid);
-            task.Status.Should().Be(TaskInfoStatus.Succeeded);
+            task.TaskUid.Should().BeGreaterThan(0);
+            var taskRessource = await _index.WaitForTaskAsync(task.TaskUid);
+            taskRessource.Status.Should().Be(TaskInfoStatus.Succeeded);
         }
 
         private async Task AssertUpdateSuccess<TValue>(IndexUpdateMethod<TValue> updateMethod, TValue newValue)

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -469,8 +469,8 @@ namespace Meilisearch.Tests
         private async Task AssertTaskInfoSucceeded(TaskInfo task)
         {
             task.TaskUid.Should().BeGreaterThan(0);
-            var taskRessource = await _index.WaitForTaskAsync(task.TaskUid);
-            taskRessource.Status.Should().Be(TaskInfoStatus.Succeeded);
+            var taskResource = await _index.WaitForTaskAsync(task.TaskUid);
+            taskResource.Status.Should().Be(TaskInfoStatus.Succeeded);
         }
 
         private async Task AssertUpdateSuccess<TValue>(IndexUpdateMethod<TValue> updateMethod, TValue newValue)

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -38,7 +38,7 @@ namespace Meilisearch.Tests
         public async Task GetOneTaskInfo()
         {
             var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "2" } });
-            var fetchedTask = await _index.GetTaskAsync(task.Uid);
+            var fetchedTask = await _index.GetTaskAsync(task.TaskUid);
             fetchedTask.Should().NotBeNull();
             fetchedTask.Uid.Should().BeGreaterOrEqualTo(0);
         }
@@ -47,8 +47,8 @@ namespace Meilisearch.Tests
         public async Task DefaultWaitForTask()
         {
             var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "3" } });
-            var finishedTask = await _index.WaitForTaskAsync(task.Uid);
-            Assert.Equal(finishedTask.Uid, task.Uid);
+            var finishedTask = await _index.WaitForTaskAsync(task.TaskUid);
+            Assert.Equal(finishedTask.Uid, task.TaskUid);
             Assert.Equal(TaskInfoStatus.Succeeded, finishedTask.Status);
         }
 
@@ -56,8 +56,8 @@ namespace Meilisearch.Tests
         public async Task CustomWaitForTask()
         {
             var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "4" } });
-            var finishedTask = await _index.WaitForTaskAsync(task.Uid, 10000.0, 20);
-            Assert.Equal(finishedTask.Uid, task.Uid);
+            var finishedTask = await _index.WaitForTaskAsync(task.TaskUid, 10000.0, 20);
+            Assert.Equal(finishedTask.Uid, task.TaskUid);
             Assert.Equal(TaskInfoStatus.Succeeded, finishedTask.Status);
         }
 
@@ -65,7 +65,7 @@ namespace Meilisearch.Tests
         public async Task WaitForTaskWithException()
         {
             var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "5" } });
-            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => _index.WaitForTaskAsync(task.Uid, 0.0, 20));
+            await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => _index.WaitForTaskAsync(task.TaskUid, 0.0, 20));
         }
     }
 }


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

### Changes

- Remove `GET /indexes/:indexUid/tasks`. Use `GET /tasks?indexUid=:indexUid` instead.
- Remove `GET /indexes/:indexUid/tasks/:taskUid`. Use `GET /tasks/:taskUid` instead.
- Add new class `TaskRessource` return by:
  - `client.GetTaskAsync`
  - `client.GetTasksAsync`
  - `index.GetTaskAsync`
  - `index.GetTasksAsync`
- Remove `GetIndexTasksAsync` method
- Rename `uid` field into `taskUid` in `TaskInfo` class