### PR TITLE
Apply changes on tenant token

### DIFF
--- a/src/Meilisearch/Errors/MeilisearchTenantTokenApiKeyUidInvalid.cs
+++ b/src/Meilisearch/Errors/MeilisearchTenantTokenApiKeyUidInvalid.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Meilisearch
+{
+    /// <summary>
+    /// Represents an exception thrown when `apiKey` is not present
+    /// to sign correctly the Tenant Token generation.
+    /// </summary>
+    public class MeilisearchTenantTokenApiKeyUidInvalid : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeilisearchTenantTokenApiKeyUidInvalid"/> class.
+        /// </summary>
+        public MeilisearchTenantTokenApiKeyUidInvalid()
+            : base("Cannot generate a signed token without a valid apiKeyUid. Provide one in the method params.")
+        {
+        }
+    }
+}

--- a/src/Meilisearch/TenantToken.cs
+++ b/src/Meilisearch/TenantToken.cs
@@ -11,8 +11,13 @@ namespace Meilisearch
         /// Generates a Tenant Token in a JWT string format.
         /// </summary>
         /// <returns>JWT string</returns>
-        public static string GenerateToken(TenantTokenRules searchRules, string apiKey, DateTime? expiresAt)
+        public static string GenerateToken(string apiKeyUid, TenantTokenRules searchRules, string apiKey, DateTime? expiresAt)
         {
+            if (String.IsNullOrEmpty(apiKeyUid))
+            {
+                throw new MeilisearchTenantTokenApiKeyUidInvalid();
+            }
+
             if (String.IsNullOrEmpty(apiKey) || apiKey.Length < 8)
             {
                 throw new MeilisearchTenantTokenApiKeyInvalid();
@@ -21,7 +26,7 @@ namespace Meilisearch
             var builder = JwtBuilder
                 .Create()
                 .WithAlgorithm(new HMACSHA256Algorithm())
-                .AddClaim("apiKeyPrefix", apiKey.Substring(0, 8))
+                .AddClaim("apiKeyUid", apiKeyUid)
                 .AddClaim("searchRules", searchRules.ToClaim())
                 .WithSecret(apiKey);
 

--- a/src/Meilisearch/TenantTokenRules.cs
+++ b/src/Meilisearch/TenantTokenRules.cs
@@ -8,7 +8,7 @@ namespace Meilisearch
     /// </summary>
     public class TenantTokenRules
     {
-        private object _rules;
+        private readonly object _rules;
 
         public TenantTokenRules(Dictionary<string, object> rules)
         {


### PR DESCRIPTION
as per the [spec](https://github.com/meilisearch/specifications/pull/148/files#diff-7b1a49daa5acb02c131aff3eb5fabb81c7e7c3d1b95adb60c4bf70cadcb488d4)


- [x] apiKeyPrefix claim is now named apiKeyUid and expects the uid of the signing API key as a value.
