### PR TITLE
Fixed missing TaskInfoStatus and TaskInfoType handling in ObjectExtesions

### DIFF
--- a/src/Meilisearch/Extensions/ObjectExtensions.cs
+++ b/src/Meilisearch/Extensions/ObjectExtensions.cs
@@ -56,6 +56,14 @@ namespace Meilisearch.Extensions
                             {
                                 values.Add(key + "=" + string.Join(",", (List<int>)value));
                             }
+                            else if (itemType == typeof(TaskInfoStatus))
+                            {
+                                values.Add(key + "=" + string.Join(",", ((List<TaskInfoStatus>)value).Select(x => x.ToString())));
+                            }
+                            else if (itemType == typeof(TaskInfoType))
+                            {
+                                values.Add(key + "=" + string.Join(",", ((List<TaskInfoType>)value).Select(x => x.ToString())));
+                            }
                         }
                         else if (value is DateTime)
                         {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #509

## What does this PR do?
- Adds handling for the missing types `TaskInfoStatus` and `TaskInfoType` in the `ToQueryString` method of `ObjectExtensions` class

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
