### PR TITLE
Add tests to custom search with `matchingStrategy` param

### DIFF
--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -91,5 +91,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("sort")]
         public IEnumerable<string> Sort { get; set; }
+
+        /// <summary>
+        /// Gets or sets the words matching strategy.
+        /// </summary>
+        [JsonPropertyName("matchingStrategy")]
+        public string MatchingStrategy { get; set; }
     }
 }

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -273,13 +273,10 @@ namespace Meilisearch.Tests
 
             // Check the documents have been updated and added
             var docs = await index.GetDocumentsAsync<Movie>();
-            Assert.Equal("1", docs.Results.First().Id);
-            Assert.Equal("Ironman", docs.Results.First().Name);
-            Assert.Null(docs.Results.First().Genre);
+            var movieNames = docs.Results.Select(movie => movie.Name);
 
-            Assert.Equal("2", docs.Results.ElementAt(1).Id);
-            Assert.Equal("Superman", docs.Results.ElementAt(1).Name);
-            docs.Results.ElementAt(1).Genre.Should().BeNull();
+            Assert.Contains("Ironman", movieNames);
+            Assert.Contains("Superman", movieNames);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -396,5 +396,23 @@ namespace Meilisearch.Tests
             Assert.Equal("11", movies.Hits.First().Id);
             Assert.Equal(1000, movies.Hits.First().Info.ReviewNb);
         }
+
+        [Fact]
+        public async Task CustomSearchWithMatchingStrategyALL()
+        {
+            SearchQuery searchQuery = new SearchQuery() { MatchingStrategy = "all" };
+            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("movie about rich", searchQuery);
+
+            movies.Hits.Should().ContainSingle();
+        }
+
+        [Fact]
+        public async Task CustomSearchWithMatchingStrategyLast()
+        {
+            SearchQuery searchQuery = new SearchQuery() { MatchingStrategy = "last" };
+            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("movie about rich", searchQuery);
+
+            Assert.True(movies.Hits.Count() > 1);
+        }
     }
 }


### PR DESCRIPTION
Ensure the support of `matchingStrategy` query parameter.