### PR TITLE
Change SearchAsync<T> signature

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -43,7 +43,7 @@ delete_one_document_1: |-
 delete_documents_1: |-
   await client.Index("movies").DeleteDocumentsAsync(new[] { "23488", "153738", "437035", "363869" });
 search_post_1: |-
-  await client.Index("movies").SearchAsync<Movie>("American ninja");
+  await client.Index("movies").SearchAsync<Movie>(new SearchQuery("American ninja"));
 get_task_1: |
   TaskInfo task = await client.GetTaskAsync(1);
 get_all_tasks_1: |
@@ -179,52 +179,51 @@ field_properties_guide_displayed_1: |-
       "release_date"
   });
 filtering_guide_1: |-
-  SearchQuery filters = new SearchQuery() { Filter = "release_date > \"795484800\"" };
-  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Avengers", filters);
+  SearchQuery filters = new SearchQuery("Avengers") { Filter = "release_date > \"795484800\"" };
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>(filters);
 filtering_guide_2: |-
-  SearchQuery filters = new SearchQuery() { Filter = "release_date > 795484800 AND (director =
+  SearchQuery filters = new SearchQuery("Batman") { Filter = "release_date > 795484800 AND (director =
   \"Tim Burton\" OR director = \"Christopher Nolan\")" };
-  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Batman", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>(filters);
 filtering_guide_3: |-
-  SearchQuery filters = new SearchQuery() { Filter = "rating >= 3 AND (NOT director = \"Tim Burton\"" };
-  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Planet of the Apes", filters);
+  SearchQuery filters = new SearchQuery("Planet of the Apes") { Filter = "rating >= 3 AND (NOT director = \"Tim Burton\"" };
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>(filters);
 search_parameter_guide_query_1: |-
-  await client.Index("movies").SearchAsync<Movie>("shifu");
+  await client.Index("movies").SearchAsync<Movie>(new SearchQuery("shifu"));
 search_parameter_guide_offset_1: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("shifu")
   {
       Offset = 1
   };
-  await client.Index("movies").SearchAsync<Movie>("shifu", sq);
+  await client.Index("movies").SearchAsync<Movie>(sq);
 search_parameter_guide_limit_1: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("shifu")
   {
       Limit = 2
   };
-  await client.Index("movies").SearchAsync<Movie>("shifu", sq);
+  await client.Index("movies").SearchAsync<Movie>(sq);
 search_parameter_guide_retrieve_1: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("shifu")
   {
       AttributesToRetrieve = new[] {"overview", "title"}
   };
-  await client.Index("movies").SearchAsync<Movie>("shifu", sq);
+  await client.Index("movies").SearchAsync<Movie>(sq);
 search_parameter_guide_crop_1: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("shifu")
   {
       AttributesToCrop = new[] {"overview"},
       CropLength = 5
   };
-  await client.Index("movies").SearchAsync<Movie>("shifu", sq);
+  await client.Index("movies").SearchAsync<Movie>(sq);
 search_parameter_guide_highlight_1: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("winter feast")
   {
   	AttributesToHighlight = new[] {"overview"}
   };
-  await client.Index("movies").SearchAsync<Movie>("winter feast", sq);
+  await client.Index("movies").SearchAsync<Movie>(sq);
 search_parameter_guide_show_matches_position_1: |-
   await client.Index("movies").SearchAsync<T>(
-    "winter feast",
-    new SearchQuery
+    new SearchQuery("winter feast")
     {
         ShowMatchesPosition = True,
     });
@@ -351,7 +350,7 @@ getting_started_search_md: |-
   MeilisearchClient client = new MeilisearchClient("http://localhost:7700", "masterKey");
   var index = client.Index("movies");
 
-  SearchResult<Movie> movies = await index.SearchAsync<Movie>("harry pottre");
+  SearchResult<Movie> movies = await index.SearchAsync<Movie>(new SearchQuery("harry pottre"));
   foreach (var movie in movies.Hits)
   {
       Console.WriteLine(movie.Title);
@@ -403,20 +402,20 @@ getting_started_synonyms: |-
   };
   await client.Index("movies").UpdateSynonymsAsync(newSynonyms);
 getting_started_filtering: |-
-  SearchQuery filter = new SearchQuery() { Filter = "mass < 200" };
-  await client.Index("meteorites").SearchAsync<Meteorite>("", filter);
+  SearchQuery filter = new SearchQuery("") { Filter = "mass < 200" };
+  await client.Index("meteorites").SearchAsync<Meteorite>(filter);
 getting_started_geo_radius: |-
-  SearchQuery filter = new SearchQuery() { Filter = "_geoRadius(46.9480, 7.4474, 210000)" };
-  await client.Index("meteorites").SearchAsync<Meteorite>("", filter);
+  SearchQuery filter = new SearchQuery("") { Filter = "_geoRadius(46.9480, 7.4474, 210000)" };
+  await client.Index("meteorites").SearchAsync<Meteorite>(filter);
 getting_started_geo_point: |-
-  SearchQuery sort = new SearchQuery() { Sort = new string[] { "_geoPoint(48.8583701,2.2922926):asc" }};
-  await client.Index("meteorites").SearchAsync<Meteorite>("", sort);
+  SearchQuery sort = new SearchQuery("") { Sort = new string[] { "_geoPoint(48.8583701,2.2922926):asc" }};
+  await client.Index("meteorites").SearchAsync<Meteorite>(sort);
 getting_started_sorting: |-
-  SearchQuery searchQuery = new SearchQuery() {
+  SearchQuery searchQuery = new SearchQuery("") {
     Sort = new string[] { "mass:asc" },
     Filter = "mass < 200",
   };
-  await client.Index("meteorites").SearchAsync<Meteorite>("", searchQuery);
+  await client.Index("meteorites").SearchAsync<Meteorite>(searchQuery);
 getting_started_configure_settings: |-
   var newSettings = new Settings
   {
@@ -427,11 +426,11 @@ getting_started_configure_settings: |-
 getting_started_communicating_with_a_protected_instance: |-
   MeilisearchClient client = new MeilisearchClient("http://localhost:7700", "apiKey");
 
-  await client.Index("Movies").SearchAsync<Movie>("");
+  await client.Index("Movies").SearchAsync<Movie>(new SearchQuery(""));
 faceted_search_update_settings_1: |-
   await client.Index("movies").UpdateFilterableAttributesAsync(new [] { "director", "genres" });
 faceted_search_filter_1: |-
-  SearchQuery filters = new SearchQuery()
+  SearchQuery filters = new SearchQuery("thriller")
   {
       Filter = new string[][]
       {
@@ -440,20 +439,20 @@ faceted_search_filter_1: |-
       }
   };
 
-  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("thriller", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>(filters);
 faceted_search_facets_1: |-
-  SearchQuery filters = new SearchQuery()
+  SearchQuery filters = new SearchQuery("Batman")
   {
       Facets = new string[] { "genres" }
   };
 
-  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>("Batman", filters);
+  SearchResult<Movie> movies = await client.Index("movies").SearchAsync<Movie>(filters);
 faceted_search_walkthrough_filter_1: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("thriller")
   {
   	Filter = "(genre = 'Horror' AND genre = 'Mystery') OR director = 'Jordan Peele'"
   };
-  await client.Index("movies").SearchAsync<Movie>("thriller", sq);
+  await client.Index("movies").SearchAsync<Movie>(sq);
 add_movies_json_1: |-
   // Make sure to add this using to your code
   using System.IO;
@@ -476,7 +475,7 @@ landing_getting_started_1: |-
 post_dump_1: |-
   await client.CreateDumpAsync();
 phrase_search_1: |-
-  await client.Index("movies").SearchAsync<Movie>("\"african american\" horror");
+  await client.Index("movies").SearchAsync<Movie>(new SearchQuery("\"african american\" horror"));
 sorting_guide_update_sortable_attributes_1: |-
   await client.Index("books").UpdateSortableAttributesAsync(new [] { "price", "author" });
 sorting_guide_update_ranking_rules_1: |-
@@ -490,17 +489,17 @@ sorting_guide_update_ranking_rules_1: |-
   	"exactness"
   });
 sorting_guide_sort_parameter_1: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("science fiction")
   {
     Sort = new[] { "price:asc" },
   };
-  await client.Index("books").SearchAsync<Book>("science fiction", sq);
+  await client.Index("books").SearchAsync<Book>(sq);
 sorting_guide_sort_parameter_2: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("butler")
   {
     Sort = new[] { "author:desc" },
   };
-  await client.Index("books").SearchAsync<Book>("butler", sq);
+  await client.Index("books").SearchAsync<Book>(sq);
 get_sortable_attributes_1: |-
   await client.Index("books").GetSortableAttributesAsync();
 update_sortable_attributes_1: |-
@@ -508,36 +507,36 @@ update_sortable_attributes_1: |-
 reset_sortable_attributes_1: |-
   await client.Index("books").ResetSortableAttributesAsync();
 search_parameter_guide_sort_1: |-
-  var sq = new SearchQuery
+  var sq = new SearchQuery("science fiction")
   {
     Sort = new[] { "price:asc" },
   };
-  await client.Index("books").SearchAsync<Book>("science fiction", sq);
+  await client.Index("books").SearchAsync<Book>(sq);
 geosearch_guide_filter_settings_1: |-
   List<string> attributes = new() { "_geo" };
   TaskInfo result = await client.Index("movies").UpdateFilterableAttributesAsync(attributes);
 geosearch_guide_filter_usage_1: |-
-  SearchQuery filters = new SearchQuery() { Filter = "_geoRadius(45.472735, 9.184019, 2000)" };
-  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>("", filters);
+  SearchQuery filters = new SearchQuery("") { Filter = "_geoRadius(45.472735, 9.184019, 2000)" };
+  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>(filters);
 geosearch_guide_filter_usage_2: |-
-  SearchQuery filters = new SearchQuery()
+  SearchQuery filters = new SearchQuery("restaurants")
   {
       Filter = new string[] { "_geoRadius(45.472735, 9.184019, 2000) AND type = pizza" }
   };
 
-  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>("restaurants", filters);
+  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>(filters);
 geosearch_guide_sort_settings_1: |-
   List<string> attributes = new() { "_geo" };
   TaskInfo result = await client.Index("restaurants").UpdateSortableAttributesAsync(attributes);
 geosearch_guide_sort_usage_1: |-
-  SearchQuery filters = new SearchQuery()
+  SearchQuery filters = new SearchQuery("")
   {
       Sort = new string[] { "_geoPoint(48.8561446,2.2978204):asc" }
   };
 
-  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>("", filters);
+  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>(filters);
 geosearch_guide_sort_usage_2: |-
-  SearchQuery filters = new SearchQuery()
+  SearchQuery filters = new SearchQuery("restaurants")
   {
       Sort = new string[] {
             "_geoPoint(48.8561446,2.2978204):asc",
@@ -545,7 +544,7 @@ geosearch_guide_sort_usage_2: |-
       }
   };
 
-  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>("restaurants", filters);
+  SearchResult<Restaurant> restaurants = await client.Index("restaurants").SearchAsync<Restaurant>(filters);
 primary_field_guide_create_index_primary_key: |-
   TaskInfo task = await client.CreateIndexAsync("books", "reference_number");
 primary_field_guide_update_document_primary_key: |-
@@ -588,7 +587,7 @@ delete_a_key_1: |-
   client.DeleteKeyAsync("6062abda-a5aa-4414-ac91-ecd7944c0f8d")
 security_guide_search_key_1: |-
   MeilisearchClient client = new MeilisearchClient("http://localhost:7700", "apiKey");
-  SearchResult<Patient> searchResult = await client.Index("patient_medical_records").SearchAsync<Patient>();
+  SearchResult<Patient> searchResult = await client.Index("patient_medical_records").SearchAsync<Patient>(new SearchQuery(""));
 security_guide_update_key_1: |-
   MeilisearchClient client = new MeilisearchClient("http://localhost:7700", "masterKey");
   await client.UpdateKeyAsync("74c9c733-3368-4738-bbe5-1d18a5fecb37", description: "Default Search API Key");
@@ -623,7 +622,7 @@ tenant_token_guide_generate_sdk_1: |-
   );
 tenant_token_guide_search_sdk_1: |-
   frontEndClient = new MeilisearchClient("http://localhost:7700", token);
-  SearchResult<Patient> searchResult = await frontEndClient.Index("patient_medical_records").SearchAsync<Patient>("blood test");
+  SearchResult<Patient> searchResult = await frontEndClient.Index("patient_medical_records").SearchAsync<Patient>(new SearchQuery("blood test"));
 getting_started_typo_tolerance: |-
   var typoTolerance = new TypoTolerance {
     MinWordSizeTypos = new TypoTolerance.TypoSize {

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ With the `uid`, you can check the status (`enqueued`, `processing`, `succeeded` 
 
 ```c#
 # Meilisearch is typo-tolerant:
-SearchResult<Movie> movies = await index.SearchAsync<Movie>("philadalphia");
+SearchResult<Movie> movies = await index.SearchAsync<Movie>(new SearchQuery("philadalphia"));
 foreach(var prop in movies.Hits) {
     Console.WriteLine (prop.Title);
 }
@@ -161,8 +161,7 @@ All the supported options are described in the [search parameters](https://docs.
 
 ```c#
 SearchResult<Movie> movies = await index.SearchAsync<Movie>(
-    "car",
-    new SearchQuery
+    new SearchQuery("car")
     {
         AttributesToHighlight = new string[] { "title" },
     }
@@ -212,8 +211,7 @@ Then, you can perform the search:
 
 ```c#
 SearchResult<Movie> movies = await index.SearchAsync<Movie>(
-    "wonder",
-    new SearchQuery
+    new SearchQuery("wonder")
     {
         Filter = "id > 1 AND genres = Action",
     }
@@ -335,13 +333,13 @@ var task = await client.GetTasksAsync();
 #### Basic Search <!-- omit in toc -->
 
 ```c#
-var movies = await this.index.SearchAsync<Movie>("prince");
+var movies = await this.index.SearchAsync<Movie>(new SearchQuery("prince"));
 ```
 
 #### Custom Search <!-- omit in toc -->
 
 ```c#
-var movies = await this.index.SearchAsync<Movie>("prince", new SearchQuery { Limit = 100 });
+var movies = await this.index.SearchAsync<Movie>(new SearchQuery("prince") { Limit = 100 });
 ```
 
 ## 🧰 Use a Custom HTTP Client

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -448,26 +448,13 @@ namespace Meilisearch
         /// <summary>
         /// Search documents according to search parameters.
         /// </summary>
-        /// <param name="query">Query Parameter with Search.</param>
-        /// <param name="searchAttributes">Attributes to search.</param>
+        /// <param name="searchQuery">Query informations.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type parameter to return.</typeparam>
         /// <returns>Returns Enumerable of items.</returns>
-        public async Task<SearchResult<T>> SearchAsync<T>(string query,
-            SearchQuery searchAttributes = default(SearchQuery), CancellationToken cancellationToken = default)
+        public async Task<SearchResult<T>> SearchAsync<T>(SearchQuery searchQuery, CancellationToken cancellationToken = default)
         {
-            SearchQuery body;
-            if (searchAttributes == null)
-            {
-                body = new SearchQuery { Q = query };
-            }
-            else
-            {
-                body = searchAttributes;
-                body.Q = query;
-            }
-
-            var responseMessage = await _http.PostAsJsonAsync($"indexes/{Uid}/search", body,
+            var responseMessage = await _http.PostAsJsonAsync($"indexes/{Uid}/search", searchQuery,
                     Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             return await responseMessage.Content

--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -8,6 +8,11 @@ namespace Meilisearch
     /// </summary>
     public class SearchQuery
     {
+        public SearchQuery(string query)
+        {
+            Q = query;
+        }
+
         /// <summary>
         /// Gets or sets query string.
         /// </summary>

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -35,7 +35,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task BasicSearch()
         {
-            var movies = await _basicIndex.SearchAsync<Movie>("man");
+            var movies = await _basicIndex.SearchAsync<Movie>(new SearchQuery("man"));
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Name.Should().NotBeEmpty();
             movies.Hits.ElementAt(1).Name.Should().NotBeEmpty();
@@ -44,7 +44,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task BasicSearchWithNoQuery()
         {
-            var movies = await _basicIndex.SearchAsync<Movie>(null);
+            var movies = await _basicIndex.SearchAsync<Movie>(new SearchQuery(null));
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Id.Should().NotBeNull();
             movies.Hits.First().Name.Should().NotBeNull();
@@ -53,7 +53,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task BasicSearchWithEmptyQuery()
         {
-            var movies = await _basicIndex.SearchAsync<Movie>(string.Empty);
+            var movies = await _basicIndex.SearchAsync<Movie>(new SearchQuery(string.Empty));
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Id.Should().NotBeNull();
             movies.Hits.First().Name.Should().NotBeNull();
@@ -63,8 +63,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithLimit()
         {
             var movies = await _basicIndex.SearchAsync<Movie>(
-                "man",
-                new SearchQuery { Limit = 1 });
+                new SearchQuery("man") { Limit = 1 });
             movies.Hits.Should().NotBeEmpty();
             Assert.Single(movies.Hits);
             movies.Hits.First().Id.Should().NotBeEmpty();
@@ -84,8 +83,7 @@ namespace Meilisearch.Tests
             await _basicIndex.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _basicIndex.SearchAsync<FormattedMovie>(
-                "man",
-                new SearchQuery { AttributesToHighlight = new string[] { "name" } });
+                new SearchQuery("man") { AttributesToHighlight = new string[] { "name" } });
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Id.Should().NotBeEmpty();
             movies.Hits.First().Name.Should().NotBeEmpty();
@@ -97,8 +95,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithNoQuery()
         {
             var movies = await _basicIndex.SearchAsync<FormattedMovie>(
-                null,
-                new SearchQuery { AttributesToHighlight = new string[] { "name" } });
+                new SearchQuery(null) { AttributesToHighlight = new string[] { "name" } });
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Id.Should().NotBeNull();
             movies.Hits.First().Name.Should().NotBeNull();
@@ -110,8 +107,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithEmptyQuery()
         {
             var movies = await _basicIndex.SearchAsync<FormattedMovie>(
-                string.Empty,
-                new SearchQuery { AttributesToHighlight = new string[] { "name" } });
+                new SearchQuery(string.Empty) { AttributesToHighlight = new string[] { "name" } });
             movies.Hits.Should().NotBeEmpty();
             movies.Hits.First().Id.Should().NotBeNull();
             movies.Hits.First().Name.Should().NotBeNull();
@@ -123,8 +119,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithMultipleOptions()
         {
             var movies = await _basicIndex.SearchAsync<FormattedMovie>(
-                "man",
-                new SearchQuery
+                new SearchQuery("man")
                 {
                     AttributesToHighlight = new string[] { "name" },
                     AttributesToRetrieve = new string[] { "name", "id" },
@@ -146,8 +141,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithFilter()
         {
             var movies = await _indexForFaceting.SearchAsync<Movie>(
-                null,
-                new SearchQuery
+                new SearchQuery(null)
                 {
                     Filter = "genre = SF",
                 });
@@ -164,8 +158,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithFilterWithSpaces()
         {
             var movies = await _indexForFaceting.SearchAsync<Movie>(
-                null,
-                new SearchQuery
+                new SearchQuery(null)
                 {
                     Filter = "genre = 'sci fi'",
                 });
@@ -180,8 +173,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithFilterArray()
         {
             var movies = await _indexForFaceting.SearchAsync<Movie>(
-                null,
-                new SearchQuery
+                new SearchQuery(null)
                 {
                     Filter = new string[] { "genre = SF" },
                 });
@@ -198,8 +190,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithFilterMultipleArray()
         {
             var movies = await _indexForFaceting.SearchAsync<Movie>(
-                null,
-                new SearchQuery
+                new SearchQuery(null)
                 {
                     Filter = new string[][] { new string[] { "genre = SF", "genre = SF" }, new string[] { "genre = SF" } },
                 });
@@ -224,8 +215,7 @@ namespace Meilisearch.Tests
             await _indexWithIntId.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _indexWithIntId.SearchAsync<MovieWithIntId>(
-                null,
-                new SearchQuery
+                new SearchQuery(null)
                 {
                     Filter = "id = 12",
                 });
@@ -249,8 +239,7 @@ namespace Meilisearch.Tests
             await _indexWithIntId.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _indexWithIntId.SearchAsync<MovieWithIntId>(
-                null,
-                new SearchQuery
+                new SearchQuery(null)
                 {
                     Filter = "genre = SF AND id > 12",
                 });
@@ -265,7 +254,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithPhraseSearch()
         {
-            var movies = await _indexForFaceting.SearchAsync<Movie>("coco \"harry\"");
+            var movies = await _indexForFaceting.SearchAsync<Movie>(new SearchQuery ("coco \"harry\""));
             movies.Hits.Should().NotBeEmpty();
             movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);
@@ -278,8 +267,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithFacetDistribution()
         {
             var movies = await _indexForFaceting.SearchAsync<Movie>(
-                null,
-                new SearchQuery
+                new SearchQuery(null)
                 {
                     Facets = new string[] { "genre" },
                 });
@@ -303,8 +291,7 @@ namespace Meilisearch.Tests
             await _basicIndex.WaitForTaskAsync(task.TaskUid);
 
             var movies = await _basicIndex.SearchAsync<Movie>(
-                "man",
-                new SearchQuery
+                new SearchQuery("man")
                 {
                     Sort = new string[] { "name:asc" },
                 });
@@ -318,8 +305,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithCroppingParameters()
         {
             var movies = await _basicIndex.SearchAsync<FormattedMovie>(
-                "man",
-                new SearchQuery { CropLength = 1, AttributesToCrop = new string[] { "*" } }
+                new SearchQuery("man") { CropLength = 1, AttributesToCrop = new string[] { "*" } }
             );
 
             Assert.NotEmpty(movies.Hits);
@@ -330,8 +316,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithCropMarker()
         {
             var movies = await _basicIndex.SearchAsync<FormattedMovie>(
-                "man",
-                new SearchQuery { CropLength = 1, AttributesToCrop = new string[] { "*" }, CropMarker = "[…] " }
+                new SearchQuery("man") { CropLength = 1, AttributesToCrop = new string[] { "*" }, CropMarker = "[…] " }
             );
 
             Assert.NotEmpty(movies.Hits);
@@ -342,8 +327,7 @@ namespace Meilisearch.Tests
         public async Task CustomSearchWithCustomHighlightTags()
         {
             var movies = await _basicIndex.SearchAsync<FormattedMovie>(
-                "man",
-                new SearchQuery
+                new SearchQuery("man")
                 {
                     AttributesToHighlight = new string[] { "*" },
                     HighlightPreTag = "<mark>",
@@ -358,7 +342,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithinNestedDocuments()
         {
-            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("wizard");
+            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>(new SearchQuery("wizard"));
 
             Assert.NotEmpty(movies.Hits);
             Assert.Equal("Harry Potter", movies.Hits.First().Name);
@@ -372,7 +356,7 @@ namespace Meilisearch.Tests
             var task = await _nestedIndex.UpdateSearchableAttributesAsync(new string[] { "name", "info.comment" });
             await _nestedIndex.WaitForTaskAsync(task.TaskUid);
 
-            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("rich");
+            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>(new SearchQuery("rich"));
 
             Assert.NotEmpty(movies.Hits);
             Assert.Equal("Iron Man", movies.Hits.First().Name);
@@ -388,8 +372,8 @@ namespace Meilisearch.Tests
             var sortTask = await _nestedIndex.UpdateSortableAttributesAsync(new string[] { "info.reviewNb" });
             await _nestedIndex.WaitForTaskAsync(sortTask.TaskUid);
 
-            var query = new SearchQuery { Sort = new string[] { "info.reviewNb:desc" } };
-            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("", query);
+            var query = new SearchQuery("") { Sort = new string[] { "info.reviewNb:desc" } };
+            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>(query);
 
             Assert.NotEmpty(movies.Hits);
             Assert.Equal("Interstellar", movies.Hits.First().Name);
@@ -400,8 +384,8 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithMatchingStrategyALL()
         {
-            SearchQuery searchQuery = new SearchQuery() { MatchingStrategy = "all" };
-            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("movie about rich", searchQuery);
+            var searchQuery = new SearchQuery("movie about rich") { MatchingStrategy = "all" };
+            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>(searchQuery);
 
             movies.Hits.Should().ContainSingle();
         }
@@ -409,8 +393,8 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithMatchingStrategyLast()
         {
-            SearchQuery searchQuery = new SearchQuery() { MatchingStrategy = "last" };
-            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("movie about rich", searchQuery);
+            var searchQuery = new SearchQuery("movie about rich") { MatchingStrategy = "last" };
+            var movies = await _nestedIndex.SearchAsync<MovieWithInfo>(searchQuery);
 
             Assert.True(movies.Hits.Count() > 1);
         }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -254,7 +254,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithPhraseSearch()
         {
-            var movies = await _indexForFaceting.SearchAsync<Movie>(new SearchQuery ("coco \"harry\""));
+            var movies = await _indexForFaceting.SearchAsync<Movie>(new SearchQuery("coco \"harry\""));
             movies.Hits.Should().NotBeEmpty();
             movies.FacetDistribution.Should().BeNull();
             Assert.Single(movies.Hits);

--- a/tests/Meilisearch.Tests/TenantTokenTests.cs
+++ b/tests/Meilisearch.Tests/TenantTokenTests.cs
@@ -89,7 +89,7 @@ namespace Meilisearch.Tests
             var token = admClient.GenerateTenantToken(createdKey.Uid, new TenantTokenRules(data));
             var customClient = new MeilisearchClient(_fixture.MeilisearchAddress(), token);
 
-            await customClient.Index(_indexName).SearchAsync<Movie>(string.Empty);
+            await customClient.Index(_indexName).SearchAsync<Movie>(new SearchQuery(string.Empty));
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace Meilisearch.Tests
             Thread.Sleep(TimeSpan.FromSeconds(2));
 
             await Assert.ThrowsAsync<MeilisearchApiError>(async () =>
-                await customClient.Index(_indexName).SearchAsync<Movie>(string.Empty));
+                await customClient.Index(_indexName).SearchAsync<Movie>(new SearchQuery(string.Empty)));
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace Meilisearch.Tests
 
             var token = admClient.GenerateTenantToken(createdKey.Uid, new TenantTokenRules(new[] { "*" }), expiresAt: DateTime.UtcNow.AddMinutes(1));
             var customClient = new MeilisearchClient(_fixture.MeilisearchAddress(), token);
-            await customClient.Index(_indexName).SearchAsync<Movie>(string.Empty);
+            await customClient.Index(_indexName).SearchAsync<Movie>(new SearchQuery(string.Empty));
         }
 
         public static IEnumerable<object[]> PossibleSearchRules()


### PR DESCRIPTION
# Pull Request

## What does this PR do?
The old signature was a bit akward, it took as first paramater a string for the query and a second parameter an optional SearchQuery object where we store later the first parameter into the Q property of the SearchQuery.

```csharp
// Old signature
public async Task<SearchResult<T>> SearchAsync<T>(string query,
            SearchQuery searchAttributes = default(SearchQuery), CancellationToken cancellationToken = default)
{
}
```

The main issue was that the SearchQuery can be created with the default constructor which is wrong. The SearchQuery object must be created by passing a search query to the constructor to be in a valid state.

The new signature is now always using the SearchQuery parameter like in other SDK

```csharp
// New signature
public async Task<SearchResult<T>> SearchAsync<T>(SearchQuery searchQuery, CancellationToken cancellationToken = default)
{
}
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
