### PR TITLE
Make Meilisearch's objects readonly and make sure json mapping works …

### DIFF
--- a/src/Meilisearch/Errors/MeilisearchApiErrorContent.cs
+++ b/src/Meilisearch/Errors/MeilisearchApiErrorContent.cs
@@ -7,28 +7,36 @@ namespace Meilisearch
     /// </summary>
     public class MeilisearchApiErrorContent
     {
+        public MeilisearchApiErrorContent(string message, string code, string type, string link)
+        {
+            Message = message;
+            Code = code;
+            Type = type;
+            Link = link;
+        }
+
         /// <summary>
         /// Gets or sets the message.
         /// </summary>
         [JsonPropertyName("message")]
-        public string Message { get; set; }
+        public string Message { get; }
 
         /// <summary>
         /// Gets or sets the code.
         /// </summary>
         [JsonPropertyName("code")]
-        public string Code { get; set; }
+        public string Code { get; }
 
         /// <summary>
         /// Gets or sets the type.
         /// </summary>
         [JsonPropertyName("type")]
-        public string Type { get; set; }
+        public string Type { get; }
 
         /// <summary>
         /// Gets or sets the link.
         /// </summary>
         [JsonPropertyName("link")]
-        public string Link { get; set; }
+        public string Link { get; }
     }
 }

--- a/src/Meilisearch/IndexStats.cs
+++ b/src/Meilisearch/IndexStats.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Meilisearch
 {
@@ -7,19 +8,29 @@ namespace Meilisearch
     /// </summary>
     public class IndexStats
     {
+        public IndexStats(int numberOfDocuments, bool isIndexing, IReadOnlyDictionary<string, int> fieldDistribution)
+        {
+            NumberOfDocuments = numberOfDocuments;
+            IsIndexing = isIndexing;
+            FieldDistribution = fieldDistribution;
+        }
+
         /// <summary>
         /// Gets or sets the total number of documents.
         /// </summary>
-        public int NumberOfDocuments { get; set; }
+        [JsonPropertyName("numberOfDocuments")]
+        public int NumberOfDocuments { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the index is currently indexing.
         /// </summary>
-        public bool IsIndexing { get; set; }
+        [JsonPropertyName("isIndexing")]
+        public bool IsIndexing { get; }
 
         /// <summary>
         /// Gets or sets field distribution.
         /// </summary>
-        public IDictionary<string, int> FieldDistribution { get; set; }
+        [JsonPropertyName("fieldDistribution")]
+        public IReadOnlyDictionary<string, int> FieldDistribution { get; }
     }
 }

--- a/src/Meilisearch/Key.cs
+++ b/src/Meilisearch/Key.cs
@@ -19,43 +19,51 @@ namespace Meilisearch
         /// Gets or sets unique identifier of the API key.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("uid")]
         public string Uid { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the API key.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the API key.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
 
         /// <summary>
         /// Gets or sets list of actions available for the API key.
         /// </summary>
+        [JsonPropertyName("actions")]
         public IEnumerable<string> Actions { get; set; }
 
         /// <summary>
         /// Gets or sets the list of indexes the API key can access.
         /// </summary>
+        [JsonPropertyName("indexes")]
         public IEnumerable<string> Indexes { get; set; }
 
         /// <summary>
         /// Gets or sets the date when the API key expires.
         /// </summary>
+        [JsonPropertyName("expiresAt")]
         public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
         /// Gets or sets the date when the API key was created.
         /// </summary>
+        [JsonPropertyName("createdAt")]
         public DateTime? CreatedAt { get; set; }
 
         /// <summary>
         /// Gets or sets the date when the API key was updated.
         /// </summary>
+        [JsonPropertyName("updatedAt")]
         public DateTime? UpdatedAt { get; set; }
     }
 }

--- a/src/Meilisearch/ResourceResults.cs
+++ b/src/Meilisearch/ResourceResults.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Meilisearch
@@ -11,7 +10,7 @@ namespace Meilisearch
     public class ResourceResults<T> : Result<T>
     {
         public ResourceResults(T results, int? limit, int offset, int total)
-            :base(results, limit)
+            : base(results, limit)
         {
             Offset = offset;
             Total = total;

--- a/src/Meilisearch/ResourceResults.cs
+++ b/src/Meilisearch/ResourceResults.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Meilisearch
 {
@@ -9,14 +10,23 @@ namespace Meilisearch
     /// <typeparam name="T">Type of the Meilisearch server object. Ex: keys, indexes, ...</typeparam>
     public class ResourceResults<T> : Result<T>
     {
+        public ResourceResults(T results, int? limit, int offset, int total)
+            :base(results, limit)
+        {
+            Offset = offset;
+            Total = total;
+        }
+
         /// <summary>
         /// Gets or sets offset size.
         /// </summary>
-        public int Offset { get; set; }
+        [JsonPropertyName("offset")]
+        public int Offset { get; }
 
         /// <summary>
         /// Gets or sets total size.
         /// </summary>
-        public int Total { get; set; }
+        [JsonPropertyName("total")]
+        public int Total { get; }
     }
 }

--- a/src/Meilisearch/Result.cs
+++ b/src/Meilisearch/Result.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Meilisearch
 {
     /// <summary>
@@ -7,14 +9,22 @@ namespace Meilisearch
     /// <typeparam name="T">Type of the Meilisearch server object. Ex: keys, tasks, ...</typeparam>
     public class Result<T>
     {
+        public Result(T results, int? limit)
+        {
+            Results = results;
+            Limit = limit;
+        }
+
         /// <summary>
         /// Gets or sets the "results" field.
         /// </summary>
-        public T Results { get; set; }
+        [JsonPropertyName("results")]
+        public T Results { get; }
 
         /// <summary>
         /// Gets or sets limit size.
         /// </summary>
-        public int? Limit { get; set; }
+        [JsonPropertyName("limit")]
+        public int? Limit { get; }
     }
 }

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -27,35 +27,42 @@ namespace Meilisearch
         /// <summary>
         /// Results of the query.
         /// </summary>
+        [JsonPropertyName("hits")]
         public IReadOnlyCollection<T> Hits { get; }
 
         /// <summary>
         /// Number of documents skipped.
         /// </summary>
+        [JsonPropertyName("offset")]
         public int Offset { get; }
 
         /// <summary>
         /// Number of documents to take.
         /// </summary>
+        [JsonPropertyName("limit")]
         public int Limit { get; }
 
         /// <summary>
         /// Gets the estimated total number of hits returned by the search.
         /// </summary>
+        [JsonPropertyName("estimatedTotalHits")]
         public int EstimatedTotalHits { get; }
 
         /// <summary>
         /// Returns the number of documents matching the current search query for each given facet.
         /// </summary>
+        [JsonPropertyName("facetDistribution")]
         public IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> FacetDistribution { get; }
 
         /// <summary>
         /// Processing time of the query.
         /// </summary>
+        [JsonPropertyName("processingTimeMs")]
         public int ProcessingTimeMs { get; }
 
         /// Query originating the response.
         /// </summary>
+        [JsonPropertyName("query")]
         public string Query { get; }
 
         /// <summary>
@@ -77,12 +84,14 @@ namespace Meilisearch
         /// The beginning of a matching term within a field.
         /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
         /// </summary>
+        [JsonPropertyName("start")]
         public int Start { get; }
 
         /// <summary>
         /// The length of a matching term within a field.
         /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
         /// </summary>
+        [JsonPropertyName("length")]
         public int Length { get; }
     }
 }

--- a/src/Meilisearch/Stats.cs
+++ b/src/Meilisearch/Stats.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Meilisearch
 {
@@ -8,19 +9,29 @@ namespace Meilisearch
     /// </summary>
     public class Stats
     {
+        public Stats(int databaseSize, DateTime? lastUpdate, IReadOnlyDictionary<string, IndexStats> indexes)
+        {
+            DatabaseSize = databaseSize;
+            LastUpdate = lastUpdate;
+            Indexes = indexes;
+        }
+
         /// <summary>
         /// Gets or sets database size.
         /// </summary>
-        public int DatabaseSize { get; set; }
+        [JsonPropertyName("databaseSize")]
+        public int DatabaseSize { get; }
 
         /// <summary>
         /// Gets or sets last update timestamp.
         /// </summary>
-        public DateTime? LastUpdate { get; set; }
+        [JsonPropertyName("lastUpdate")]
+        public DateTime? LastUpdate { get; }
 
         /// <summary>
         /// Gets or sets index stats.
         /// </summary>
-        public IDictionary<string, IndexStats> Indexes { get; set; }
+        [JsonPropertyName("indexes")]
+        public IReadOnlyDictionary<string, IndexStats> Indexes { get; }
     }
 }

--- a/src/Meilisearch/TaskInfo.cs
+++ b/src/Meilisearch/TaskInfo.cs
@@ -10,7 +10,7 @@ namespace Meilisearch
     public class TaskInfo
     {
         public TaskInfo(int taskUid, string indexUid, TaskInfoStatus status, TaskInfoType type,
-            Dictionary<string, object> details, Dictionary<string, string> error, string duration, DateTime enqueuedAt,
+            IReadOnlyDictionary<string, object> details, IReadOnlyDictionary<string, string> error, string duration, DateTime enqueuedAt,
             DateTime? startedAt, DateTime? finishedAt)
         {
             TaskUid = taskUid;
@@ -28,51 +28,61 @@ namespace Meilisearch
         /// <summary>
         /// The unique sequential identifier of the task.
         /// </summary>
+        [JsonPropertyName("taskUid")]
         public int TaskUid { get; }
 
         /// <summary>
         /// The unique index identifier.
         /// </summary>
+        [JsonPropertyName("indexUid")]
         public string IndexUid { get; }
 
         /// <summary>
         /// The status of the task. Possible values are enqueued, processing, succeeded, failed.
         /// </summary>
+        [JsonPropertyName("status")]
         public TaskInfoStatus Status { get; }
 
         /// <summary>
         /// The type of task.
         /// </summary>
+        [JsonPropertyName("type")]
         public TaskInfoType Type { get; }
 
         /// <summary>
         /// Detailed information on the task payload.
         /// </summary>
-        public Dictionary<string, object> Details { get; }
+        [JsonPropertyName("details")]
+        public IReadOnlyDictionary<string, object> Details { get; }
 
         /// <summary>
         /// Error details and context. Only present when a task has the failed status.
         /// </summary>
-        public Dictionary<string, string> Error { get; }
+        [JsonPropertyName("error")]
+        public IReadOnlyDictionary<string, string> Error { get; }
 
         /// <summary>
         /// The total elapsed time the task spent in the processing state, in ISO 8601 format.
         /// </summary>
+        [JsonPropertyName("duration")]
         public string Duration { get; }
 
         /// <summary>
         /// The date and time when the task was first enqueued, in RFC 3339 format.
         /// </summary>
+        [JsonPropertyName("enqueuedAt")]
         public DateTime EnqueuedAt { get; }
 
         /// <summary>
         /// The date and time when the task began processing, in RFC 3339 format.
         /// </summary>
+        [JsonPropertyName("startedAt")]
         public DateTime? StartedAt { get; }
 
         /// <summary>
         /// The date and time when the task finished processing, whether failed or succeeded, in RFC 3339 format.
         /// </summary>
+        [JsonPropertyName("finishedAt")]
         public DateTime? FinishedAt { get; }
     }
 

--- a/src/Meilisearch/TaskResource.cs
+++ b/src/Meilisearch/TaskResource.cs
@@ -10,7 +10,7 @@ namespace Meilisearch
     public class TaskResource
     {
         public TaskResource(int uid, string indexUid, TaskInfoStatus status, TaskInfoType type,
-            Dictionary<string, object> details, Dictionary<string, string> error, string duration, DateTime enqueuedAt,
+            IReadOnlyDictionary<string, object> details, IReadOnlyDictionary<string, string> error, string duration, DateTime enqueuedAt,
             DateTime? startedAt, DateTime? finishedAt)
         {
             Uid = uid;
@@ -28,51 +28,61 @@ namespace Meilisearch
         /// <summary>
         /// The unique sequential identifier of the task.
         /// </summary>
+        [JsonPropertyName("uid")]
         public int Uid { get; }
 
         /// <summary>
         /// The unique index identifier.
         /// </summary>
+        [JsonPropertyName("indexUid")]
         public string IndexUid { get; }
 
         /// <summary>
         /// The status of the task. Possible values are enqueued, processing, succeeded, failed.
         /// </summary>
+        [JsonPropertyName("status")]
         public TaskInfoStatus Status { get; }
 
         /// <summary>
         /// The type of task.
         /// </summary>
+        [JsonPropertyName("type")]
         public TaskInfoType Type { get; }
 
         /// <summary>
         /// Detailed information on the task payload.
         /// </summary>
-        public Dictionary<string, dynamic> Details { get; }
+        [JsonPropertyName("details")]
+        public IReadOnlyDictionary<string, dynamic> Details { get; }
 
         /// <summary>
         /// Error details and context. Only present when a task has the failed status.
         /// </summary>
-        public Dictionary<string, string> Error { get; }
+        [JsonPropertyName("error")]
+        public IReadOnlyDictionary<string, string> Error { get; }
 
         /// <summary>
         /// The total elapsed time the task spent in the processing state, in ISO 8601 format.
         /// </summary>
+        [JsonPropertyName("duration")]
         public string Duration { get; }
 
         /// <summary>
         /// The date and time when the task was first enqueued, in RFC 3339 format.
         /// </summary>
+        [JsonPropertyName("enqueuedAt")]
         public DateTime EnqueuedAt { get; }
 
         /// <summary>
         /// The date and time when the task began processing, in RFC 3339 format.
         /// </summary>
+        [JsonPropertyName("startedAt")]
         public DateTime? StartedAt { get; }
 
         /// <summary>
         /// The date and time when the task finished processing, whether failed or succeeded, in RFC 3339 format.
         /// </summary>
+        [JsonPropertyName("finishedAt")]
         public DateTime? FinishedAt { get; }
     }
 }

--- a/src/Meilisearch/TasksResults.cs
+++ b/src/Meilisearch/TasksResults.cs
@@ -9,14 +9,21 @@ namespace Meilisearch
     /// <typeparam name="T">Type of the Meilisearch server object. Ex: keys, indexes, ...</typeparam>
     public class TasksResults<T> : Result<T>
     {
+        public TasksResults(T results, int? limit, int? from, int? next)
+            :base(results, limit)
+        {
+            From = from;
+            Next = next;
+        }
+
         /// <summary>
         /// Gets or sets from size.
         /// </summary>
-        public int? From { get; set; }
+        public int? From { get; }
 
         /// <summary>
         /// Gets or sets next size.
         /// </summary>
-        public int? Next { get; set; }
+        public int? Next { get; }
     }
 }

--- a/src/Meilisearch/TasksResults.cs
+++ b/src/Meilisearch/TasksResults.cs
@@ -10,7 +10,7 @@ namespace Meilisearch
     public class TasksResults<T> : Result<T>
     {
         public TasksResults(T results, int? limit, int? from, int? next)
-            :base(results, limit)
+            : base(results, limit)
         {
             From = from;
             Next = next;


### PR DESCRIPTION
…regardless of JsonSerializerOptions

# Pull Request

## What does this PR do?
This PR makes sure that the server's response are well mapped to Meilisearch's objects.
Make this objects read only where it makes sense.

This is a first step for #311 

