### PR TITLE
GetAllRawIndexes now support pagination with the IndexesQuery

### DIFF
--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -122,11 +122,17 @@ namespace Meilisearch
         /// <summary>
         /// Gets all the raw indexes for the instance as returned by the resposne of the Meilisearch server. Throws error if the index does not exist.
         /// </summary>
+        /// <param name="query">Query parameters. Supports limit and offset.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>An IEnumerable of indexes in JsonElement format.</returns>
-        public async Task<JsonDocument> GetAllRawIndexesAsync(CancellationToken cancellationToken = default)
+        public async Task<JsonDocument> GetAllRawIndexesAsync(IndexesQuery query = default, CancellationToken cancellationToken = default)
         {
-            var response = await _http.GetAsync("indexes", cancellationToken).ConfigureAwait(false);
+            var uri = $"indexes";
+            if (query != null)
+            {
+                uri = $"{uri}?{query.ToQueryString()}";
+            }
+            var response = await _http.GetAsync(uri, cancellationToken).ConfigureAwait(false);
 
             var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             return JsonDocument.Parse(content);

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -143,6 +143,36 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task GetMultipleRawExistingIndexesWithLimit()
+        {
+            var indexUid1 = "GetMultipleExistingIndexesWithLimit1";
+            var indexUid2 = "GetMultipleExistingIndexesWithLimit2";
+            await _fixture.SetUpEmptyIndex(indexUid1, _defaultPrimaryKey);
+            await _fixture.SetUpEmptyIndex(indexUid2, _defaultPrimaryKey);
+
+            var indexes = await _client.GetAllRawIndexesAsync(new IndexesQuery() { Limit = 1 });
+            var results = indexes.RootElement.GetProperty("results");
+            var limit = indexes.RootElement.GetProperty("limit").GetInt32();
+            results.GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
+            Assert.Equal(1, limit);
+        }
+
+        [Fact]
+        public async Task GetMultipleRawExistingIndexesWithOffset()
+        {
+            var indexUid1 = "GetMultipleExistingIndexesWithOffset1";
+            var indexUid2 = "GetMultipleExistingIndexesWithOffset2";
+            await _fixture.SetUpEmptyIndex(indexUid1, _defaultPrimaryKey);
+            await _fixture.SetUpEmptyIndex(indexUid2, _defaultPrimaryKey);
+
+            var indexes = await _client.GetAllRawIndexesAsync(new IndexesQuery() { Offset = 1 });
+            var results = indexes.RootElement.GetProperty("results");
+            var offset = indexes.RootElement.GetProperty("offset").GetInt32();
+            results.GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
+            Assert.Equal(1, offset);
+        }
+
+        [Fact]
         public async Task GetMultipleExistingIndexes()
         {
             var indexUid1 = "GetMultipleExistingIndexesTest1";

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -145,8 +145,8 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task GetMultipleRawExistingIndexesWithLimit()
         {
-            var indexUid1 = "GetMultipleExistingIndexesWithLimit1";
-            var indexUid2 = "GetMultipleExistingIndexesWithLimit2";
+            var indexUid1 = "GetMultipleRawExistingIndexesWithLimit1";
+            var indexUid2 = "GetMultipleRawExistingIndexesWithLimit2";
             await _fixture.SetUpEmptyIndex(indexUid1, _defaultPrimaryKey);
             await _fixture.SetUpEmptyIndex(indexUid2, _defaultPrimaryKey);
 
@@ -160,8 +160,8 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task GetMultipleRawExistingIndexesWithOffset()
         {
-            var indexUid1 = "GetMultipleExistingIndexesWithOffset1";
-            var indexUid2 = "GetMultipleExistingIndexesWithOffset2";
+            var indexUid1 = "GetMultipleRawExistingIndexesWithOffset1";
+            var indexUid2 = "GetMultipleRawExistingIndexesWithOffset2";
             await _fixture.SetUpEmptyIndex(indexUid1, _defaultPrimaryKey);
             await _fixture.SetUpEmptyIndex(indexUid2, _defaultPrimaryKey);
 

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -400,7 +400,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithMatchingStrategyALL()
         {
-            SearchQuery searchQuery = new SearchQuery() { MatchingStrategy = "all" };
+            var searchQuery = new SearchQuery() { MatchingStrategy = "all" };
             var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("movie about rich", searchQuery);
 
             movies.Hits.Should().ContainSingle();
@@ -409,7 +409,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithMatchingStrategyLast()
         {
-            SearchQuery searchQuery = new SearchQuery() { MatchingStrategy = "last" };
+            var searchQuery = new SearchQuery() { MatchingStrategy = "last" };
             var movies = await _nestedIndex.SearchAsync<MovieWithInfo>("movie about rich", searchQuery);
 
             Assert.True(movies.Hits.Count() > 1);

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -48,7 +48,7 @@ namespace Meilisearch.Tests
             var tasks = taskResponse.Results.Where(t => t.IndexUid != _index.Uid);
 
             taskResponse.Results.Count().Should().BeGreaterOrEqualTo(1);
-            Assert.Equal(0, tasks.Count());
+            Assert.Empty(tasks);
         }
 
         [Fact]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #306

## What does this PR do?
- It allows the `GetAllRawIndexes` feature to support pagination with offset and limits

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
