### PR TITLE
Apply changes for paginations in multiples methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The returned `task` is a `TaskInfo` that can access to `Uid` to get the status o
 #### Get Documents <!-- omit in toc -->
 
 ```c#
-var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery { Limit = 1 });
+var documents = await index.GetDocumentsAsync<Movie>(new DocumentsQuery { Limit = 1 });
 ```
 
 #### Get Document by Id <!-- omit in toc -->

--- a/src/Meilisearch/Extensions/ObjectExtensions.cs
+++ b/src/Meilisearch/Extensions/ObjectExtensions.cs
@@ -38,5 +38,31 @@ namespace Meilisearch.Extensions
             var queryString = string.Join("&", values);
             return queryString;
         }
+
+        /// <summary>
+        /// Transforms a Meilisearch object containing Lists into an URL encoded query string.
+        /// </summary>
+        /// <param name="source">Object to transform.</param>
+        /// <param name="bindingAttr">Binding flags.</param>
+        /// <returns>Returns an url encoded query string.</returns>
+        internal static string ToQueryStringWithList(this object source, BindingFlags bindingAttr = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance)
+        {
+            var values = new List<string>(); ;
+            foreach (var p in source.GetType().GetProperties(bindingAttr))
+            {
+                if (p.GetValue(source, null) != null)
+                {
+                    if (!(p.GetValue(source, null).GetType().IsGenericType && p.GetValue(source, null).GetType().GetGenericTypeDefinition() == typeof(List<>)))
+                    {
+                        values.Add(Uri.EscapeDataString(char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1)) + "=" + Uri.EscapeDataString(p.GetValue(source, null).ToString()));
+                    }
+                    if (p.GetValue(source, null).GetType().IsGenericType && p.GetValue(source, null).GetType().GetGenericTypeDefinition() == typeof(List<>))
+                    {
+                        values.Add(Uri.EscapeDataString(char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1)) + "=" + string.Join(",", (List<string>)p.GetValue(source, null)));
+                    }
+                }
+            }
+            return string.Join("&", values);
+        }
     }
 }

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Meilisearch.Extensions;
+using Meilisearch.QueryParameters;
 
 namespace Meilisearch
 {
@@ -357,22 +358,17 @@ namespace Meilisearch
         /// <summary>
         /// Get documents with the allowed Query Parameters.
         /// </summary>
-        /// <param name="query">Query parameters. Supports limit, offset and attributes to retrieve.</param>
+        /// <param name="query">Query parameters. Supports limit, offset and attributes to retrieve named fields.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document.</typeparam>
         /// <returns>Returns the list of documents.</returns>
-        public async Task<ResourceResults<IEnumerable<T>>> GetDocumentsAsync<T>(DocumentQuery query = default,
+        public async Task<ResourceResults<IEnumerable<T>>> GetDocumentsAsync<T>(DocumentsQuery query = default,
             CancellationToken cancellationToken = default)
         {
             var uri = $"indexes/{Uid}/documents";
             if (query != null)
             {
-                var request = new { Limit = query.Limit, Offset = query.Offset };
-                uri = $"{uri}?{request.ToQueryString()}";
-                if (query.Fields != null)
-                {
-                    uri = $"{uri}&fields={string.Join(",", query.Fields)}";
-                }
+                uri = $"{uri}?{query.ToQueryStringWithList()}";
             }
 
             return await _http.GetFromJsonAsync<ResourceResults<IEnumerable<T>>>(uri, cancellationToken: cancellationToken)

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -368,7 +368,7 @@ namespace Meilisearch
             var uri = $"indexes/{Uid}/documents";
             if (query != null)
             {
-                uri = $"{uri}?{query.ToQueryStringWithList()}";
+                uri = $"{uri}?{query.ToQueryString()}";
             }
 
             return await _http.GetFromJsonAsync<ResourceResults<IEnumerable<T>>>(uri, cancellationToken: cancellationToken)

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -358,7 +358,7 @@ namespace Meilisearch
         /// <summary>
         /// Get documents with the allowed Query Parameters.
         /// </summary>
-        /// <param name="query">Query parameters. Supports limit, offset and attributes to retrieve named fields.</param>
+        /// <param name="query">Query parameters supports by the method.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document.</typeparam>
         /// <returns>Returns the list of documents.</returns>

--- a/src/Meilisearch/Index.Tasks.cs
+++ b/src/Meilisearch/Index.Tasks.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Meilisearch.QueryParameters;
+
 namespace Meilisearch
 {
     public partial class Index
@@ -9,11 +11,12 @@ namespace Meilisearch
         /// <summary>
         /// Gets the tasks.
         /// </summary>
+        /// <param name="query">Query parameters. Supports limit, from, indexUid, status and types.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the operations status.</returns>
-        public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(TasksQuery query = default, CancellationToken cancellationToken = default)
         {
-            return await TaskEndpoint().GetTasksAsync(cancellationToken).ConfigureAwait(false);
+            return await TaskEndpoint().GetTasksAsync(query, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Meilisearch/Index.Tasks.cs
+++ b/src/Meilisearch/Index.Tasks.cs
@@ -11,7 +11,7 @@ namespace Meilisearch
         /// <summary>
         /// Gets the tasks.
         /// </summary>
-        /// <param name="query">Query parameters. Supports limit, from, indexUid, status and types.</param>
+        /// <param name="query">Query parameters supports by the method.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the operations status.</returns>
         public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(TasksQuery query = default, CancellationToken cancellationToken = default)

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -182,7 +182,7 @@ namespace Meilisearch
         /// <summary>
         /// Gets the tasks.
         /// </summary>
-        /// <param name="query">Query parameters. Supports limit, from, indexUid, status and types.</param>
+        /// <param name="query">Query parameters supports by the method.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of tasks.</returns>
         public async Task<Result<IEnumerable<TaskResource>>> GetTasksAsync(TasksQuery query = default, CancellationToken cancellationToken = default)
@@ -273,8 +273,7 @@ namespace Meilisearch
         /// <summary>
         /// Gets the API keys.
         /// </summary>
-        /// <param name="query">Query parameters. Supports limit and offset.</param>
-        /// <param name="query">Query parameters. Supports limit and offset.</param>
+        /// <param name="query">Query parameters supports by the method.</param>
         /// <returns>Returns a list of the API keys.</returns>
         public async Task<ResourceResults<IEnumerable<Key>>> GetKeysAsync(KeysQuery query = default, CancellationToken cancellationToken = default)
         {

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Meilisearch.Extensions;
+using Meilisearch.QueryParameters;
+
 namespace Meilisearch
 {
 
@@ -133,11 +135,17 @@ namespace Meilisearch
         /// <summary>
         /// Gets all the Indexes for the instance. Throws error if the index does not exist.
         /// </summary>
+        /// <param name="query">Query parameters. Supports limit and offset.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Return Enumerable of Index.</returns>
-        public async Task<ResourceResults<IEnumerable<Index>>> GetAllIndexesAsync(CancellationToken cancellationToken = default)
+        public async Task<ResourceResults<IEnumerable<Index>>> GetAllIndexesAsync(IndexesQuery query = default, CancellationToken cancellationToken = default)
         {
-            var response = await _http.GetAsync("indexes", cancellationToken).ConfigureAwait(false);
+            var uri = $"indexes";
+            if (query != null)
+            {
+                uri = $"{uri}?{query.ToQueryString()}";
+            }
+            var response = await _http.GetAsync(uri, cancellationToken).ConfigureAwait(false);
 
             var content = await response.Content.ReadFromJsonAsync<ResourceResults<IEnumerable<Index>>>(cancellationToken: cancellationToken).ConfigureAwait(false);
             content.Results
@@ -174,11 +182,12 @@ namespace Meilisearch
         /// <summary>
         /// Gets the tasks.
         /// </summary>
+        /// <param name="query">Query parameters. Supports limit, from, indexUid, status and types.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of tasks.</returns>
-        public async Task<Result<IEnumerable<TaskResource>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<Result<IEnumerable<TaskResource>>> GetTasksAsync(TasksQuery query = default, CancellationToken cancellationToken = default)
         {
-            return await TaskEndpoint().GetTasksAsync(cancellationToken).ConfigureAwait(false);
+            return await TaskEndpoint().GetTasksAsync(query, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -264,11 +273,17 @@ namespace Meilisearch
         /// <summary>
         /// Gets the API keys.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <param name="query">Query parameters. Supports limit and offset.</param>
+        /// <param name="query">Query parameters. Supports limit and offset.</param>
         /// <returns>Returns a list of the API keys.</returns>
-        public async Task<ResourceResults<IEnumerable<Key>>> GetKeysAsync(CancellationToken cancellationToken = default)
+        public async Task<ResourceResults<IEnumerable<Key>>> GetKeysAsync(KeysQuery query = default, CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<ResourceResults<IEnumerable<Key>>>("keys", cancellationToken: cancellationToken)
+            var uri = $"keys";
+            if (query != null)
+            {
+                uri = $"{uri}?{query.ToQueryString()}";
+            }
+            return await _http.GetFromJsonAsync<ResourceResults<IEnumerable<Key>>>(uri, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Meilisearch/QueryParamaters/DocumentsQuery.cs
+++ b/src/Meilisearch/QueryParamaters/DocumentsQuery.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Meilisearch.QueryParameters
 {
     /// <summary>
-    /// Documents Query for Meilisearch class.
+    /// A class that handles the creation of a query string for Documents.
     /// </summary>
     public class DocumentsQuery
     {

--- a/src/Meilisearch/QueryParamaters/DocumentsQuery.cs
+++ b/src/Meilisearch/QueryParamaters/DocumentsQuery.cs
@@ -1,21 +1,21 @@
 using System.Collections.Generic;
 
-namespace Meilisearch
+namespace Meilisearch.QueryParameters
 {
     /// <summary>
-    /// Document Query for Meilisearch class.
+    /// Documents Query for Meilisearch class.
     /// </summary>
-    public class DocumentQuery
+    public class DocumentsQuery
     {
-        /// <summary>
-        /// Gets or sets the offset.
-        /// </summary>
-        public int? Offset { get; set; }
-
         /// <summary>
         /// Gets or sets the limit.
         /// </summary>
         public int? Limit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset.
+        /// </summary>
+        public int? Offset { get; set; }
 
         /// <summary>
         /// Gets or sets the attributes to retrieve.

--- a/src/Meilisearch/QueryParamaters/IndexesQuery.cs
+++ b/src/Meilisearch/QueryParamaters/IndexesQuery.cs
@@ -1,0 +1,18 @@
+namespace Meilisearch.QueryParameters
+{
+    /// <summary>
+    /// Indexes Query for Meilisearch class.
+    /// </summary>
+    public class IndexesQuery
+    {
+        /// <summary>
+        /// Gets or sets the limit.
+        /// </summary>
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset.
+        /// </summary>
+        public int? Offset { get; set; }
+    }
+}

--- a/src/Meilisearch/QueryParamaters/IndexesQuery.cs
+++ b/src/Meilisearch/QueryParamaters/IndexesQuery.cs
@@ -1,7 +1,7 @@
 namespace Meilisearch.QueryParameters
 {
     /// <summary>
-    /// Indexes Query for Meilisearch class.
+    /// A class that handles the creation of a query string for Indexes.
     /// </summary>
     public class IndexesQuery
     {

--- a/src/Meilisearch/QueryParamaters/KeysQuery.cs
+++ b/src/Meilisearch/QueryParamaters/KeysQuery.cs
@@ -1,7 +1,7 @@
 namespace Meilisearch.QueryParameters
 {
     /// <summary>
-    /// Keys Query for Meilisearch class.
+    /// A class that handles the creation of a query string for Keys.
     /// </summary>
     public class KeysQuery
     {

--- a/src/Meilisearch/QueryParamaters/KeysQuery.cs
+++ b/src/Meilisearch/QueryParamaters/KeysQuery.cs
@@ -1,0 +1,18 @@
+namespace Meilisearch.QueryParameters
+{
+    /// <summary>
+    /// Keys Query for Meilisearch class.
+    /// </summary>
+    public class KeysQuery
+    {
+        /// <summary>
+        /// Gets or sets the limit.
+        /// </summary>
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset.
+        /// </summary>
+        public int? Offset { get; set; }
+    }
+}

--- a/src/Meilisearch/QueryParamaters/TasksQuery.cs
+++ b/src/Meilisearch/QueryParamaters/TasksQuery.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Meilisearch.QueryParameters
+{
+    /// <summary>
+    /// Tasks Query for Meilisearch class.
+    /// </summary>
+    public class TasksQuery
+    {
+        /// <summary>
+        /// Gets or sets the limit.
+        /// </summary>
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// Gets or sets offset size.
+        /// </summary>
+        public int? From { get; set; }
+
+        /// <summary>
+        /// Gets or sets offset size.
+        /// </summary>
+        public List<string> IndexUid { get; set; }
+
+        /// <summary>
+        /// Gets or sets offset size.
+        /// </summary>
+        public List<string> Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets offset size.
+        /// </summary>
+        public List<string> Types { get; set; }
+    }
+}

--- a/src/Meilisearch/QueryParamaters/TasksQuery.cs
+++ b/src/Meilisearch/QueryParamaters/TasksQuery.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Meilisearch.QueryParameters
 {
     /// <summary>
-    /// Tasks Query for Meilisearch class.
+    /// A class that handles the creation of a query string for Tasks.
     /// </summary>
     public class TasksQuery
     {

--- a/src/Meilisearch/TaskEndpoint.cs
+++ b/src/Meilisearch/TaskEndpoint.cs
@@ -21,7 +21,7 @@ namespace Meilisearch
         /// <summary>
         /// Gets the tasks.
         /// </summary>
-        /// <param name="query">Query parameters. Supports limit, from, indexUid, status and types.</param>
+        /// <param name="query">Query parameters supports by the method.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the tasks.</returns>
         public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(TasksQuery query = default, CancellationToken cancellationToken = default)

--- a/src/Meilisearch/TaskEndpoint.cs
+++ b/src/Meilisearch/TaskEndpoint.cs
@@ -4,6 +4,10 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Meilisearch.Extensions;
+using Meilisearch.QueryParameters;
+
 namespace Meilisearch
 {
 
@@ -17,11 +21,17 @@ namespace Meilisearch
         /// <summary>
         /// Gets the tasks.
         /// </summary>
+        /// <param name="query">Query parameters. Supports limit, from, indexUid, status and types.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the tasks.</returns>
-        public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(TasksQuery query = default, CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskResource>>>("tasks", cancellationToken: cancellationToken)
+            var uri = $"tasks";
+            if (query != null)
+            {
+                uri = $"{uri}?{query.ToQueryStringWithList()}";
+            }
+            return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskResource>>>(uri, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Meilisearch/TaskEndpoint.cs
+++ b/src/Meilisearch/TaskEndpoint.cs
@@ -29,7 +29,7 @@ namespace Meilisearch
             var uri = $"tasks";
             if (query != null)
             {
-                uri = $"{uri}?{query.ToQueryStringWithList()}";
+                uri = $"{uri}?{query.ToQueryString()}";
             }
             return await _http.GetFromJsonAsync<TasksResults<IEnumerable<TaskResource>>>(uri, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
+using Meilisearch.QueryParameters;
+
 using Xunit;
 
 namespace Meilisearch.Tests
@@ -545,7 +547,7 @@ namespace Meilisearch.Tests
         public async Task GetMultipleExistingDocumentsWithLimit()
         {
             var index = await _fixture.SetUpBasicIndex("GetMultipleExistingDocumentWithLimitTest");
-            var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery() { Limit = 2 });
+            var documents = await index.GetDocumentsAsync<Movie>(new DocumentsQuery() { Limit = 2 });
             Assert.Equal(2, documents.Results.Count());
             documents.Results.First().Id.Should().Be("10");
             documents.Results.Last().Id.Should().Be("11");
@@ -555,7 +557,7 @@ namespace Meilisearch.Tests
         public async Task GetMultipleExistingDocumentsWithField()
         {
             var index = await _fixture.SetUpBasicIndex("GetMultipleExistingDocumentWithLimitTest");
-            var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery() { Limit = 2, Fields = new List<string> { "id" } });
+            var documents = await index.GetDocumentsAsync<Movie>(new DocumentsQuery() { Limit = 2, Fields = new List<string> { "id" } });
             Assert.Equal(2, documents.Results.Count());
             documents.Results.First().Id.Should().Be("10");
             documents.Results.First().Name.Should().BeNull();
@@ -566,7 +568,7 @@ namespace Meilisearch.Tests
         public async Task GetMultipleExistingDocumentsWithMultipleFields()
         {
             var index = await _fixture.SetUpBasicIndex("GetMultipleExistingDocumentWithLimitTest");
-            var documents = await index.GetDocumentsAsync<Movie>(new DocumentQuery() { Limit = 2, Fields = new List<string> { "id", "name" } });
+            var documents = await index.GetDocumentsAsync<Movie>(new DocumentsQuery() { Limit = 2, Fields = new List<string> { "id", "name" } });
             Assert.Equal(2, documents.Results.Count());
             documents.Results.First().Id.Should().Be("10");
             documents.Results.First().Name.Should().Be("Gladiator");

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 using FluentAssertions;
+
+using Meilisearch.QueryParameters;
 
 using Xunit;
 
@@ -142,13 +143,42 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
-        public async Task GetAllExistingIndexes()
+        public async Task GetMultipleExistingIndexes()
         {
-            var indexUid = "GetAllExistingIndexesTest";
-            var index = await _fixture.SetUpEmptyIndex(indexUid, _defaultPrimaryKey);
+            var indexUid1 = "GetMultipleExistingIndexesTest1";
+            var indexUid2 = "GetMultipleExistingIndexesTest2";
+            await _fixture.SetUpEmptyIndex(indexUid1, _defaultPrimaryKey);
+            await _fixture.SetUpEmptyIndex(indexUid2, _defaultPrimaryKey);
 
             var indexes = await _client.GetAllIndexesAsync();
+            indexes.Results.Count().Should().BeGreaterOrEqualTo(2);
+        }
+
+        [Fact]
+        public async Task GetMultipleExistingIndexesWithLimit()
+        {
+            var indexUid1 = "GetMultipleExistingIndexesWithLimit1";
+            var indexUid2 = "GetMultipleExistingIndexesWithLimit2";
+            await _fixture.SetUpEmptyIndex(indexUid1, _defaultPrimaryKey);
+            await _fixture.SetUpEmptyIndex(indexUid2, _defaultPrimaryKey);
+
+            var indexes = await _client.GetAllIndexesAsync(new IndexesQuery() { Limit = 1 });
             indexes.Results.Count().Should().BeGreaterOrEqualTo(1);
+            indexes.Limit.Should().BeGreaterOrEqualTo(1);
+            Assert.Equal(1, indexes.Limit);
+        }
+
+        [Fact]
+        public async Task GetMultipleExistingIndexesWithOffset()
+        {
+            var indexUid1 = "GetMultipleExistingIndexesWithOffset1";
+            var indexUid2 = "GetMultipleExistingIndexesWithOffset2";
+            await _fixture.SetUpEmptyIndex(indexUid1, _defaultPrimaryKey);
+            await _fixture.SetUpEmptyIndex(indexUid2, _defaultPrimaryKey);
+
+            var indexes = await _client.GetAllIndexesAsync(new IndexesQuery() { Offset = 1 });
+            indexes.Results.Count().Should().BeGreaterOrEqualTo(1);
+            Assert.Equal(1, indexes.Offset);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
+using Meilisearch.QueryParameters;
+
 using Xunit;
 
 namespace Meilisearch.Tests
@@ -27,12 +29,30 @@ namespace Meilisearch.Tests
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
-        public async Task GetAllKeys()
+        public async Task GetMultipleKeys()
         {
             var keyResponse = await _client.GetKeysAsync();
             var keys = keyResponse.Results;
 
             keys.Count().Should().BeGreaterOrEqualTo(2);
+        }
+
+        [Fact]
+        public async Task GetMultipleKeysWithLimit()
+        {
+            var keys = await _client.GetKeysAsync(new KeysQuery { Limit = 1 });
+
+            keys.Results.Count().Should().BeGreaterOrEqualTo(1);
+            Assert.Equal(1, keys.Limit);
+        }
+
+        [Fact]
+        public async Task GetMultipleKeysWithOffset()
+        {
+            var keys = await _client.GetKeysAsync(new KeysQuery { Offset = 1 });
+
+            keys.Results.Count().Should().BeGreaterOrEqualTo(1);
+            Assert.Equal(1, keys.Offset);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
+++ b/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 
 using Meilisearch.Extensions;
+using Meilisearch.QueryParameters;
 
 using Microsoft.AspNetCore.WebUtilities;
 
@@ -35,11 +37,47 @@ namespace Meilisearch.Tests
         public void QueryStringsAreEqualsForDocumentQuery(int? offset, int? limit, string fields)
         {
             var uri = "indexes/myindex/documents";
-            var dq = new DocumentQuery { Offset = offset, Limit = limit, Fields = new List<string> { fields } };
+            var dq = new DocumentsQuery { Offset = offset, Limit = limit, Fields = new List<string> { fields } };
 
             var expected = QueryHelpers.AddQueryString(uri, dq.AsDictionary());
             var actual = $"{uri}?{dq.ToQueryString()}";
             Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData(1, null, null)]
+        [InlineData(null, 3, null)]
+        [InlineData(null, null, new string[] { "attr" })]
+        [InlineData(null, null, new string[] { "attr", "attr2", "attr3" })]
+        [InlineData(1, 2, null)]
+        [InlineData(1, null, new string[] { "attr" })]
+        [InlineData(null, 2, new string[] { "attr" })]
+        [InlineData(1, 2, new string[] { "attr" })]
+        [InlineData(1, 2, new string[] { "attr", "attr2", "attr3" })]
+        public void QueryStringsWithListAreEqualsForDocumentsQuery(int? offset, int? limit, string[] fields)
+        {
+            var uri = "indexes/myindex/documents";
+            var dq = new DocumentsQuery { Offset = offset, Limit = limit, Fields = fields != null ? new List<string>(fields) : null };
+            var actualQuery = $"{uri}?{dq.ToQueryStringWithList()}";
+
+            Assert.NotEmpty(actualQuery);
+            Assert.NotNull(actualQuery);
+            if (limit != null)
+            {
+                Assert.Contains("limit", actualQuery);
+                Assert.Contains(dq.Limit.ToString(), actualQuery);
+            }
+            if (offset != null)
+            {
+                Assert.Contains("offset", actualQuery);
+                Assert.Contains(dq.Offset.ToString(), actualQuery);
+            }
+            if (fields != null)
+            {
+                Assert.Contains("fields", actualQuery);
+                Assert.Contains(String.Join(",", dq.Fields), actualQuery);
+            }
         }
     }
 }

--- a/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
+++ b/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
@@ -29,25 +29,6 @@ namespace Meilisearch.Tests
         [InlineData(null, null, null)]
         [InlineData(1, null, null)]
         [InlineData(null, 3, null)]
-        [InlineData(null, null, "attr")]
-        [InlineData(1, 2, null)]
-        [InlineData(1, null, "attr")]
-        [InlineData(null, 2, "attr")]
-        [InlineData(1, 2, "attr")]
-        public void QueryStringsAreEqualsForDocumentQuery(int? offset, int? limit, string fields)
-        {
-            var uri = "indexes/myindex/documents";
-            var dq = new DocumentsQuery { Offset = offset, Limit = limit, Fields = new List<string> { fields } };
-
-            var expected = QueryHelpers.AddQueryString(uri, dq.AsDictionary());
-            var actual = $"{uri}?{dq.ToQueryString()}";
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData(null, null, null)]
-        [InlineData(1, null, null)]
-        [InlineData(null, 3, null)]
         [InlineData(null, null, new string[] { "attr" })]
         [InlineData(null, null, new string[] { "attr", "attr2", "attr3" })]
         [InlineData(1, 2, null)]
@@ -59,7 +40,7 @@ namespace Meilisearch.Tests
         {
             var uri = "indexes/myindex/documents";
             var dq = new DocumentsQuery { Offset = offset, Limit = limit, Fields = fields != null ? new List<string>(fields) : null };
-            var actualQuery = $"{uri}?{dq.ToQueryStringWithList()}";
+            var actualQuery = $"{uri}?{dq.ToQueryString()}";
 
             Assert.NotEmpty(actualQuery);
             Assert.NotNull(actualQuery);

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -64,8 +64,8 @@ namespace Meilisearch.Tests
         {
             await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
             var taskResponse = await _index.GetTasksAsync(new TasksQuery { Limit = 1, IndexUid = new List<string> { _index.Uid } });
-            var tasks = taskResponse.Results;
-            tasks.Count().Should().BeGreaterOrEqualTo(1);
+
+            taskResponse.Results.Count().Should().BeGreaterOrEqualTo(1);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -53,9 +53,9 @@ namespace Meilisearch.Tests
         public async Task GetMultipleTaskInfoWithLimitFromClient()
         {
             await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
-            var taskResponse = await _client.GetTasksAsync(new TasksQuery { Limit = 1 });
+            var tasks = await _client.GetTasksAsync(new TasksQuery { Limit = 1 });
 
-            taskResponse.Results.Count().Should().BeGreaterOrEqualTo(1);
+            tasks.Results.Count().Should().BeGreaterOrEqualTo(1);
             Assert.Equal(1, tasks.Limit);
         }
 

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 using FluentAssertions;
+
+using Meilisearch.QueryParameters;
 
 using Xunit;
 
@@ -9,12 +13,14 @@ namespace Meilisearch.Tests
 {
     public abstract class TaskInfoTests<TFixture> : IAsyncLifetime where TFixture : IndexFixture
     {
+        private readonly MeilisearchClient _client;
         private Index _index;
         private readonly TFixture _fixture;
 
         public TaskInfoTests(TFixture fixture)
         {
             _fixture = fixture;
+            _client = fixture.DefaultClient;
         }
 
         public async Task InitializeAsync()
@@ -26,10 +32,38 @@ namespace Meilisearch.Tests
         public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
-        public async Task GetAllTaskInfo()
+        public async Task GetMultipleTaskInfoFromClient()
+        {
+            await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
+            var taskResponse = await _client.GetTasksAsync();
+            var tasks = taskResponse.Results;
+            tasks.Count().Should().BeGreaterOrEqualTo(1);
+        }
+
+        [Fact]
+        public async Task GetMultipleTaskInfoFromIndex()
         {
             await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
             var taskResponse = await _index.GetTasksAsync();
+            var tasks = taskResponse.Results;
+            tasks.Count().Should().BeGreaterOrEqualTo(1);
+        }
+
+        [Fact]
+        public async Task GetMultipleTaskInfoWithLimitFromClient()
+        {
+            await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
+            var taskResponse = await _client.GetTasksAsync(new TasksQuery { Limit = 1 });
+            var tasks = taskResponse;
+            tasks.Results.Count().Should().BeGreaterOrEqualTo(1);
+            Assert.Equal(1, tasks.Limit);
+        }
+
+        [Fact]
+        public async Task GetMultipleTaskInfoWithQueryParameters()
+        {
+            await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
+            var taskResponse = await _index.GetTasksAsync(new TasksQuery { Limit = 1, IndexUid = new List<string> { _index.Uid } });
             var tasks = taskResponse.Results;
             tasks.Count().Should().BeGreaterOrEqualTo(1);
         }

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -54,8 +54,8 @@ namespace Meilisearch.Tests
         {
             await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
             var taskResponse = await _client.GetTasksAsync(new TasksQuery { Limit = 1 });
-            var tasks = taskResponse;
-            tasks.Results.Count().Should().BeGreaterOrEqualTo(1);
+
+            taskResponse.Results.Count().Should().BeGreaterOrEqualTo(1);
             Assert.Equal(1, tasks.Limit);
         }
 


### PR DESCRIPTION
Add pagination filter to all these routes and methods:
- GET /tasks has pagination metadata, `type`, `status`, and `indexUid` in `AsyncGetTaks()`
- GET /keys has pagination metadata, added limit (default: 20), offset (default: 0), total in `AsyncGetKeys()`
- GET /indexes has pagination metadata, added limit (default: 20), offset (default: 0), total in `AsyncGetIndexes()`
- GET /documents has pagination metadata, added limit (default: 20), offset (default: 0), total in `AsyncGetDocuments()`