### PR TITLE
Add documents and embbedings database metrics to IndexStats

### DIFF
--- a/src/Meilisearch/IndexStats.cs
+++ b/src/Meilisearch/IndexStats.cs
@@ -8,11 +8,15 @@ namespace Meilisearch
     /// </summary>
     public class IndexStats
     {
-        public IndexStats(int numberOfDocuments, bool isIndexing, IReadOnlyDictionary<string, int> fieldDistribution)
+        public IndexStats(int numberOfDocuments, bool isIndexing, IReadOnlyDictionary<string, int> fieldDistribution, long rawDocumentDbSize, long avgDocumentSize, int numberOfEmbeddedDocuments, int numberOfEmbeddings)
         {
             NumberOfDocuments = numberOfDocuments;
             IsIndexing = isIndexing;
             FieldDistribution = fieldDistribution;
+            RawDocumentDbSize = rawDocumentDbSize;
+            AvgDocumentSize = avgDocumentSize;
+            NumberOfEmbeddedDocuments = numberOfEmbeddedDocuments;
+            NumberOfEmbeddings = numberOfEmbeddings;
         }
 
         /// <summary>
@@ -32,5 +36,30 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("fieldDistribution")]
         public IReadOnlyDictionary<string, int> FieldDistribution { get; }
+
+        /// <summary>
+        /// Get the total size of the documents stored in Meilisearch
+        /// </summary>
+        [JsonPropertyName("rawDocumentDbSize")]
+        public long RawDocumentDbSize { get; }
+
+        /// <summary>
+        /// Get the total size of the documents stored in Meilisearch divided by the number of documents
+        /// </summary>
+        [JsonPropertyName("avgDocumentSize")]
+        public long AvgDocumentSize { get; }
+
+        /// <summary>
+        /// Get the number of document in index that contains at least one embedded representation
+        /// </summary>
+        [JsonPropertyName("numberOfEmbeddedDocuments")]
+        public int NumberOfEmbeddedDocuments { get; }
+
+
+        /// <summary>
+        /// Get the total number of embeddings representation that exists in that indexes
+        /// </summary>
+        [JsonPropertyName("numberOfEmbeddings")]
+        public int NumberOfEmbeddings { get; }
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #629
Fixes #628

## What does this PR do?

This pull request includes changes to the `IndexStats` class in the `Meilisearch` namespace to enhance its functionality by adding new properties. These changes aim to provide more detailed statistics about the indexed documents.

### Enhancements to `IndexStats` class:

* [`src/Meilisearch/IndexStats.cs`](diffhunk://#diff-c1df1350b10dfcd3601aae24cd48feba5dce4686d1a03f38fa9a6b9dae852f21L11-R19): Added new properties `RawDocumentDbSize`, `AvgDocumentSize`, `NumberOfEmbeddedDocuments`, and `NumberOfEmbeddings` to the `IndexStats` class. These properties provide additional insights into the size and structure of the indexed documents. [[1]](diffhunk://#diff-c1df1350b10dfcd3601aae24cd48feba5dce4686d1a03f38fa9a6b9dae852f21L11-R19) [[2]](diffhunk://#diff-c1df1350b10dfcd3601aae24cd48feba5dce4686d1a03f38fa9a6b9dae852f21R39-R63)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
