### PR TITLE
Add TotalHits and TotalPages fields to PaginatedSearchResult

### DIFF
--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -9,15 +9,23 @@ namespace Meilisearch
     /// <typeparam name="T">Hit type.</typeparam>
     public class PaginatedSearchResult<T> : ISearchable<T>
     {
-        public PaginatedSearchResult(IReadOnlyCollection<T> hits, int hitsPerPage, int page, int total,
+        public PaginatedSearchResult(
+            IReadOnlyCollection<T> hits,
+            int hitsPerPage,
+            int page,
+            int totalHits,
+            int totalPages,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
-            int processingTimeMs, string query,
-            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion)
+            int processingTimeMs,
+            string query,
+            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion
+        )
         {
             Hits = hits;
             HitsPerPage = hitsPerPage;
             Page = page;
-            Total = total;
+            TotalHits = totalHits;
+            TotalPages = totalPages;
             FacetDistribution = facetDistribution;
             ProcessingTimeMs = processingTimeMs;
             Query = query;
@@ -37,16 +45,22 @@ namespace Meilisearch
         public int Page { get; }
 
         /// <summary>
+        /// Total number of documents' pages.
+        /// </summary>
+        [JsonPropertyName("totalPages")]
+        public int TotalPages { get; }
+
+        /// <summary>
         /// Results of the query.
         /// </summary>
         [JsonPropertyName("hits")]
         public IReadOnlyCollection<T> Hits { get; }
 
         /// <summary>
-        /// Gets the estimated total number of hits returned by the search.
+        /// Gets the total number of hits returned by the search.
         /// </summary>
-        [JsonPropertyName("total")]
-        public int Total { get; }
+        [JsonPropertyName("totalHits")]
+        public int TotalHits { get; }
 
         /// <summary>
         /// Returns the number of documents matching the current search query for each given facet.

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -75,10 +75,12 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CustomSearchWithPage()
         {
-            var movies = (PaginatedSearchResult<Movie>)await _basicIndex.SearchAsync<Movie>("man", new SearchQuery { Page = 1 });
+            var movies = (PaginatedSearchResult<Movie>)await _basicIndex.SearchAsync<Movie>("man", new SearchQuery { Page = 1, HitsPerPage = 1 });
 
             Assert.Equal(1, movies.Page);
-            Assert.Equal(20, movies.HitsPerPage);
+            Assert.Equal(1, movies.HitsPerPage);
+            Assert.Equal(2, movies.TotalHits);
+            Assert.Equal(2, movies.TotalPages);
             movies.Hits.First().Id.Should().NotBeEmpty();
             movies.Hits.First().Name.Should().NotBeEmpty();
             movies.Hits.First().Genre.Should().NotBeEmpty();


### PR DESCRIPTION
Fixes https://github.com/meilisearch/meilisearch-dotnet/issues/400

You can use this as the release CHANGELOG @alallema: 
 
- Remove `Total` from `PaginatedSearchResult`.
- Add `TotalHits` and `TotalPages` to `PaginatedSearchResult`.