### PR TITLE
Update version for the next release (v0.11.0)

### DIFF
--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>MeiliSearch</PackageId>
-        <Version>0.10.2</Version>
+        <Version>0.11.0</Version>
         <Description>.NET wrapper for Meilisearch, an open-source search engine</Description>
         <RepositoryUrl>https://github.com/meilisearch/meilisearch-dotnet</RepositoryUrl>
         <PackageTags>meilisearch;dotnet;sdk;search-engine;search;instant-search</PackageTags>


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.28.0 :tada:
Check out the changelog of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) for more information on the changes.

## 💥  Breaking Changes

- `MeilisearchClient#GetKeysAsync` now returns a `ResourceResults<Key>`. (#291) @alallema
- `MeilisearchClient#GetAllIndexesAsync` now returns a `ResourceResults<Index>` (#289) @alallema
- `MeilisearchClient#GetAllRawIndexesAsync` now returns a json object. (#289) @alallema
- `MeilisearchClient#CreateDumpAsync` now responds with a `TaskInfo` object. (#292) @alallema
- `MeilisearchClient#GetDumpStatusAsync` was removed. Use the `MeilisearchClient#GetTasksAsync` or `MeilisearchClient#GetTaskAsync` instead. (#288) @alallema
- `DumpStatus` type was removed (#292) @alallema.
- `SearchQuery` changes (#282) @curqui
  - Renamed `FacetsDistribution` field to `Facets`.
  - Renamed `Matches` field to `ShowMatchesPosition`.
- `SearchResult` changes (#282) @curqui
  - Renamed `NbHits` field to `EstimatedTotalHits`.
  - Removed `ExhaustiveFacetsCount` field.
  - Removed `ExhaustiveNbHits` field.
- `Index#GetDocumentsAsync<T>` now returns an object `ResourceResults<IEnumerable<T>>` (#290) @alallema
- `MeilisearchClient#GetTasksAsync` and `Index#GetTasksAsync` now returns an object `TasksResults<IEnumerable<TaskResource>>` (#290) @alallema
- `AddDocumentsAsync<T>`, `CreateDumpAsync`, `UpdateSettingsAsync` and other methods that "creates" a new task, now responds with a `TaskInfo` and therefore they have a `TaskUid` instead of `Uid` (#288), (#341) @alallema
- `MeilisearchClient#GenerateTenantToken` now requires a `api key uid` to generate tenant tokens as the first positional attribute. (#298) @alallema

## 🐛 Enhancements

- Add support to `PATCH` requests (#286), (#293) @alallema
- Add `MeilisearchClient#UpdateKeyAsync` method to update keys (#304) @brunoocasali

- `MeilisearchClient#GetAllIndexesAsync` now accepts an object with pagination `IndexesQuery`. (#289) @alallema
- `MeilisearchClient#GetDocumentsAsync<T>` now accepts an object with pagination `DocumentsQuery`. (#290) @alallema
- `MeilisearchClient#GetDocumentAsync<T>` now accepts a param called `fields` which takes an array of strings to remap the response. (#290) @alallema
- `MeilisearchClient#CreateKeyAsync` and `MeilisearchClient#DeleteKeyAsync` accepts both `api key` or `api key uid`. (#291) @alallema
- `MeilisearchClient#CreateKeyAsync` can optionally specify a `uid:` to generate deterministic API keys. (#291) @alallema

Thanks again to @alallema and @brunoocasali! 🎉
