### PR TITLE
Mark Enabled as a nullable boolean value.

### DIFF
--- a/src/Meilisearch/TypoTolerance.cs
+++ b/src/Meilisearch/TypoTolerance.cs
@@ -12,7 +12,7 @@ namespace Meilisearch
         /// Whether the typo tolerance feature is enabled
         /// </summary>
         [JsonPropertyName("enabled")]
-        public bool Enabled { get; set; }
+        public bool? Enabled { get; set; }
 
         /// <summary>
         /// Disable the typo tolerance feature on the specified document attributes.

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -374,6 +374,7 @@ namespace Meilisearch.Tests
 
             var returnedTypoTolerance = new TypoTolerance
             {
+                Enabled = true,
                 DisableOnAttributes = new string[] { },
                 DisableOnWords = new string[] { "harry", "potter" },
                 MinWordSizeForTypos = new TypoTolerance.TypoSize
@@ -402,6 +403,7 @@ namespace Meilisearch.Tests
 
             var returnedTypoTolerance = new TypoTolerance
             {
+                Enabled = true,
                 DisableOnAttributes = new string[] { "title" },
                 DisableOnWords = new string[] { "harry", "potter" },
                 MinWordSizeForTypos = new TypoTolerance.TypoSize

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -430,6 +430,7 @@ namespace Meilisearch.Tests
 
             var returnedTypoTolerance = new TypoTolerance
             {
+                Enabled = true,
                 DisableOnAttributes = new string[] { },
                 DisableOnWords = new string[] { "harry", "potter" },
                 MinWordSizeForTypos = new TypoTolerance.TypoSize


### PR DESCRIPTION
Otherwise the default value would have always been `false` if not set to `true` in the code.
