### PR TITLE
Add tests to wildcarded action keys

### DIFF
--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -273,13 +273,10 @@ namespace Meilisearch.Tests
 
             // Check the documents have been updated and added
             var docs = await index.GetDocumentsAsync<Movie>();
-            Assert.Equal("1", docs.Results.First().Id);
-            Assert.Equal("Ironman", docs.Results.First().Name);
-            Assert.Null(docs.Results.First().Genre);
+            var movieNames = docs.Results.Select(movie => movie.Name);
 
-            Assert.Equal("2", docs.Results.ElementAt(1).Id);
-            Assert.Equal("Superman", docs.Results.ElementAt(1).Name);
-            docs.Results.ElementAt(1).Genre.Should().BeNull();
+            Assert.Contains("Ironman", movieNames);
+            Assert.Contains("Superman", movieNames);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -167,6 +167,22 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task CreateOneKeyWithWildcardedAction()
+        {
+            var keyOptions = new Key
+            {
+                Actions = new string[] { "documents.*" },
+                Indexes = new string[] { "*" },
+                ExpiresAt = null,
+            };
+            var createdKey = await _client.CreateKeyAsync(keyOptions);
+            var createdKeyUid = createdKey.KeyUid;
+            var fetchedKey = await _client.GetKeyAsync(createdKeyUid);
+
+            Assert.Equal(fetchedKey.Actions, new string[] { "documents.*" });
+        }
+
+        [Fact]
         public async Task UpdateKey()
         {
             var keyOptions = new Key


### PR DESCRIPTION
Ensure support to keys with wildcarded actions.

- `actions` field during key creation now accepts wildcards on actions. For example, `indexes.*` provides rights to `indexes.create`, `indexes.get`,`indexes.delete`, `indexes.delete`, and `indexes.update`.