### PR TITLE
 Add parameter to show ranking score details to the search query

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -755,6 +755,12 @@ search_parameter_guide_show_ranking_score_1: |-
     ShowRankingScore = true
   };
   await client.Index("movies").SearchAsync<MovieWithRankingScore>("dragon", params);
+search_parameter_guide_show_ranking_score_details_1: |-
+  var params = new SearchQuery()
+  {
+    ShowRankingScoreDetails = true
+  };
+  await client.Index("movies").SearchAsync<MovieWithRankingScoreDetails>("dragon", params);
 get_proximity_precision_settings_1: |-
   await client.Index("books").GetProximityPrecisionAsync();
 update_proximity_precision_settings_1: |-

--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -104,6 +104,12 @@ namespace Meilisearch
         [JsonPropertyName("showRankingScore")]
         public bool? ShowRankingScore { get; set; }
 
+        /// <summary>
+        /// Gets or sets showRankingScoreDetails parameter. It defines whether details on how the ranking score was computed are returned or not.
+        /// </summary>
+        [JsonPropertyName("showRankingScoreDetails")]
+        public bool? ShowRankingScoreDetails { get; set; }
+
         // pagination:
 
         /// <summary>

--- a/tests/Meilisearch.Tests/Movie.cs
+++ b/tests/Meilisearch.Tests/Movie.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
 namespace Meilisearch.Tests
 {
     public class Movie
@@ -55,5 +58,15 @@ namespace Meilisearch.Tests
 
         public string Genre { get; set; }
         public double? _RankingScore { get; set; }
+    }
+
+    public class MovieWithRankingScoreDetails
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Genre { get; set; }
+        public IDictionary<string, JsonElement> _RankingScoreDetails { get; set; }
     }
 }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -505,6 +505,18 @@ namespace Meilisearch.Tests
             var movies = await _basicIndex.SearchAsync<MovieWithRankingScore>("iron man", searchQuery);
             Assert.NotNull(movies.Hits.First()._RankingScore);
         }
+
+        [Fact]
+        public async Task CustomSearchWithShowRankingScoreDetails()
+        {
+            var searchQuery = new SearchQuery()
+            {
+                ShowRankingScoreDetails = true
+            };
+            var movies = await _basicIndex.SearchAsync<MovieWithRankingScoreDetails>("iron man", searchQuery);
+            Assert.NotEmpty(movies.Hits.First()._RankingScoreDetails);
+        }
+
         [Fact]
         public async Task CustomSearchProductsWithoutDistinct()
         {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #530

## What does this PR do?
- Adds the showRankingScoreDetails parameter to the search query

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
