### PR TITLE
fix for #577

### DIFF
--- a/src/Meilisearch/ISearchable.cs
+++ b/src/Meilisearch/ISearchable.cs
@@ -23,6 +23,24 @@ namespace Meilisearch
         IReadOnlyCollection<T> Hits { get; }
 
         /// <summary>
+        /// Number of documents skipped.
+        /// </summary>
+        [JsonPropertyName("offset")]
+        int Offset { get; }
+
+        /// <summary>
+        /// Number of documents to take.
+        /// </summary>
+        [JsonPropertyName("limit")]
+        int Limit { get; }
+
+        /// <summary>
+        /// Gets the estimated total number of hits returned by the search.
+        /// </summary>
+        [JsonPropertyName("estimatedTotalHits")]
+        int EstimatedTotalHits { get; }
+
+        /// <summary>
         /// Returns the number of documents matching the current search query for each given facet.
         /// </summary>
         [JsonPropertyName("facetDistribution")]

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -45,21 +45,15 @@ namespace Meilisearch
         [JsonPropertyName("hits")]
         public IReadOnlyCollection<T> Hits { get; }
 
-        /// <summary>
-        /// Number of documents skipped.
-        /// </summary>
+        /// <inheritdoc/>
         [JsonPropertyName("offset")]
         public int Offset { get; }
 
-        /// <summary>
-        /// Number of documents to take.
-        /// </summary>
+        /// <inheritdoc/>
         [JsonPropertyName("limit")]
         public int Limit { get; }
 
-        /// <summary>
-        /// Gets the estimated total number of hits returned by the search.
-        /// </summary>
+        /// <inheritdoc/>
         [JsonPropertyName("estimatedTotalHits")]
         public int EstimatedTotalHits { get; }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #577 

## What does this PR do?
- brings the `Offset`, `Limit` and `EstimatedTotalHits` fields to `ISearchable<T>`
- migrated fields in `SearchResult<T>` now use `/// <inheritdoc/>` as docs were also moved to `ISearchable<T>`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Not sure if `Offset` and `Limit` also need to ported up, but i could envision a scenario where it would be useful, so I brought them along too.
