### PR TITLE
Rename TaskQuery fields (IndexUids & Statuses)

### DIFF
--- a/src/Meilisearch/Index.Tasks.cs
+++ b/src/Meilisearch/Index.Tasks.cs
@@ -18,7 +18,7 @@ namespace Meilisearch
         {
             if (query == null)
             {
-                query = new TasksQuery { IndexUid = new List<string> { this.Uid } };
+                query = new TasksQuery { IndexUids = new List<string> { this.Uid } };
             }
 
             return await TaskEndpoint().GetTasksAsync(query, cancellationToken).ConfigureAwait(false);

--- a/src/Meilisearch/QueryParameters/TasksQuery.cs
+++ b/src/Meilisearch/QueryParameters/TasksQuery.cs
@@ -20,12 +20,12 @@ namespace Meilisearch.QueryParameters
         /// <summary>
         /// Gets or sets the lists of indexUid to filter on. Case-sensitive.
         /// </summary>
-        public List<string> IndexUid { get; set; }
+        public List<string> IndexUids { get; set; }
 
         /// <summary>
         /// Gets or sets the list of statuses to filter on.
         /// </summary>
-        public List<TaskInfoStatus> Status { get; set; }
+        public List<TaskInfoStatus> Statuses { get; set; }
 
         /// <summary>
         /// Gets or sets the list of types to filter on.

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -65,7 +65,7 @@ namespace Meilisearch.Tests
         public async Task GetMultipleTaskInfoWithQueryParameters()
         {
             await _index.AddDocumentsAsync(new[] { new Movie { Id = "1" } });
-            var taskResponse = await _index.GetTasksAsync(new TasksQuery { Limit = 1, IndexUid = new List<string> { _index.Uid } });
+            var taskResponse = await _index.GetTasksAsync(new TasksQuery { Limit = 1, IndexUids = new List<string> { _index.Uid } });
 
             taskResponse.Results.Count().Should().BeGreaterOrEqualTo(1);
         }


### PR DESCRIPTION
Rename `TaskInfoQuery` fields to match the v0.30 spec.
- from `IndexUid` to `IndexUids`.
- from `Status` to `Statuses`.