### PR TITLE
Apply keys changes

### DIFF
--- a/src/Meilisearch/Key.cs
+++ b/src/Meilisearch/Key.cs
@@ -16,9 +16,23 @@ namespace Meilisearch
         public string KeyUid { get; set; }
 
         /// <summary>
+        /// Gets or sets unique identifier of the API key.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Uid { get; set; }
+
+        /// <summary>
         /// Gets or sets the description of the API key.
         /// </summary>
-        public string Description { get; set; }
+        // [JsonIgnore]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the API key.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets list of actions available for the API key.

--- a/src/Meilisearch/Key.cs
+++ b/src/Meilisearch/Key.cs
@@ -24,7 +24,6 @@ namespace Meilisearch
         /// <summary>
         /// Gets or sets the description of the API key.
         /// </summary>
-        // [JsonIgnore]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Name { get; set; }
 

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -285,21 +285,21 @@ namespace Meilisearch
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the API keys.</returns>
-        public async Task<Result<IEnumerable<Key>>> GetKeysAsync(CancellationToken cancellationToken = default)
+        public async Task<ResourceResults<IEnumerable<Key>>> GetKeysAsync(CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<Result<IEnumerable<Key>>>("keys", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<ResourceResults<IEnumerable<Key>>>("keys", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
         /// <summary>
         /// Gets one API key.
         /// </summary>
-        /// <param name="keyUid">Unique identifier of the API key.</param>
+        /// <param name="keyOrUid">Unique identifier of the API key or the Key.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the API key information.</returns>
-        public async Task<Key> GetKeyAsync(string keyUid, CancellationToken cancellationToken = default)
+        public async Task<Key> GetKeyAsync(string keyOrUid, CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<Key>($"keys/{keyUid}", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<Key>($"keys/{keyOrUid}", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -321,13 +321,13 @@ namespace Meilisearch
         /// <summary>
         /// Deletes an API key from the Meilisearch server.
         /// </summary>
-        /// <param name="keyUid">Unique identifier of the API key.</param>
+        /// <param name="keyOrUid">Unique identifier of the API key or the Key</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns true if the API key was deleted.</returns>
-        public async Task<bool> DeleteKeyAsync(string keyUid, CancellationToken cancellationToken = default)
+        public async Task<bool> DeleteKeyAsync(string keyOrUid, CancellationToken cancellationToken = default)
         {
             var responseMessage =
-                await _http.DeleteAsync($"keys/{keyUid}", cancellationToken: cancellationToken).ConfigureAwait(false);
+                await _http.DeleteAsync($"keys/{keyOrUid}", cancellationToken: cancellationToken).ConfigureAwait(false);
             return responseMessage.StatusCode == HttpStatusCode.NoContent;
         }
 

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -54,10 +54,31 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task GetOneKeyUsingUid()
+        {
+            var keyResponse = await _client.GetKeysAsync();
+            var keys = keyResponse.Results;
+            var firstKey = keys.First();
+
+            var fetchedKey = await _client.GetKeyAsync(firstKey.Uid);
+
+            Assert.Equal(fetchedKey.KeyUid, firstKey.KeyUid);
+            Assert.Equal(fetchedKey.Uid, firstKey.Uid);
+            Assert.Equal(fetchedKey.Name, firstKey.Name);
+            Assert.Equal(fetchedKey.Description, firstKey.Description);
+            Assert.Equal(fetchedKey.Indexes, firstKey.Indexes);
+            Assert.Equal(fetchedKey.Actions, firstKey.Actions);
+            Assert.Equal(fetchedKey.ExpiresAt, firstKey.ExpiresAt);
+            Assert.Equal(fetchedKey.CreatedAt, firstKey.CreatedAt);
+            Assert.Equal(fetchedKey.UpdatedAt, firstKey.UpdatedAt);
+        }
+
+        [Fact]
         public async Task CreateOneKey()
         {
             var keyOptions = new Key
             {
+                Name = "AddDocumentToAllIndexes",
                 Description = "Key to add document to all indexes.",
                 Actions = new string[] { "documents.add" },
                 Indexes = new string[] { "*" },

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -57,8 +57,7 @@ namespace Meilisearch.Tests
         public async Task GetOneKeyUsingUid()
         {
             var keyResponse = await _client.GetKeysAsync();
-            var keys = keyResponse.Results;
-            var firstKey = keys.First();
+            var firstKey = keyResponse.Results.First();
 
             var fetchedKey = await _client.GetKeyAsync(firstKey.Uid);
 


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

### Changes

- `GetKeysAsync` now return a `ResourceResults` object
- Add `Name` and `Uid` fields to `Key` object