### PR TITLE
Add support for fetching documents by IDs using GetDocumentsAsync overload

### DIFF
--- a/src/Meilisearch/Index.Documents.cs
+++ b/src/Meilisearch/Index.Documents.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -412,6 +413,29 @@ namespace Meilisearch
                     .ConfigureAwait(false);
             }
         }
+
+        /// <summary>
+        /// Gets documents by list of Ids
+        /// </summary>
+        /// <param name="ids">Ids to be searched</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the list of documents.</returns>
+        public async Task<ResourceResults<IEnumerable<T>>> GetDocumentsAsync<T>(List<string> ids, CancellationToken cancellationToken = default)
+        {
+            if (ids == null || ids.Count == 0)
+                throw new ArgumentException("At least one ID must be provided.", nameof(ids));
+
+            var query = new DocumentsQuery { Ids = ids };
+
+            var uri = $"indexes/{Uid}/documents/fetch";
+            var result = await _http.PostAsJsonAsync(uri, query, Constants.JsonSerializerOptionsRemoveNulls,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            return await result.Content
+                .ReadFromJsonAsync<ResourceResults<IEnumerable<T>>>(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
 
         /// <summary>
         /// Delete one document.

--- a/src/Meilisearch/QueryParameters/DocumentsQuery.cs
+++ b/src/Meilisearch/QueryParameters/DocumentsQuery.cs
@@ -31,5 +31,11 @@ namespace Meilisearch.QueryParameters
         /// </summary>
         [JsonPropertyName("filter")]
         public object Filter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of Ids
+        /// </summary>
+        [JsonPropertyName("ids")]
+        public List<string> Ids { get; set; }
     }
 }

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -758,5 +758,31 @@ namespace Meilisearch.Tests
             var docs = await index.GetDocumentsAsync<Movie>();
             docs.Results.Should().BeEmpty();
         }
+
+        [Fact]
+        public async Task CanFetchMultipleDocumentsByIds()
+        {
+            var indexUID = nameof(CanFetchMultipleDocumentsByIds);
+            var index = _client.Index(indexUID);
+
+            var documents = new[]
+            {
+                new Movie { Id = "1", Name = "The Matrix" },
+                new Movie { Id = "2", Name = "Inception" },
+                new Movie { Id = "3", Name = "Arrival" }
+            };
+
+            var task = await index.AddDocumentsAsync(documents);
+            await index.WaitForTaskAsync(task.TaskUid);
+
+            // Fetch by IDs
+            var idsToFetch = new List<string> { "1", "3" };
+            var fetched = await index.GetDocumentsAsync<Movie>(idsToFetch);
+            var resultDocs = fetched.Results.ToList();
+
+            Assert.Equal(2, resultDocs.Count);
+            Assert.Contains(resultDocs, d => d.Id == "1" && d.Name == "The Matrix");
+            Assert.Contains(resultDocs, d => d.Id == "3" && d.Name == "Arrival");
+        }
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes [v1.14] Get documents by ID #646 

## What does this PR do?
This PR adds an overload to `GetDocumentsAsync<T>` that accepts a list of document IDs. This allows users to retrieve specific documents by ID using the `/documents/fetch` API endpoint, similar to the Meilisearch JS SDK.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!