### PR TITLE
Make RankingScoreThreshold optional

### DIFF
--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -147,6 +147,6 @@ namespace Meilisearch
         /// Gets or sets rankingScoreThreshold, a number between 0.0 and 1.0. 
         /// </summary>
         [JsonPropertyName("rankingScoreThreshold")]
-        public decimal RankingScoreThreshold { get; set; }
+        public decimal? RankingScoreThreshold { get; set; }
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #601 

## What does this PR do?
- make RankingScoreThreshold nullable (thereby optional and ignored by json convertor if left null)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Passes all current integration tests.
