### PR TITLE
Add `UsedDatabaseSize` to `Stats`

### DIFF
--- a/src/Meilisearch/Stats.cs
+++ b/src/Meilisearch/Stats.cs
@@ -9,11 +9,12 @@ namespace Meilisearch
     /// </summary>
     public class Stats
     {
-        public Stats(long databaseSize, DateTime? lastUpdate, IReadOnlyDictionary<string, IndexStats> indexes)
+        public Stats(long databaseSize, DateTime? lastUpdate, IReadOnlyDictionary<string, IndexStats> indexes, long usedDatabaseSize)
         {
             DatabaseSize = databaseSize;
             LastUpdate = lastUpdate;
             Indexes = indexes;
+            UsedDatabaseSize = usedDatabaseSize;
         }
 
         /// <summary>
@@ -21,6 +22,12 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("databaseSize")]
         public long DatabaseSize { get; }
+
+        /// <summary>
+        /// Gets the total space used by the data stored in Meilisearch.
+        /// </summary>
+        [JsonPropertyName("usedDatabaseSize")]
+        public long UsedDatabaseSize { get; }
 
         /// <summary>
         /// Gets last update timestamp.


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #627


## What does this PR do?

This pull request introduces a new property to the `Stats` class in the `Meilisearch` namespace to track the total space used by the data stored in Meilisearch. The most important changes include updating the constructor and adding a new property with its corresponding documentation.

Enhancements to `Stats` class:

* [`src/Meilisearch/Stats.cs`](diffhunk://#diff-bad7203e43575ca251ab555f251d2de803abd3976f21c56288d7c8f9bb4e5e02L12-R17): Updated the `Stats` constructor to include a new parameter `usedDatabaseSize` and initialized the corresponding property.
* [`src/Meilisearch/Stats.cs`](diffhunk://#diff-bad7203e43575ca251ab555f251d2de803abd3976f21c56288d7c8f9bb4e5e02R26-R31): Added the `UsedDatabaseSize` property with its documentation and JSON property name attribute.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
