### PR TITLE
Apply changes for HTTP method patch

### DIFF
--- a/src/Meilisearch/Index.Settings.cs
+++ b/src/Meilisearch/Index.Settings.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Meilisearch.Extensions;
 namespace Meilisearch
 {
     public partial class Index
@@ -27,7 +28,7 @@ namespace Meilisearch
         public async Task<TaskInfo> UpdateSettingsAsync(Settings settings, CancellationToken cancellationToken = default)
         {
             var responseMessage =
-                await _http.PostAsJsonAsync($"indexes/{Uid}/settings", settings, Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
+                await _http.PatchAsJsonAsync($"indexes/{Uid}/settings", settings, Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
         }

--- a/src/Meilisearch/Index.TypoTolerance.cs
+++ b/src/Meilisearch/Index.TypoTolerance.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Meilisearch.Extensions;
 namespace Meilisearch
 {
     public partial class Index
@@ -26,7 +27,7 @@ namespace Meilisearch
         public async Task<TaskInfo> UpdateTypoToleranceAsync(TypoTolerance typoTolerance, CancellationToken cancellationToken = default)
         {
             var responseMessage =
-                await _http.PostAsJsonAsync($"indexes/{Uid}/settings/typo-tolerance", typoTolerance, Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
+                await _http.PatchAsJsonAsync($"indexes/{Uid}/settings/typo-tolerance", typoTolerance, Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
 
             return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken)

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Meilisearch.Extensions;
 namespace Meilisearch
 {
 
@@ -98,7 +99,7 @@ namespace Meilisearch
         public async Task<TaskInfo> UpdateAsync(string primarykeytoChange, CancellationToken cancellationToken = default)
         {
             var responseMessage =
-                await _http.PutAsJsonAsync($"indexes/{Uid}", new { primaryKey = primarykeytoChange }, cancellationToken: cancellationToken)
+                await _http.PatchAsJsonAsync($"indexes/{Uid}", new { primaryKey = primarykeytoChange }, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
 
             return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Breaking because enforces the users to use Meilisearch v0.28.0

Add last HTTP changes after the addition of `PATCH`
- `PATCH` `/indexes/{indexUid}` instead of `PUT`
- `PATCH` `/indexes/{indexUid}/settings` instead of `POST`
- `PATCH` `/indexes/{indexUid}/settings/typo-tolerance` instead of `POST`