### PR TITLE
Add documentation for intellisense when publishing package

### DIFF
--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -327,6 +327,7 @@ namespace Meilisearch
         /// Get document by its ID.
         /// </summary>
         /// <param name="documentId">Document identifier.</param>
+        /// <param name="fields">Document attributes to show (case-sensitive).</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type of the document.</typeparam>
         /// <returns>Returns the document, with the according type if the object is available.</returns>
@@ -347,6 +348,7 @@ namespace Meilisearch
         /// Get document by its ID.
         /// </summary>
         /// <param name="documentId">Document Id for query.</param>
+        /// <param name="fields">Document attributes to show (case-sensitive).</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <typeparam name="T">Type to return for document.</typeparam>
         /// <returns>Type if the object is availble.</returns>

--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -12,6 +12,11 @@
         <PackageProjectUrl>https://meilisearch.com</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/meilisearch_dotnet.png</PackageIconUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <!-- Warnings for missing XML documentation are only visible during dev time -->
+        <!-- You may want to remove the NoWarn node in case documentation will be mandatory in the future -->
+        <NoWarn Condition=" '$(Configuration)' == 'Release'">$(NoWarn);1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -280,6 +280,7 @@ namespace Meilisearch
         /// Gets the API keys.
         /// </summary>
         /// <param name="query">Query parameters supports by the method.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns a list of the API keys.</returns>
         public async Task<ResourceResults<IEnumerable<Key>>> GetKeysAsync(KeysQuery query = default, CancellationToken cancellationToken = default)
         {
@@ -344,6 +345,7 @@ namespace Meilisearch
         /// <summary>
         /// Updates an API key for the Meilisearch server.
         /// </summary>
+        /// <param name="keyOrUid">Unique identifier of the API key or the Key</param>
         /// <param name="description">A description to give meaning to the key.</param>
         /// <param name="name">A name to label the key internally.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
@@ -393,6 +395,7 @@ namespace Meilisearch
         /// <summary>
         /// Generate a tenant token string to be used during search.
         /// </summary>
+        /// <param name="apiKeyUid">Unique identifier of the API key.</param>
         /// <param name="searchRules">Object with the rules applied in a search call.</param>
         /// <param name="apiKey">API Key which signs the generated token.</param>
         /// <param name="expiresAt">Date to express how long the generated token will last. If null the token will last forever.</param>

--- a/src/Meilisearch/Settings.cs
+++ b/src/Meilisearch/Settings.cs
@@ -68,6 +68,7 @@ namespace Meilisearch
         [JsonPropertyName("faceting")]
         public Faceting Faceting { get; set; }
 
+        /// <summary>
         /// Gets or sets the pagination attributes.
         /// </summary>
         [JsonPropertyName("pagination")]


### PR DESCRIPTION
# Pull Request

## What does this PR do?

This PR add the xml doc to the package in order to have it displayed in intellisense for end users.

During dev time, warnings will be displayed for missing documentation and is disabled when releasing a new version to avoid polluting build logs.

In case you want all the documentation mandatory after fixing the warnings you may want to remove this from the `Meilisearch.csproj`

```xml
<!-- Warnings for missing XML documentation are only visible during dev time -->
<!-- You may want to remove the NoWarn node in case documentation will be mandatory in the future -->
<NoWarn Condition=" '$(Configuration)' == 'Release'">$(NoWarn);1591</NoWarn>
```


## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
