### PR TITLE
Fixed breaking typo: rename `MatchesPostion` into `MatchesPosition`

### DIFF
--- a/src/Meilisearch/ISearchable.cs
+++ b/src/Meilisearch/ISearchable.cs
@@ -44,7 +44,7 @@ namespace Meilisearch
         /// Contains the location of each occurrence of queried terms across all fields.
         /// </summary>
         [JsonPropertyName("_matchesPosition")]
-        IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
+        IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPosition { get; }
 
         /// <summary>
         /// Returns the numeric min and max values per facet of the hits returned by the search query.

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -20,7 +20,7 @@ namespace Meilisearch
         /// <param name="facetDistribution"></param>
         /// <param name="processingTimeMs"></param>
         /// <param name="query"></param>
-        /// <param name="matchesPostion"></param>
+        /// <param name="matchesPosition"></param>
         /// <param name="facetStats"></param>
         /// <param name="indexUid"></param>
         public PaginatedSearchResult(

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -32,7 +32,7 @@ namespace Meilisearch
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
             int processingTimeMs,
             string query,
-            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion,
+            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPosition,
             IReadOnlyDictionary<string, FacetStat> facetStats,
             string indexUid
         )
@@ -45,7 +45,7 @@ namespace Meilisearch
             FacetDistribution = facetDistribution;
             ProcessingTimeMs = processingTimeMs;
             Query = query;
-            MatchesPostion = matchesPostion;
+            MatchesPosition = matchesPosition;
             FacetStats = facetStats;
             IndexUid = indexUid;
         }
@@ -92,7 +92,7 @@ namespace Meilisearch
 
         /// <inheritdoc/>
         [JsonPropertyName("_matchesPosition")]
-        public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
+        public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPosition { get; }
 
         /// <inheritdoc/>
         [JsonPropertyName("facetStats")]

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -25,7 +25,7 @@ namespace Meilisearch
         public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int estimatedTotalHits,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
             int processingTimeMs, string query,
-            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPostion,
+            IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPosition,
             IReadOnlyDictionary<string, FacetStat> facetStats,
             string indexUid)
         {
@@ -36,7 +36,7 @@ namespace Meilisearch
             FacetDistribution = facetDistribution;
             ProcessingTimeMs = processingTimeMs;
             Query = query;
-            MatchesPostion = matchesPostion;
+            MatchesPosition = matchesPosition;
             FacetStats = facetStats;
             IndexUid = indexUid;
         }
@@ -77,7 +77,7 @@ namespace Meilisearch
 
         /// <inheritdoc/>
         [JsonPropertyName("_matchesPosition")]
-        public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPostion { get; }
+        public IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> MatchesPosition { get; }
 
         /// <inheritdoc/>
         [JsonPropertyName("facetStats")]

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -19,7 +19,7 @@ namespace Meilisearch
         /// <param name="facetDistribution"></param>
         /// <param name="processingTimeMs"></param>
         /// <param name="query"></param>
-        /// <param name="matchesPostion"></param>
+        /// <param name="matchesPosition"></param>
         /// <param name="facetStats"></param>
         /// <param name="indexUid"></param>
         public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int estimatedTotalHits,


### PR DESCRIPTION
# Pull Request

Fixes #516 

- Fixed typo in property name matchesPostion
