### PR TITLE
Fix tests for Meilisearch 1.16 CI

### DIFF
--- a/src/Meilisearch/Key.cs
+++ b/src/Meilisearch/Key.cs
@@ -80,6 +80,14 @@ namespace Meilisearch
         /// </summary>
         All,
         /// <summary>
+        /// Provides access to all get endpoints.
+        /// </summary>
+        AllGet,
+        /// <summary>
+        /// Provides access to chat completions endpoint.
+        /// </summary>
+        ChatCompletions,
+        /// <summary>
         /// Provides access to both POST and GET search endpoints.
         /// </summary>
         Search,


### PR DESCRIPTION
## Why

Fix tests to make Meilisearch 1.16 CI pass: https://github.com/meilisearch/meilisearch/actions/runs/16573762878/job/47016022240

## What does this PR do?
- Add AllGet key action for accessing all get endpoints
- Add ChatCompletions key action for chat completions endpoint
- Fixes compatibility issues with Meilisearch v1.16.0-rc.4

> [!note]
> I ran the tests locally with MEILISEARCH_VERSION=v1.16.0-rc.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new access options for API keys, including permissions for all GET endpoints and for chat completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->