### PR TITLE
Allow multiple pagination styles co-exist in the same response

### DIFF
--- a/src/Meilisearch/ISearchable.cs
+++ b/src/Meilisearch/ISearchable.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Meilisearch
+{
+    /// <summary>
+    /// Wrapper for Search Results.
+    /// </summary>
+    /// <typeparam name="T">Hit type.</typeparam>
+    public interface ISearchable<T>
+    {
+        /// <summary>
+        /// Results of the query.
+        /// </summary>
+        [JsonPropertyName("hits")]
+        IReadOnlyCollection<T> Hits { get; }
+
+        /// <summary>
+        /// Returns the number of documents matching the current search query for each given facet.
+        /// </summary>
+        [JsonPropertyName("facetDistribution")]
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> FacetDistribution { get; }
+
+        /// <summary>
+        /// Processing time of the query.
+        /// </summary>
+        [JsonPropertyName("processingTimeMs")]
+        int ProcessingTimeMs { get; }
+
+        /// <summary>
+        /// Query originating the response.
+        /// </summary>
+        [JsonPropertyName("query")]
+        string Query { get; }
+
+        /// <summary>
+        /// Contains the location of each occurrence of queried terms across all fields.
+        /// </summary>
+        [JsonPropertyName("_matchesPosition")]
+        IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
+    }
+}

--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -453,7 +453,7 @@ namespace Meilisearch
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type parameter to return.</typeparam>
         /// <returns>Returns Enumerable of items.</returns>
-        public async Task<SearchResult<T>> SearchAsync<T>(string query,
+        public async Task<ISearchable<T>> SearchAsync<T>(string query,
             SearchQuery searchAttributes = default(SearchQuery), CancellationToken cancellationToken = default)
         {
             SearchQuery body;
@@ -470,8 +470,16 @@ namespace Meilisearch
             var responseMessage = await _http.PostAsJsonAsync($"indexes/{Uid}/search", body,
                     Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
-            return await responseMessage.Content
-                .ReadFromJsonAsync<SearchResult<T>>(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (body.Page != null || body.HitsPerPage != null) {
+                return await responseMessage.Content
+                    .ReadFromJsonAsync<PaginatedSearchResult<T>>(cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            } else {
+                return await responseMessage.Content
+                    .ReadFromJsonAsync<SearchResult<T>>(cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Meilisearch/MatchPosition.cs
+++ b/src/Meilisearch/MatchPosition.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Meilisearch
+{
+    public class MatchPosition
+    {
+        public MatchPosition(int start, int length)
+        {
+            Start = start;
+            Length = length;
+        }
+
+        /// <summary>
+        /// The beginning of a matching term within a field.
+        /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
+        /// </summary>
+        [JsonPropertyName("start")]
+        public int Start { get; }
+
+        /// <summary>
+        /// The length of a matching term within a field.
+        /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
+        /// </summary>
+        [JsonPropertyName("length")]
+        public int Length { get; }
+    }
+}

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -7,22 +7,34 @@ namespace Meilisearch
     /// Wrapper for Search Results.
     /// </summary>
     /// <typeparam name="T">Hit type.</typeparam>
-    public class SearchResult<T> : ISearchable<T>
+    public class PaginatedSearchResult<T> : ISearchable<T>
     {
-        public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int estimatedTotalHits,
+        public PaginatedSearchResult(IReadOnlyCollection<T> hits, int hitsPerPage, int page, int total,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
             int processingTimeMs, string query,
             IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion)
         {
             Hits = hits;
-            Offset = offset;
-            Limit = limit;
-            EstimatedTotalHits = estimatedTotalHits;
+            HitsPerPage = hitsPerPage;
+            Page = page;
+            Total = total;
             FacetDistribution = facetDistribution;
             ProcessingTimeMs = processingTimeMs;
             Query = query;
             MatchesPostion = matchesPostion;
         }
+
+        /// <summary>
+        /// Number of documents skipped.
+        /// </summary>
+        [JsonPropertyName("hitsPerPage")]
+        public int HitsPerPage { get; }
+
+        /// <summary>
+        /// Number of documents to take.
+        /// </summary>
+        [JsonPropertyName("page")]
+        public int Page { get; }
 
         /// <summary>
         /// Results of the query.
@@ -31,22 +43,10 @@ namespace Meilisearch
         public IReadOnlyCollection<T> Hits { get; }
 
         /// <summary>
-        /// Number of documents skipped.
-        /// </summary>
-        [JsonPropertyName("offset")]
-        public int Offset { get; }
-
-        /// <summary>
-        /// Number of documents to take.
-        /// </summary>
-        [JsonPropertyName("limit")]
-        public int Limit { get; }
-
-        /// <summary>
         /// Gets the estimated total number of hits returned by the search.
         /// </summary>
-        [JsonPropertyName("estimatedTotalHits")]
-        public int EstimatedTotalHits { get; }
+        [JsonPropertyName("total")]
+        public int Total { get; }
 
         /// <summary>
         /// Returns the number of documents matching the current search query for each given facet.
@@ -71,28 +71,5 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("_matchesPosition")]
         public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
-    }
-
-    public class MatchPosition
-    {
-        public MatchPosition(int start, int length)
-        {
-            Start = start;
-            Length = length;
-        }
-
-        /// <summary>
-        /// The beginning of a matching term within a field.
-        /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
-        /// </summary>
-        [JsonPropertyName("start")]
-        public int Start { get; }
-
-        /// <summary>
-        /// The length of a matching term within a field.
-        /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
-        /// </summary>
-        [JsonPropertyName("length")]
-        public int Length { get; }
     }
 }

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace Meilisearch
 {
     /// <summary>
-    /// Wrapper for Search Results.
+    /// Wrapper for Search Results with finite pagination.
     /// </summary>
     /// <typeparam name="T">Hit type.</typeparam>
     public class PaginatedSearchResult<T> : ISearchable<T>
@@ -25,7 +25,7 @@ namespace Meilisearch
         }
 
         /// <summary>
-        /// Number of documents skipped.
+        /// Number of documents each page.
         /// </summary>
         [JsonPropertyName("hitsPerPage")]
         public int HitsPerPage { get; }

--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -15,18 +15,6 @@ namespace Meilisearch
         public string Q { get; set; }
 
         /// <summary>
-        /// Gets or sets offset for the Query.
-        /// </summary>
-        [JsonPropertyName("offset")]
-        public int? Offset { get; set; }
-
-        /// <summary>
-        /// Gets or sets limits the number of results.
-        /// </summary>
-        [JsonPropertyName("limit")]
-        public int? Limit { get; set; }
-
-        /// <summary>
         /// Gets or sets the filter to apply to the query.
         /// </summary>
         [JsonPropertyName("filter")]
@@ -97,5 +85,32 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("matchingStrategy")]
         public string MatchingStrategy { get; set; }
+
+        // pagination:
+
+        /// <summary>
+        /// Gets or sets offset for the Query.
+        /// </summary>
+        [JsonPropertyName("offset")]
+        public int? Offset { get; set; }
+
+        /// <summary>
+        /// Gets or sets limits the number of results.
+        /// </summary>
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+
+        /// <summary>
+        /// Gets or sets hitsPerPage.
+        /// </summary>
+        [JsonPropertyName("hitsPerPage")]
+        public int? HitsPerPage { get; set; }
+
+        /// <summary>
+        /// Gets or sets page.
+        /// </summary>
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
     }
 }

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -72,27 +72,4 @@ namespace Meilisearch
         [JsonPropertyName("_matchesPosition")]
         public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
     }
-
-    public class MatchPosition
-    {
-        public MatchPosition(int start, int length)
-        {
-            Start = start;
-            Length = length;
-        }
-
-        /// <summary>
-        /// The beginning of a matching term within a field.
-        /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
-        /// </summary>
-        [JsonPropertyName("start")]
-        public int Start { get; }
-
-        /// <summary>
-        /// The length of a matching term within a field.
-        /// WARNING: This value is in bytes and not the number of characters. For example, ü represents two bytes but one character.
-        /// </summary>
-        [JsonPropertyName("length")]
-        public int Length { get; }
-    }
 }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -73,6 +73,28 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task CustomSearchWithPage()
+        {
+            var movies = (PaginatedSearchResult<Movie>) await _basicIndex.SearchAsync<Movie>("man", new SearchQuery { Page = 1 });
+
+            Assert.Equal(1, movies.Page);
+            Assert.Equal(20, movies.HitsPerPage);
+            movies.Hits.First().Id.Should().NotBeEmpty();
+            movies.Hits.First().Name.Should().NotBeEmpty();
+            movies.Hits.First().Genre.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public async Task CustomSearchWithPageWithoutTypeCast()
+        {
+            var movies = await _basicIndex.SearchAsync<Movie>("man", new SearchQuery { Page = 1 });
+
+            movies.Hits.First().Id.Should().NotBeEmpty();
+            movies.Hits.First().Name.Should().NotBeEmpty();
+            movies.Hits.First().Genre.Should().NotBeEmpty();
+        }
+
+        [Fact]
         public async Task CustomSearchWithAttributesToHighlight()
         {
             var newFilters = new Settings


### PR DESCRIPTION
This is part of a proof-of-concept that will be part of the next release, v0.30.

The idea of this PR is to accommodate in a strongly typed language the ability to handle two different response types: the estimation-based response and the finite pagination based.

More details here: https://github.com/meilisearch/meilisearch/discussions/2635.

For reviewers:

- [ ] Check if the ergonomics of the API are good enough.
- [ ] If possible try-it-out with [v0.30.0-pagination.beta.4](https://hub.docker.com/layers/getmeili/meilisearch/v0.30.0-pagination.beta.4/images/sha256-0c5207423dded2489a53ae8325b803d10f5313e08d712cfb5102eee9644dd41e?context=explore) add it to `.env`.

How to use:

```c#
// When you want to search with finite pagination:
await client.SearchAsync<Movie>("man", new SearchQuery { Page = 2 });

// When you want to search with finite pagination but also need additional data like (total, page, and hits per page):
var movies = (PaginatedSearchResult<Movie>) await client.SearchAsync<Movie>("man", new SearchQuery { Page = 2 });
var currentPage = movies.Page; 

// When you want to use the old-style estimated value:
await client.SearchAsync<Movie>("man", new SearchQuery { Limit = 20 });
await client.SearchAsync<Movie>("man", new SearchQuery { }); // just don't use HitsPerPage and Page.
```
