### PR TITLE
Support structs as search result

### DIFF
--- a/src/Meilisearch/ISearchableJsonConverter.cs
+++ b/src/Meilisearch/ISearchableJsonConverter.cs
@@ -33,7 +33,7 @@ namespace Meilisearch
     /// The json converter for <see cref="ISearchable{T}"/>
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class ISearchableJsonConverter<T> : JsonConverter<ISearchable<T>> where T : class
+    public class ISearchableJsonConverter<T> : JsonConverter<ISearchable<T>>
     {
         /// <inheritdoc/>
         public override ISearchable<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/tests/Meilisearch.Tests/Movie.cs
+++ b/tests/Meilisearch.Tests/Movie.cs
@@ -12,6 +12,14 @@ namespace Meilisearch.Tests
         public string Genre { get; set; }
     }
 
+    public struct MovieStruct
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Genre { get; set; }
+    }
     public class MovieInfo
     {
         public string Comment { get; set; }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -46,6 +46,28 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task BasicSearchWithStruct()
+        {
+            var movies = await _basicIndex.SearchAsync<MovieStruct>("man");
+            movies.Hits.Should().NotBeEmpty();
+            movies.Hits.First().Name.Should().NotBeEmpty();
+            movies.Hits.ElementAt(1).Name.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public async Task PaginatedSearchWithStruct()
+        {
+            var movies = await _basicIndex.SearchAsync<MovieStruct>("man", new SearchQuery()
+            {
+                Page = 1,
+                HitsPerPage = 2,
+            });
+            movies.Hits.Should().NotBeEmpty();
+            movies.Hits.First().Name.Should().NotBeEmpty();
+            movies.Hits.ElementAt(1).Name.Should().NotBeEmpty();
+        }
+
+        [Fact]
         public async Task BasicSearchWithNoQuery()
         {
             var movies = await _basicIndex.SearchAsync<Movie>(null);


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This PR removes the class constraint on the `ISearchableJsonConverter` to allow using structs as the search result model (`T`).
The class constraint `where T : class` isn't present on anywhere else and therefore only breaks at runtime and as the JSON serializer can handle structs just fine this restriction isn't needed.

I've added some basic tests showing that the JSON converter works with structs.

## Current problem
To explain the current problem. When using a struct as the response model you'll get the following error when running a search query:
```stacktrace
System.ArgumentException : GenericArguments[0], 'Meilisearch.Tests.MovieStruct', on 'Meilisearch.ISearchableJsonConverter`1[T]' violates the constraint of type 'T'.
---- System.TypeLoadException : GenericArguments[0], 'Meilisearch.Tests.MovieStruct', on 'Meilisearch.ISearchableJsonConverter`1[T]' violates the constraint of type parameter 'T'.
```

Just removing the constraint on the converter removes the issue.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for searching and handling value types (structs) in search functionality.
- **Tests**
  - Introduced new tests to verify search operations using struct-based movie data, ensuring correct results and pagination with value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->