### PR TITLE
Update version for the next release (v0.13.1)

### DIFF
--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>MeiliSearch</PackageId>
-        <Version>0.13.0</Version>
+        <Version>0.13.1</Version>
         <Description>.NET wrapper for Meilisearch, an open-source search engine</Description>
         <RepositoryUrl>https://github.com/meilisearch/meilisearch-dotnet</RepositoryUrl>
         <PackageTags>meilisearch;dotnet;sdk;search-engine;search;instant-search</PackageTags>


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v1.0.0 🎉
Check out the changelog of [Meilisearch v1.0.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for more information on the changes(https://github.com/meilisearch/meilisearch-dotnet/pull/383).

## 🚀 Enhancements

- Key class has been changed; all the `Key` fields were available in the structure, but some of them aren't needed when creating a Key.
    - `createdAt` has been `JsonIgnore`
    - `updatedAt` has been `JsonIgnore`
    - `key` has been `JsonIgnore`

Thanks again to @alallema,  @brunoocasali and @juchom ! 🎉