### PR TITLE
Feature/Add filters to tasks

### DIFF
--- a/src/Meilisearch/Extensions/ObjectExtensions.cs
+++ b/src/Meilisearch/Extensions/ObjectExtensions.cs
@@ -40,10 +40,19 @@ namespace Meilisearch.Extensions
 
                 if (value != null)
                 {
-                    var isList = value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition() == typeof(List<>);
-                    if (isList)
+                    var type = value.GetType();
+
+                    if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
                     {
-                        values.Add(key + "=" + string.Join(",", (List<string>)value));
+                        Type itemType = type.GetGenericArguments()[0];
+                        if (itemType == typeof(string))
+                        {
+                            values.Add(key + "=" + string.Join(",", (List<string>)value));
+                        }
+                        else if (itemType == typeof(int))
+                        {
+                            values.Add(key + "=" + string.Join(",", (List<int>)value));
+                        }
                     }
                     else if (value is DateTime)
                     {

--- a/src/Meilisearch/QueryParameters/TasksQuery.cs
+++ b/src/Meilisearch/QueryParameters/TasksQuery.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Meilisearch.QueryParameters
@@ -23,6 +24,11 @@ namespace Meilisearch.QueryParameters
         public List<string> IndexUids { get; set; }
 
         /// <summary>
+        /// Gets or sets the lists of uid to filter on. Case-sensitive.
+        /// </summary>
+        public List<int> Uids { get; set; }
+
+        /// <summary>
         /// Gets or sets the list of statuses to filter on.
         /// </summary>
         public List<TaskInfoStatus> Statuses { get; set; }
@@ -31,5 +37,40 @@ namespace Meilisearch.QueryParameters
         /// Gets or sets the list of types to filter on.
         /// </summary>
         public List<TaskInfoType> Types { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of canceledBy uids to filter on. Case-sensitive.
+        /// </summary>
+        public List<string> CanceledBy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date before the task is enqueued to filter.
+        /// </summary>
+        public DateTime? BeforeEnqueuedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date after the task is enqueued to filter.
+        /// </summary>
+        public DateTime? AfterEnqueuedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date before the task was started to filter.
+        /// </summary>
+        public DateTime? BeforeStartedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date after the task was started to filter.
+        /// </summary>
+        public DateTime? AfterStartedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date before the task was finished to filter.
+        /// </summary>
+        public DateTime? BeforeFinishedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date after the task was finished to filter.
+        /// </summary>
+        public DateTime? AfterFinishedAt { get; set; }
     }
 }


### PR DESCRIPTION
TasksQuery now supports these filters:

- `List<int> Uids`
- `List<string> CanceledBy`
- `DateTime? BeforeEnqueuedAt`
- `DateTime? AfterEnqueuedAt`
- `DateTime? BeforeStartedAt`
- `DateTime? AfterStartedAt`
- `DateTime? BeforeFinishedAt`
- `DateTime? AfterFinishedAt`