### PR TITLE
Add FacetStats field in SearchResponse

### DIFF
--- a/src/Meilisearch/FacetStat.cs
+++ b/src/Meilisearch/FacetStat.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Meilisearch
+{
+    /// <summary>
+    /// Wrapper for Facet Stats.
+    /// </summary>
+    public class FacetStat
+    {
+        /// <summary>
+        /// Minimum value returned by FacetDistribution per facet
+        /// </summary>
+        [JsonPropertyName("min")]
+        public float Min { get; set; }
+
+        /// <summary>
+        /// Maximum value returned by FacetDistribution per facet
+        /// </summary>
+        [JsonPropertyName("max")]
+        public float Max { get; set; }
+    }
+}

--- a/src/Meilisearch/ISearchable.cs
+++ b/src/Meilisearch/ISearchable.cs
@@ -38,5 +38,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("_matchesPosition")]
         IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
+
+        /// <summary>
+        /// Returns the numeric min and max values per facet of the hits returned by the search query.
+        /// </summary>
+        [JsonPropertyName("facetStats")]
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> FacetStats { get; }
     }
 }

--- a/src/Meilisearch/ISearchable.cs
+++ b/src/Meilisearch/ISearchable.cs
@@ -43,6 +43,6 @@ namespace Meilisearch
         /// Returns the numeric min and max values per facet of the hits returned by the search query.
         /// </summary>
         [JsonPropertyName("facetStats")]
-        IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> FacetStats { get; }
+        IReadOnlyDictionary<string, FacetStat> FacetStats { get; }
     }
 }

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -18,7 +18,8 @@ namespace Meilisearch
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
             int processingTimeMs,
             string query,
-            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion
+            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> facetStats
         )
         {
             Hits = hits;
@@ -30,6 +31,7 @@ namespace Meilisearch
             ProcessingTimeMs = processingTimeMs;
             Query = query;
             MatchesPostion = matchesPostion;
+            FacetStats = facetStats;
         }
 
         /// <summary>
@@ -85,5 +87,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("_matchesPosition")]
         public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
+
+        /// <summary>
+        /// Returns the numeric min and max values per facet of the hits returned by the search query.
+        /// </summary>
+        [JsonPropertyName("facetStats")]
+        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> FacetStats { get; }
     }
 }

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -19,7 +19,7 @@ namespace Meilisearch
             int processingTimeMs,
             string query,
             IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion,
-            IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> facetStats
+            IReadOnlyDictionary<string, FacetStat> facetStats
         )
         {
             Hits = hits;
@@ -92,6 +92,6 @@ namespace Meilisearch
         /// Returns the numeric min and max values per facet of the hits returned by the search query.
         /// </summary>
         [JsonPropertyName("facetStats")]
-        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> FacetStats { get; }
+        public IReadOnlyDictionary<string, FacetStat> FacetStats { get; }
     }
 }

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -13,7 +13,7 @@ namespace Meilisearch
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
             int processingTimeMs, string query,
             IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion,
-            IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> facetStats)
+            IReadOnlyDictionary<string, FacetStat> facetStats)
         {
             Hits = hits;
             Offset = offset;
@@ -78,6 +78,6 @@ namespace Meilisearch
         /// Returns the numeric min and max values per facet of the hits returned by the search query.
         /// </summary>
         [JsonPropertyName("facetStats")]
-        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> FacetStats { get; }
+        public IReadOnlyDictionary<string, FacetStat> FacetStats { get; }
     }
 }

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -12,7 +12,8 @@ namespace Meilisearch
         public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int estimatedTotalHits,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
             int processingTimeMs, string query,
-            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion)
+            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> facetStats)
         {
             Hits = hits;
             Offset = offset;
@@ -22,6 +23,7 @@ namespace Meilisearch
             ProcessingTimeMs = processingTimeMs;
             Query = query;
             MatchesPostion = matchesPostion;
+            FacetStats = facetStats;
         }
 
         /// <summary>
@@ -71,5 +73,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("_matchesPosition")]
         public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
+
+        /// <summary>
+        /// Returns the numeric min and max values per facet of the hits returned by the search query.
+        /// </summary>
+        [JsonPropertyName("facetStats")]
+        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, float>> FacetStats { get; }
     }
 }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -333,8 +333,8 @@ namespace Meilisearch.Tests
             movies.Hits.Should().NotBeEmpty();
             movies.FacetDistribution.Should().NotBeEmpty();
             movies.FacetDistribution["id"].Should().NotBeEmpty();
-            Assert.Equal(10, movies.FacetStats["id"]["min"]);
-            Assert.Equal(16, movies.FacetStats["id"]["max"]);
+            Assert.Equal(10, movies.FacetStats["id"].Min);
+            Assert.Equal(16, movies.FacetStats["id"].Max);
         }
 
         [Fact]

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -316,6 +316,28 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task CustomSearchWithFacetStats()
+        {
+            var newFilters = new Settings
+            {
+                FilterableAttributes = new string[] { "id" },
+            };
+            var task = await _indexWithIntId.UpdateSettingsAsync(newFilters);
+            await _indexWithIntId.WaitForTaskAsync(task.TaskUid);
+            var movies = await _indexWithIntId.SearchAsync<MovieWithIntId>(
+                null,
+                new SearchQuery
+                {
+                    Facets = new string[] { "id" },
+                });
+            movies.Hits.Should().NotBeEmpty();
+            movies.FacetDistribution.Should().NotBeEmpty();
+            movies.FacetDistribution["id"].Should().NotBeEmpty();
+            Assert.Equal(10, movies.FacetStats["id"]["min"]);
+            Assert.Equal(16, movies.FacetStats["id"]["max"]);
+        }
+
+        [Fact]
         public async Task CustomSearchWithSort()
         {
             var newSortable = new Settings


### PR DESCRIPTION
As per [the specification](https://github.com/meilisearch/specifications/pull/224)
SDK requirements: https://github.com/meilisearch/integration-guides/issues/251

A new `facetStats` field is returned when `facets` is used in the search parameters and contains numerical values. The min and max numeric values of these facets will be returned.
