### PR TITLE
Add the ability to provide a specific csvDelimiter when adding and updating documents in CSV format

### DIFF
--- a/tests/Meilisearch.Tests/Datasets.cs
+++ b/tests/Meilisearch.Tests/Datasets.cs
@@ -10,6 +10,7 @@ namespace Meilisearch.Tests
         private static readonly string BasePath = Path.Combine(Directory.GetCurrentDirectory(), "Datasets");
         public static readonly string SmallMoviesJsonPath = Path.Combine(BasePath, "small_movies.json");
         public static readonly string SongsCsvPath = Path.Combine(BasePath, "songs.csv");
+        public static readonly string SongsCsvCustomDelimiterPath = Path.Combine(BasePath, "songs_custom_delimiter.csv");
         public static readonly string SongsNdjsonPath = Path.Combine(BasePath, "songs.ndjson");
 
         public static readonly string MoviesWithStringIdJsonPath = Path.Combine(BasePath, "movies_with_string_id.json");

--- a/tests/Meilisearch.Tests/Datasets/songs_custom_delimiter.csv
+++ b/tests/Meilisearch.Tests/Datasets/songs_custom_delimiter.csv
@@ -1,0 +1,28 @@
+id;title;album;artist;genre;country;released;duration;released-timestamp;duration-float
+702481615;Armatage Shanks;Dookie: The Ultimate Critical Review;Green Day;Rock;Europe;2005;;1104537600;
+888221515;Old Folks;Six Classic Albums Plus Bonus Tracks;Harold Land;Jazz;Europe;2013;6:36;1356998400;6.36
+1382413601;คำขอร้อง;สำเนียงคนจันทร์ / เอาเถอะถ้าเห็นเขาดีกว่า;อิทธิพล บำรุงกุล;"Folk; World; & Country";Thailand;;;;
+190889300;Track 1;Summer Breeze;Dreas;Funk / Soul;US;2008;18:56;1199145600;18.56
+813645611;Slave (Alternative Version);Honky Château;Elton John;Rock;Europe;;2:53;;2.5300000000000002
+394018506;Sex & Geld;Trackz Für Den Index;Mafia Clikk;Hip Hop;Germany;2006;5:02;1136073600;5.02
+1522481803;Pisciaunella;Don Pepp U Pacce;Giovanni Russo (2);"Folk; World; & Country";Italy;1980;;315532800;
+862296713;不知;Kiss 2001 Hong Kong Live Concert;Various;Electronic;Hong Kong;2002-04-13;;1018656000;
+467946423;Rot;Be Quick Or Be Dead Vol. 3;Various;Electronic;Serbia;2013-06-20;1:00;1371686400;1
+1323854803;"Simulation Project 1; ツキハナ「Moonflower」";Unlimited Dream Company;Amun Dragoon;Electronic;US;2018-04-10;2:44;1523318400;2.44
+235115704;Doctor Vine;The Big F;The Big F;Rock;US;1989;5:29;599616000;5.29
+249025232;"Ringel; Ringel; Reihe";Kinderlieder ABC - Der Bielefelder Kinderchor Singt 42 Lieder Von A-Z;Der Bielefelder Kinderchor;Children's;Germany;1971;;31536000;
+710094000;Happy Safari = Safari Feliz;Safari Swings Again = El Safari Sigue En Su Swing;Bert Kaempfert & His Orchestra;Jazz;Argentina;1977;2:45;220924800;2.45
+538632700;Take Me Up;Spring;Various;Electronic;US;2000;3:06;946684800;3.06
+1556505508;Doin To Me ( Radio Version );Say My Name;Netta Dogg;Hip Hop;US;2005;;1104537600;
+1067031900;Concerto For Balloon & Orchestra / Concerto For Synthesizer & Orchestra;Concerto For Balloon & Orchestra And Three Overtures;Stanyan String & Wind Ensemble;Classical;US;1977;;220924800;
+137251914;"I Love The Nightlife (Disco 'Round) (Real Rapino 7"" Mix)";The Adventures Of Priscilla: Queen Of The Desert - Original Motion Picture Soundtrack;Various;Stage & Screen;US;1994;3:31;757382400;3.31
+554983904;Walking On The Moon;Certifiable (Live In Buenos Aires);The Police;Rock;Malaysia;2008-11-00;;1225497600;
+557616002;Two Soldiers;Jerry Garcia / David Grisman;David Grisman;"Folk; World; & Country";US;2014-04-00;4:24;1396310400;4.24
+878936809;When You Gonna Learn;Live At Firenze 93;Jamiroquai;Funk / Soul;France;2004;13:01;1072915200;13.01
+368960707;Sardo D.O.C.;Sardinia Pride Compilation Vol.2;Various;Hip Hop;Italy;2012-06-22;4:41;1340323200;4.41
+1416041312;Sympathy For The Devil;Under Cover;Ozzy Osbourne;Rock;Russia;2005;7:11;1104537600;7.11
+1260509200;Grosse Overturen;noxious effects garanty;Nocif (3);Rock;France;1990;;631152000;
+1466381324;Πρινιώτης;Μουσικά Πατήματα Της Κρήτης;Αντώνης Μαρτσάκης;"Folk; World; & Country";Greece;2019;;1546300800;
+256009724;Here I Stand And Face The Rain (Demo);Hunting High And Low;a-ha;Electronic;UK & Europe;2010-07-23;;1279843200;
+565253008;Born Free;At His Best Goldfinger;The Royal Philharmonic Orchestra;Blues;Japan;1976;;189302400;
+492519701;Others;Where Did She Go;Stephan Sulke;Rock;US;1965;2:43;-157766400;2.43

--- a/tests/Meilisearch.Tests/Meilisearch.Tests.csproj
+++ b/tests/Meilisearch.Tests/Meilisearch.Tests.csproj
@@ -21,6 +21,7 @@
     <ItemGroup>
       <None Update="Datasets\small_movies.json" CopyToOutputDirectory="PreserveNewest" />
       <None Update="Datasets\songs.csv" CopyToOutputDirectory="PreserveNewest" />
+      <None Update="Datasets\songs_custom_delimiter.csv" CopyToOutputDirectory="PreserveNewest" />
       <None Update="Datasets\songs.ndjson" CopyToOutputDirectory="PreserveNewest" />
       <None Update="Datasets\movies_with_string_id.json" CopyToOutputDirectory="PreserveNewest" />
       <None Update="Datasets\movies_for_faceting.json" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
Add the ability to provide a CSV delimiter for adding and updating CSV documents as in the [specification](https://github.com/meilisearch/specifications/pull/221)

SDK requirements: https://github.com/meilisearch/integration-guides/issues/251

All these methods now have the ability to take a `csvDelimiter` argument as a char:
- `AddDocumentsCsvAsync()`
- `AddDocumentsCsvInBatchesAsync()`