### PR TITLE
Apply documents changes

### DIFF
--- a/src/Meilisearch/DocumentQuery.cs
+++ b/src/Meilisearch/DocumentQuery.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Meilisearch
 {
     /// <summary>
@@ -16,8 +18,8 @@ namespace Meilisearch
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Gets or sets the attributes to retrieve..
+        /// Gets or sets the attributes to retrieve.
         /// </summary>
-        public IEnumerable<string> Fields { get; set; }
+        public List<string>? Fields { get; set; }
     }
 }

--- a/src/Meilisearch/DocumentQuery.cs
+++ b/src/Meilisearch/DocumentQuery.cs
@@ -16,8 +16,8 @@ namespace Meilisearch
         public int? Limit { get; set; }
 
         /// <summary>
-        /// Gets or sets the attributes to retrieve.
+        /// Gets or sets the attributes to retrieve..
         /// </summary>
-        public string AttributesToRetrieve { get; set; }
+        public IEnumerable<string> Fields { get; set; }
     }
 }

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -329,10 +329,16 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document.</typeparam>
         /// <returns>Returns the document, with the according type if the object is available.</returns>
-        public async Task<T> GetDocumentAsync<T>(string documentId, CancellationToken cancellationToken = default)
+        public async Task<T> GetDocumentAsync<T>(string documentId, List<string>? fields = default, CancellationToken cancellationToken = default)
         {
+            var uri = $"indexes/{Uid}/documents/{documentId}";
+            if (query != null)
+            {
+                uri = $"{uri}?fields={fields.ToQueryString()}";
+            }
+
             return await _http
-                .GetFromJsonAsync<T>($"indexes/{Uid}/documents/{documentId}", cancellationToken: cancellationToken)
+                .GetFromJsonAsync<T>(uri, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -343,9 +349,9 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type to return for document.</typeparam>
         /// <returns>Type if the object is availble.</returns>
-        public async Task<T> GetDocumentAsync<T>(int documentId, CancellationToken cancellationToken = default)
+        public async Task<T> GetDocumentAsync<T>(int documentId, List<string>? fields = default, CancellationToken cancellationToken = default)
         {
-            return await GetDocumentAsync<T>(documentId.ToString(), cancellationToken);
+            return await GetDocumentAsync<T>(documentId.ToString(), fields, cancellationToken);
         }
 
         /// <summary>
@@ -355,7 +361,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document.</typeparam>
         /// <returns>Returns the list of documents.</returns>
-        public async Task<IEnumerable<T>> GetDocumentsAsync<T>(DocumentQuery? query = default,
+        public async Task<ResourceResults<IEnumerable<T>>> GetDocumentsAsync<T>(DocumentQuery? query = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
@@ -364,7 +370,7 @@ namespace Meilisearch
                 uri = $"{uri}?{query.ToQueryString()}";
             }
 
-            return await _http.GetFromJsonAsync<IEnumerable<T>>(uri, cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<ResourceResults<IEnumerable<T>>>(uri, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -332,7 +332,7 @@ namespace Meilisearch
         public async Task<T> GetDocumentAsync<T>(string documentId, List<string>? fields = default, CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents/{documentId}";
-            if (query != null)
+            if (fields != null)
             {
                 uri = $"{uri}?fields={fields.ToQueryString()}";
             }

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -334,7 +334,7 @@ namespace Meilisearch
             var uri = $"indexes/{Uid}/documents/{documentId}";
             if (fields != null)
             {
-                uri = $"{uri}?fields={fields.ToQueryString()}";
+                uri = $"{uri}?fields={string.Join( ",", fields)}";
             }
 
             return await _http
@@ -367,7 +367,12 @@ namespace Meilisearch
             var uri = $"indexes/{Uid}/documents";
             if (query != null)
             {
-                uri = $"{uri}?{query.ToQueryString()}";
+                var request = new { Limit = query.Limit, Offset = query.Offset };
+                uri = $"{uri}?{request.ToQueryString()}";
+                if (query.Fields != null)
+                {
+                    uri = $"{uri}&fields={string.Join( ",", query.Fields)}";
+                }
             }
 
             return await _http.GetFromJsonAsync<ResourceResults<IEnumerable<T>>>(uri, cancellationToken: cancellationToken)

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 using FluentAssertions;
 
@@ -512,6 +513,25 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task GetOneExistingDocumentWithField()
+        {
+            var index = await _fixture.SetUpBasicIndex("GetOneExistingDocumentWithStringIdTest");
+            var documents = await index.GetDocumentAsync<Movie>("10", new List<string>{ "name" });
+            documents.Id.Should().BeNull();
+            documents.Name.Should().Be("Gladiator");
+        }
+
+        [Fact]
+        public async Task GetOneExistingDocumentWithMultipleFields()
+        {
+            var index = await _fixture.SetUpBasicIndex("GetOneExistingDocumentWithStringIdTest");
+            var documents = await index.GetDocumentAsync<Movie>("10", new List<string>{ "name", "id" });
+            documents.Id.Should().Be("10");
+            documents.Name.Should().Be("Gladiator");
+            documents.Genre.Should().BeNull();
+        }
+
+        [Fact]
         public async Task GetMultipleExistingDocuments()
         {
             var index = await _fixture.SetUpBasicIndex("GetMultipleExistingDocumentTest");
@@ -528,6 +548,28 @@ namespace Meilisearch.Tests
             var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery() { Limit = 2 });
             Assert.Equal(2, documents.Results.Count());
             documents.Results.First().Id.Should().Be("10");
+            documents.Results.Last().Id.Should().Be("11");
+        }
+
+        [Fact]
+        public async Task GetMultipleExistingDocumentsWithField()
+        {
+            var index = await _fixture.SetUpBasicIndex("GetMultipleExistingDocumentWithLimitTest");
+            var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery() { Limit = 2 , Fields = new List<string>{ "id" } });
+            Assert.Equal(2, documents.Results.Count());
+            documents.Results.First().Id.Should().Be("10");
+            documents.Results.First().Name.Should().BeNull();
+            documents.Results.Last().Id.Should().Be("11");
+        }
+
+        [Fact]
+        public async Task GetMultipleExistingDocumentsWithMultipleFields()
+        {
+            var index = await _fixture.SetUpBasicIndex("GetMultipleExistingDocumentWithLimitTest");
+            var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery() { Limit = 2 , Fields = new List<string>{ "id" , "name" } });
+            Assert.Equal(2, documents.Results.Count());
+            documents.Results.First().Id.Should().Be("10");
+            documents.Results.First().Name.Should().Be("Gladiator");
             documents.Results.Last().Id.Should().Be("11");
         }
 

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -37,9 +37,9 @@ namespace Meilisearch.Tests
 
             // Check the documents have been added
             var docs = await index.GetDocumentsAsync<Movie>();
-            Assert.Equal("1", docs.First().Id);
-            Assert.Equal("Batman", docs.First().Name);
-            docs.First().Genre.Should().BeNull();
+            Assert.Equal("1", docs.Results.First().Id);
+            Assert.Equal("Batman", docs.Results.First().Name);
+            docs.Results.First().Genre.Should().BeNull();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Meilisearch.Tests
             await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been added
-            var docs = (await index.GetDocumentsAsync<DatasetSmallMovie>()).ToList();
+            var docs = (await index.GetDocumentsAsync<DatasetSmallMovie>()).Results.ToList();
             Assert.NotEmpty(docs);
             var doc = docs.First();
             Assert.Equal("287947", doc.Id);
@@ -74,7 +74,7 @@ namespace Meilisearch.Tests
             await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been added
-            var docs = (await index.GetDocumentsAsync<DatasetSong>()).ToList();
+            var docs = (await index.GetDocumentsAsync<DatasetSong>()).Results.ToList();
             Assert.NotEmpty(docs);
             var doc = docs.First();
             Assert.Equal("702481615", doc.Id);
@@ -94,7 +94,7 @@ namespace Meilisearch.Tests
             await index.WaitForTaskAsync(task.TaskUid);
 
             // Check the documents have been added
-            var docs = (await index.GetDocumentsAsync<DatasetSong>()).ToList();
+            var docs = (await index.GetDocumentsAsync<DatasetSong>()).Results.ToList();
             Assert.NotEmpty(docs);
             var doc = docs.First();
             Assert.Equal("412559401", doc.Id);
@@ -125,7 +125,7 @@ namespace Meilisearch.Tests
             }
 
             // Check the documents have been added (one movie from each batch)
-            var docs = (await index.GetDocumentsAsync<Movie>()).ToList();
+            var docs = (await index.GetDocumentsAsync<Movie>()).Results.ToList();
             Assert.Equal("1", docs.ElementAt(0).Id);
             Assert.Equal("Batman", docs.ElementAt(0).Name);
             Assert.Equal("3", docs.ElementAt(2).Id);
@@ -204,9 +204,9 @@ namespace Meilisearch.Tests
 
             // Check the documents have been added
             var docs = await index.GetDocumentsAsync<Movie>();
-            Assert.Equal("1", docs.First().Id);
-            Assert.Equal("Batman", docs.First().Name);
-            docs.First().Genre.Should().BeNull();
+            Assert.Equal("1", docs.Results.First().Id);
+            Assert.Equal("Batman", docs.Results.First().Name);
+            docs.Results.First().Genre.Should().BeNull();
         }
 
         [Fact]
@@ -270,13 +270,13 @@ namespace Meilisearch.Tests
 
             // Check the documents have been updated and added
             var docs = await index.GetDocumentsAsync<Movie>();
-            Assert.Equal("1", docs.First().Id);
-            Assert.Equal("Ironman", docs.First().Name);
-            Assert.Null(docs.First().Genre);
+            Assert.Equal("1", docs.Results.First().Id);
+            Assert.Equal("Ironman", docs.Results.First().Name);
+            Assert.Null(docs.Results.First().Genre);
 
-            Assert.Equal("2", docs.ElementAt(1).Id);
-            Assert.Equal("Superman", docs.ElementAt(1).Name);
-            docs.ElementAt(1).Genre.Should().BeNull();
+            Assert.Equal("2", docs.Results.ElementAt(1).Id);
+            Assert.Equal("Superman", docs.Results.ElementAt(1).Name);
+            docs.Results.ElementAt(1).Genre.Should().BeNull();
         }
 
         [Fact]
@@ -398,7 +398,7 @@ namespace Meilisearch.Tests
             }
 
             // Assert movies have genre after updating
-            var docs = (await index.GetDocumentsAsync<Movie>()).ToList();
+            var docs = (await index.GetDocumentsAsync<Movie>()).Results.ToList();
             foreach (var movie in docs)
             {
                 movie.Genre.Should().NotBeNull();
@@ -516,9 +516,9 @@ namespace Meilisearch.Tests
         {
             var index = await _fixture.SetUpBasicIndex("GetMultipleExistingDocumentTest");
             var documents = await index.GetDocumentsAsync<Movie>();
-            Assert.Equal(7, documents.Count());
-            documents.First().Id.Should().Be("10");
-            documents.Last().Id.Should().Be("16");
+            Assert.Equal(7, documents.Results.Count());
+            documents.Results.First().Id.Should().Be("10");
+            documents.Results.Last().Id.Should().Be("16");
         }
 
         [Fact]
@@ -526,9 +526,9 @@ namespace Meilisearch.Tests
         {
             var index = await _fixture.SetUpBasicIndex("GetMultipleExistingDocumentWithLimitTest");
             var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery() { Limit = 2 });
-            Assert.Equal(2, documents.Count());
-            documents.First().Id.Should().Be("10");
-            documents.Last().Id.Should().Be("11");
+            Assert.Equal(2, documents.Results.Count());
+            documents.Results.First().Id.Should().Be("10");
+            documents.Results.Last().Id.Should().Be("11");
         }
 
         [Fact]
@@ -543,7 +543,7 @@ namespace Meilisearch.Tests
 
             // Check the document has been deleted
             var docs = await index.GetDocumentsAsync<Movie>();
-            Assert.Equal(6, docs.Count());
+            Assert.Equal(6, docs.Results.Count());
             var ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<Movie>("11"));
             Assert.Equal("document_not_found", ex.Code);
         }
@@ -560,7 +560,7 @@ namespace Meilisearch.Tests
 
             // Check the document has been deleted
             var docs = await index.GetDocumentsAsync<MovieWithIntId>();
-            Assert.Equal(6, docs.Count());
+            Assert.Equal(6, docs.Results.Count());
             var ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<MovieWithIntId>(11));
             Assert.Equal("document_not_found", ex.Code);
         }
@@ -577,7 +577,7 @@ namespace Meilisearch.Tests
 
             // Check the documents have been deleted
             var docs = await index.GetDocumentsAsync<Movie>();
-            Assert.Equal(4, docs.Count());
+            Assert.Equal(4, docs.Results.Count());
             MeilisearchApiError ex;
             ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<Movie>("12"));
             Assert.Equal("document_not_found", ex.Code);
@@ -599,7 +599,7 @@ namespace Meilisearch.Tests
 
             // Check the documents have been deleted
             var docs = await index.GetDocumentsAsync<MovieWithIntId>();
-            Assert.Equal(4, docs.Count());
+            Assert.Equal(4, docs.Results.Count());
             MeilisearchApiError ex;
             ex = await Assert.ThrowsAsync<MeilisearchApiError>(() => index.GetDocumentAsync<MovieWithIntId>("12"));
             Assert.Equal("document_not_found", ex.Code);
@@ -621,7 +621,7 @@ namespace Meilisearch.Tests
 
             // Check all the documents have been deleted
             var docs = await index.GetDocumentsAsync<Movie>();
-            docs.Should().BeEmpty();
+            docs.Results.Should().BeEmpty();
         }
     }
 }

--- a/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
+++ b/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
@@ -30,10 +30,10 @@ namespace Meilisearch.Tests
         [InlineData(1, null, "attr")]
         [InlineData(null, 2, "attr")]
         [InlineData(1, 2, "attr")]
-        public void QueryStringsAreEqualsForDocumentQuery(int? offset, int? limit, string attributesToRetrieve)
+        public void QueryStringsAreEqualsForDocumentQuery(int? offset, int? limit, string fields)
         {
             var uri = "indexes/myindex/documents";
-            var dq = new DocumentQuery { Offset = offset, Limit = limit, AttributesToRetrieve = attributesToRetrieve };
+            var dq = new DocumentQuery { Offset = offset, Limit = limit, Fields = fields };
 
             var expected = QueryHelpers.AddQueryString(uri, dq.AsDictionary());
             var actual = $"{uri}?{dq.ToQueryString()}";

--- a/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
+++ b/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Meilisearch.Extensions;
 
 using Microsoft.AspNetCore.WebUtilities;
@@ -22,18 +24,18 @@ namespace Meilisearch.Tests
         }
 
         [Theory]
-        [InlineData(null, null, "")]
-        [InlineData(1, null, "")]
-        [InlineData(null, 3, "")]
+        [InlineData(null, null, null)]
+        [InlineData(1, null, null)]
+        [InlineData(null, 3, null)]
         [InlineData(null, null, "attr")]
-        [InlineData(1, 2, "")]
+        [InlineData(1, 2, null)]
         [InlineData(1, null, "attr")]
         [InlineData(null, 2, "attr")]
         [InlineData(1, 2, "attr")]
         public void QueryStringsAreEqualsForDocumentQuery(int? offset, int? limit, string fields)
         {
             var uri = "indexes/myindex/documents";
-            var dq = new DocumentQuery { Offset = offset, Limit = limit, Fields = fields };
+            var dq = new DocumentQuery { Offset = offset, Limit = limit, Fields = new List<string>{ fields } };
 
             var expected = QueryHelpers.AddQueryString(uri, dq.AsDictionary());
             var actual = $"{uri}?{dq.ToQueryString()}";


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

- `GET /documents/:uid`, `GET /documents` Add the possibility to reduce the body payload by using a query parameter called `fields` (previously called `attributesToRetrieve`), check the issue and the spec for the entire behavior.
- The documents objects in now return wrap in a `ResourceResults`