### PR TITLE
GetIndexAsync should return null if index_not_found

### DIFF
--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -165,8 +165,8 @@ namespace Meilisearch
         /// </summary>
         /// <param name="uid">Unique identifier of the index.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
-        /// <returns>Returns Index or Throws if the index does not exist.</returns>
-        /// <exception cref="MeilisearchApiError">If the index doesn't exist</exception>
+        /// <returns>Returns Index.</returns>
+        /// <exception cref="MeilisearchApiError">Throws if the index doesn't exist.</exception>
         public async Task<Index> GetIndexAsync(string uid, CancellationToken cancellationToken = default)
         {
             return await Index(uid).FetchInfoAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -165,7 +165,8 @@ namespace Meilisearch
         /// </summary>
         /// <param name="uid">Unique identifier of the index.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
-        /// <returns>Returns Index or Null if the index does not exist.</returns>
+        /// <returns>Returns Index or Throws if the index does not exist.</returns>
+        /// <exception cref="MeilisearchApiError">If the index doesn't exist</exception>
         public async Task<Index> GetIndexAsync(string uid, CancellationToken cancellationToken = default)
         {
             return await Index(uid).FetchInfoAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #386

## What does this PR do?
- Catches `MeilisearchApiError` in `GetIndexAsync` and returns null if code is index_not_found

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
