### PR TITLE
Simplify construction of MeilisearchClient in DI

### DIFF
--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -29,13 +29,8 @@ namespace Meilisearch
         /// </summary>
         /// <param name="url">URL corresponding to Meilisearch server.</param>
         /// <param name="apiKey">API Key to connect to the Meilisearch server.</param>
-        public MeilisearchClient(string url, string apiKey = default)
+        public MeilisearchClient(string url, string apiKey = default) : this(new HttpClient(new MeilisearchMessageHandler(new HttpClientHandler())) { BaseAddress = url.ToSafeUri() }, apiKey)
         {
-            _http = new HttpClient(new MeilisearchMessageHandler(new HttpClientHandler())) { BaseAddress = url.ToSafeUri() };
-            _http.AddApiKeyToHeader(apiKey);
-            _http.AddDefaultUserAgent();
-            _taskEndpoint = null;
-            ApiKey = apiKey;
         }
 
         /// <summary>

--- a/src/Meilisearch/MeilisearchMessageHandler.cs
+++ b/src/Meilisearch/MeilisearchMessageHandler.cs
@@ -10,6 +10,15 @@ namespace Meilisearch
     /// </summary>
     public class MeilisearchMessageHandler : DelegatingHandler
     {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeilisearchMessageHandler"/> class.
+        /// Default message handler for Meilisearch API.
+        /// </summary>
+        public MeilisearchMessageHandler()
+        {
+        }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="MeilisearchMessageHandler"/> class.
         /// Default message handler for Meilisearch API.

--- a/src/Meilisearch/MeilisearchMessageHandler.cs
+++ b/src/Meilisearch/MeilisearchMessageHandler.cs
@@ -18,7 +18,7 @@ namespace Meilisearch
         public MeilisearchMessageHandler()
         {
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MeilisearchMessageHandler"/> class.
         /// Default message handler for Meilisearch API.


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes part of #481, which is the inability to use `.AddHttpMessageHandler<MeilisearchMessageHandler>()`

## What does this PR do?
- Adds default constructor for `MeilisearchMessageHandler`
- Refactor `MeilisearchClient` constructors to call one another, instead of redefining the logic in both.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
