### PR TITLE
Fixed missing TaskInfoStatus and TaskInfoType handling in ObjectExtensions

### DIFF
--- a/src/Meilisearch/Extensions/ObjectExtensions.cs
+++ b/src/Meilisearch/Extensions/ObjectExtensions.cs
@@ -56,6 +56,14 @@ namespace Meilisearch.Extensions
                             {
                                 values.Add(key + "=" + string.Join(",", (List<int>)value));
                             }
+                            else if (itemType == typeof(TaskInfoStatus))
+                            {
+                                values.Add(key + "=" + string.Join(",", ((List<TaskInfoStatus>)value).Select(x => x.ToString())));
+                            }
+                            else if (itemType == typeof(TaskInfoType))
+                            {
+                                values.Add(key + "=" + string.Join(",", ((List<TaskInfoType>)value).Select(x => x.ToString())));
+                            }
                         }
                         else if (value is DateTime)
                         {

--- a/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
+++ b/tests/Meilisearch.Tests/ObjectExtensionsTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 
+using Meilisearch.Converters;
 using Meilisearch.Extensions;
 using Meilisearch.QueryParameters;
 
@@ -17,6 +19,8 @@ namespace Meilisearch.Tests
         public string FakeString { get; set; }
         public int? FakeInteger { get; set; }
         public List<string> FakeStringList { get; set; }
+        public List<TaskInfoStatus> FakeStatusList { get; set; }
+        public List<TaskInfoType> FakeTypeList { get; set; }
         public string Path { get; set; }
     }
 
@@ -39,6 +43,21 @@ namespace Meilisearch.Tests
             yield return new object[] {
                 new FakeQuery { FakeDate = date, FakeStringList = new List<string> { "hey", "ho" } },
                 $"fakeDate={Uri.EscapeDataString(date.ToString("yyyy-MM-dd'T'HH:mm:ss.fffzzz"))}&fakeStringList=hey,ho"
+            };
+
+            yield return new object[] {
+                new FakeQuery { FakeStatusList = new List<TaskInfoStatus> { TaskInfoStatus.Enqueued, TaskInfoStatus.Succeeded } },
+                "fakeStatusList=Enqueued,Succeeded"
+            };
+
+            yield return new object[] {
+                new FakeQuery { FakeTypeList = new List<TaskInfoType> { TaskInfoType.IndexCreation, TaskInfoType.DocumentDeletion } },
+                "fakeTypeList=IndexCreation,DocumentDeletion"
+            };
+
+            yield return new object[] {
+                new FakeQuery { FakeStatusList = new List<TaskInfoStatus> { TaskInfoStatus.Processing }, FakeTypeList = new List<TaskInfoType> { TaskInfoType.SettingsUpdate } },
+                "fakeStatusList=Processing&fakeTypeList=SettingsUpdate"
             };
         }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #509 

## What does this PR do?
- Adds 4 lines of code to include **TaskInfoStatus** and **TaskInfoType** in the respective function.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

![image](https://github.com/user-attachments/assets/dac1395b-210b-41b0-8205-1a12ef17ba4b)


Tests and formatted ran successfully

