### PR TITLE
Remove nullable and force langage to 8

### DIFF
--- a/src/Meilisearch/DocumentQuery.cs
+++ b/src/Meilisearch/DocumentQuery.cs
@@ -20,6 +20,6 @@ namespace Meilisearch
         /// <summary>
         /// Gets or sets the attributes to retrieve.
         /// </summary>
-        public List<string>? Fields { get; set; }
+        public List<string> Fields { get; set; }
     }
 }

--- a/src/Meilisearch/Extensions/HttpExtensions.cs
+++ b/src/Meilisearch/Extensions/HttpExtensions.cs
@@ -83,7 +83,7 @@ namespace Meilisearch.Extensions
             client.DefaultRequestHeaders.Add("User-Agent", version.GetQualifiedVersion());
         }
 
-        private static StringContent PrepareJsonPayload<T>(T body, JsonSerializerOptions? options = null)
+        private static StringContent PrepareJsonPayload<T>(T body, JsonSerializerOptions options = null)
         {
             options = options ?? Constants.JsonSerializerOptionsWriteNulls;
             var payload = new StringContent(JsonSerializer.Serialize(body, options), Encoding.UTF8, "application/json");
@@ -92,13 +92,13 @@ namespace Meilisearch.Extensions
             return payload;
         }
 
-        private static Task<HttpResponseMessage> PatchAsync(this HttpClient client, string? requestUri, HttpContent content, CancellationToken cancellationToken)
+        private static Task<HttpResponseMessage> PatchAsync(this HttpClient client, string requestUri, HttpContent content, CancellationToken cancellationToken)
         {
             var uri = new Uri(requestUri, UriKind.RelativeOrAbsolute);
             return client.PatchAsync(uri, content, cancellationToken);
         }
 
-        private static Task<HttpResponseMessage> PatchAsync(this HttpClient client, Uri? requestUri, HttpContent content, CancellationToken cancellationToken)
+        private static Task<HttpResponseMessage> PatchAsync(this HttpClient client, Uri requestUri, HttpContent content, CancellationToken cancellationToken)
         {
             // HttpClient.PatchAsync is not available in .NET standard and NET462
             var method = new HttpMethod("PATCH");
@@ -106,7 +106,7 @@ namespace Meilisearch.Extensions
             return client.SendAsync(request, cancellationToken);
         }
 
-        internal static Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, string? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        internal static Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, string requestUri, TValue value, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             var content = JsonContent.Create(value, mediaType: null, options);
             return client.PatchAsync(requestUri, content, cancellationToken);

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -20,7 +20,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document. Even though documents are schemaless in Meilisearch, making it typed helps in compile time.</typeparam>
         /// <returns>Returns the task info.</returns>
-        public async Task<TaskInfo> AddDocumentsAsync<T>(IEnumerable<T> documents, string? primaryKey = default,
+        public async Task<TaskInfo> AddDocumentsAsync<T>(IEnumerable<T> documents, string primaryKey = default,
             CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage;
@@ -44,7 +44,7 @@ namespace Meilisearch
         /// <param name="primaryKey">Primary key for the documents.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info.</returns>
-        public async Task<TaskInfo> AddDocumentsJsonAsync(string documents, string? primaryKey = default,
+        public async Task<TaskInfo> AddDocumentsJsonAsync(string documents, string primaryKey = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
@@ -67,7 +67,7 @@ namespace Meilisearch
         /// <param name="primaryKey">Primary key for the documents.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info.</returns>
-        public async Task<TaskInfo> AddDocumentsCsvAsync(string documents, string? primaryKey = default,
+        public async Task<TaskInfo> AddDocumentsCsvAsync(string documents, string primaryKey = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
@@ -90,7 +90,7 @@ namespace Meilisearch
         /// <param name="primaryKey">Primary key for the documents.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info.</returns>
-        public async Task<TaskInfo> AddDocumentsNdjsonAsync(string documents, string? primaryKey = default,
+        public async Task<TaskInfo> AddDocumentsNdjsonAsync(string documents, string primaryKey = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
@@ -116,7 +116,7 @@ namespace Meilisearch
         /// <typeparam name="T">Type of the document. Even though documents are schemaless in Meilisearch, making it typed helps in compile time.</typeparam>
         /// <returns>Returns the task list.</returns>
         public async Task<IEnumerable<TaskInfo>> AddDocumentsInBatchesAsync<T>(IEnumerable<T> documents,
-            int batchSize = 1000, string? primaryKey = default, CancellationToken cancellationToken = default)
+            int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var tasks = new List<TaskInfo>();
             foreach (var chunk in documents.GetChunks(batchSize))
@@ -136,7 +136,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task list.</returns>
         public async Task<IEnumerable<TaskInfo>> AddDocumentsCsvInBatchesAsync(string documents,
-            int batchSize = 1000, string? primaryKey = default, CancellationToken cancellationToken = default)
+            int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var tasks = new List<TaskInfo>();
             foreach (var chunk in documents.GetCsvChunks(batchSize))
@@ -156,7 +156,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task list.</returns>
         public async Task<IEnumerable<TaskInfo>> AddDocumentsNdjsonInBatchesAsync(string documents,
-            int batchSize = 1000, string? primaryKey = default, CancellationToken cancellationToken = default)
+            int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var tasks = new List<TaskInfo>();
             foreach (var chunk in documents.GetNdjsonChunks(batchSize))
@@ -175,7 +175,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of document. Even though documents are schemaless in Meilisearch, making it typed helps in compile time.</typeparam>
         /// <returns>Returns the task list.</returns>
-        public async Task<TaskInfo> UpdateDocumentsAsync<T>(IEnumerable<T> documents, string? primaryKey = default,
+        public async Task<TaskInfo> UpdateDocumentsAsync<T>(IEnumerable<T> documents, string primaryKey = default,
             CancellationToken cancellationToken = default)
         {
             HttpResponseMessage responseMessage;
@@ -199,7 +199,7 @@ namespace Meilisearch
         /// <param name="primaryKey">Primary key for the documents.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info.</returns>
-        public async Task<TaskInfo> UpdateDocumentsJsonAsync(string documents, string? primaryKey = default,
+        public async Task<TaskInfo> UpdateDocumentsJsonAsync(string documents, string primaryKey = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
@@ -222,7 +222,7 @@ namespace Meilisearch
         /// <param name="primaryKey">Primary key for the documents.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info.</returns>
-        public async Task<TaskInfo> UpdateDocumentsCsvAsync(string documents, string? primaryKey = default,
+        public async Task<TaskInfo> UpdateDocumentsCsvAsync(string documents, string primaryKey = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
@@ -245,7 +245,7 @@ namespace Meilisearch
         /// <param name="primaryKey">Primary key for the documents.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info.</returns>
-        public async Task<TaskInfo> UpdateDocumentsNdjsonAsync(string documents, string? primaryKey = default,
+        public async Task<TaskInfo> UpdateDocumentsNdjsonAsync(string documents, string primaryKey = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
@@ -271,7 +271,7 @@ namespace Meilisearch
         /// <typeparam name="T">Type of the document. Even though documents are schemaless in Meilisearch, making it typed helps in compile time.</typeparam>
         /// <returns>Returns the task list.</returns>
         public async Task<IEnumerable<TaskInfo>> UpdateDocumentsInBatchesAsync<T>(IEnumerable<T> documents,
-            int batchSize = 1000, string? primaryKey = default, CancellationToken cancellationToken = default)
+            int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var tasks = new List<TaskInfo>();
             foreach (var chunk in documents.GetChunks(batchSize))
@@ -291,7 +291,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task list.</returns>
         public async Task<IEnumerable<TaskInfo>> UpdateDocumentsCsvInBatchesAsync(string documents,
-            int batchSize = 1000, string? primaryKey = default, CancellationToken cancellationToken = default)
+            int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var tasks = new List<TaskInfo>();
             foreach (var chunk in documents.GetCsvChunks(batchSize))
@@ -311,7 +311,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task list.</returns>
         public async Task<IEnumerable<TaskInfo>> UpdateDocumentsNdjsonInBatchesAsync(string documents,
-            int batchSize = 1000, string? primaryKey = default, CancellationToken cancellationToken = default)
+            int batchSize = 1000, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var tasks = new List<TaskInfo>();
             foreach (var chunk in documents.GetNdjsonChunks(batchSize))
@@ -329,7 +329,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document.</typeparam>
         /// <returns>Returns the document, with the according type if the object is available.</returns>
-        public async Task<T> GetDocumentAsync<T>(string documentId, List<string>? fields = default, CancellationToken cancellationToken = default)
+        public async Task<T> GetDocumentAsync<T>(string documentId, List<string> fields = default, CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents/{documentId}";
             if (fields != null)
@@ -349,7 +349,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type to return for document.</typeparam>
         /// <returns>Type if the object is availble.</returns>
-        public async Task<T> GetDocumentAsync<T>(int documentId, List<string>? fields = default, CancellationToken cancellationToken = default)
+        public async Task<T> GetDocumentAsync<T>(int documentId, List<string> fields = default, CancellationToken cancellationToken = default)
         {
             return await GetDocumentAsync<T>(documentId.ToString(), fields, cancellationToken);
         }
@@ -361,7 +361,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document.</typeparam>
         /// <returns>Returns the list of documents.</returns>
-        public async Task<ResourceResults<IEnumerable<T>>> GetDocumentsAsync<T>(DocumentQuery? query = default,
+        public async Task<ResourceResults<IEnumerable<T>>> GetDocumentsAsync<T>(DocumentQuery query = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
@@ -458,7 +458,7 @@ namespace Meilisearch
         /// <typeparam name="T">Type parameter to return.</typeparam>
         /// <returns>Returns Enumerable of items.</returns>
         public async Task<SearchResult<T>> SearchAsync<T>(string query,
-            SearchQuery? searchAttributes = default(SearchQuery), CancellationToken cancellationToken = default)
+            SearchQuery searchAttributes = default(SearchQuery), CancellationToken cancellationToken = default)
         {
             SearchQuery body;
             if (searchAttributes == null)

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -24,7 +24,7 @@ namespace Meilisearch
         /// <param name="primaryKey">Documents primary key.</param>
         /// <param name="createdAt">The creation date of the index.</param>
         /// <param name="updatedAt">The latest update of the index.</param>
-        public Index(string uid, string? primaryKey = default, DateTimeOffset? createdAt = default, DateTimeOffset? updatedAt = default)
+        public Index(string uid, string primaryKey = default, DateTimeOffset? createdAt = default, DateTimeOffset? updatedAt = default)
         {
             Uid = uid;
             PrimaryKey = primaryKey;

--- a/src/Meilisearch/Key.cs
+++ b/src/Meilisearch/Key.cs
@@ -19,19 +19,19 @@ namespace Meilisearch
         /// Gets or sets unique identifier of the API key.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string? Uid { get; set; }
+        public string Uid { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the API key.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string? Name { get; set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the API key.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string? Description { get; set; }
+        public string Description { get; set; }
 
         /// <summary>
         /// Gets or sets list of actions available for the API key.

--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -12,8 +12,6 @@
         <PackageProjectUrl>https://meilisearch.com</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/meilisearch_dotnet.png</PackageIconUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Nullable>enable</Nullable>
-        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -321,7 +321,7 @@ namespace Meilisearch
         /// <exception cref="MeilisearchTenantTokenApiKeyInvalid">When there is no <paramref name="apiKey"/> defined in the client or as argument.</exception>
         /// <exception cref="MeilisearchTenantTokenExpired">When the sent <paramref name="expiresAt"/> param is in the past</exception>
         /// <returns>Returns a generated tenant token.</returns>
-        public string GenerateTenantToken(string apiKeyUid, TenantTokenRules searchRules, string? apiKey = null, DateTime? expiresAt = null)
+        public string GenerateTenantToken(string apiKeyUid, TenantTokenRules searchRules, string apiKey = null, DateTime? expiresAt = null)
         {
             return TenantToken.GenerateToken(apiKeyUid, searchRules, apiKey ?? ApiKey, expiresAt);
         }

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -84,7 +84,7 @@ namespace Meilisearch
         /// <param name="primaryKey">Primary key for documents.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the associated task.</returns>
-        public async Task<TaskInfo> CreateIndexAsync(string uid, string? primaryKey = default, CancellationToken cancellationToken = default)
+        public async Task<TaskInfo> CreateIndexAsync(string uid, string primaryKey = default, CancellationToken cancellationToken = default)
         {
             var index = new Index(uid, primaryKey);
             var responseMessage = await _http.PostJsonCustomAsync("indexes", index, Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)

--- a/src/Meilisearch/TaskInfo.cs
+++ b/src/Meilisearch/TaskInfo.cs
@@ -9,7 +9,7 @@ namespace Meilisearch
     /// </summary>
     public class TaskInfo
     {
-        public TaskInfo(int taskUid, string? indexUid, TaskInfoStatus status, TaskInfoType type,
+        public TaskInfo(int taskUid, string indexUid, TaskInfoStatus status, TaskInfoType type,
             Dictionary<string, object> details, Dictionary<string, string> error, string duration, DateTime enqueuedAt,
             DateTime? startedAt, DateTime? finishedAt)
         {
@@ -33,7 +33,7 @@ namespace Meilisearch
         /// <summary>
         /// The unique index identifier.
         /// </summary>
-        public string? IndexUid { get; }
+        public string IndexUid { get; }
 
         /// <summary>
         /// The status of the task. Possible values are enqueued, processing, succeeded, failed.

--- a/src/Meilisearch/TaskResource.cs
+++ b/src/Meilisearch/TaskResource.cs
@@ -9,7 +9,7 @@ namespace Meilisearch
     /// </summary>
     public class TaskResource
     {
-        public TaskResource(int uid, string? indexUid, TaskInfoStatus status, TaskInfoType type,
+        public TaskResource(int uid, string indexUid, TaskInfoStatus status, TaskInfoType type,
             Dictionary<string, object> details, Dictionary<string, string> error, string duration, DateTime enqueuedAt,
             DateTime? startedAt, DateTime? finishedAt)
         {
@@ -33,7 +33,7 @@ namespace Meilisearch
         /// <summary>
         /// The unique index identifier.
         /// </summary>
-        public string? IndexUid { get; }
+        public string IndexUid { get; }
 
         /// <summary>
         /// The status of the task. Possible values are enqueued, processing, succeeded, failed.


### PR DESCRIPTION
When implementing the `PATCH` method the `nullable` option has been enabled, this forces to use version 8 of the language which would be a breaking change. This has been removed