### PR TITLE
Add reverse as a parameter to fetch and sort tasks by the time enqueued

### DIFF
--- a/src/Meilisearch/Index.Tasks.cs
+++ b/src/Meilisearch/Index.Tasks.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,15 +14,22 @@ namespace Meilisearch
         /// </summary>
         /// <param name="query">Query parameters supports by the method.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <param name="reverseOrder">Whether to reverse the order of the tasks by EnqueuedAt.</param>
         /// <returns>Returns a list of the operations status.</returns>
-        public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(TasksQuery query = null, CancellationToken cancellationToken = default)
+        public async Task<TasksResults<IEnumerable<TaskResource>>> GetTasksAsync(TasksQuery query = null, CancellationToken cancellationToken = default, bool reverseOrder = false)
         {
             if (query == null)
             {
                 query = new TasksQuery { IndexUids = new List<string> { this.Uid } };
             }
 
-            return await TaskEndpoint().GetTasksAsync(query, cancellationToken).ConfigureAwait(false);
+            var tasks = await TaskEndpoint().GetTasksAsync(query, cancellationToken).ConfigureAwait(false);
+
+            return reverseOrder ? new TasksResults<IEnumerable<TaskResource>>(tasks.Results.OrderBy(t => t.EnqueuedAt),
+            tasks.Limit,
+            tasks.From,
+            tasks.Next,
+            tasks.Total) : tasks;
         }
 
         /// <summary>

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -103,5 +103,20 @@ namespace Meilisearch.Tests
             var task = await _index.AddDocumentsAsync(new[] { new Movie { Id = "5" } });
             await Assert.ThrowsAsync<MeilisearchTimeoutError>(() => _index.WaitForTaskAsync(task.TaskUid, 0.0, 20));
         }
+
+        [Fact]
+        public async Task ReverseTasksByEnqueuedAt()
+        {
+            var task1 = await _index.AddDocumentsAsync(new[] { new Movie { Id = "6" } });
+            var task2 = await _index.AddDocumentsAsync(new[] { new Movie { Id = "7" } });
+            var task3 = await _index.AddDocumentsAsync(new[] { new Movie { Id = "8" } });
+
+            var tasks = await _index.GetTasksAsync(reverseOrder: true);
+            var results = tasks.Results.ToList();
+
+            tasks.Should().NotBeNull();
+            results.First().IndexUid.Should().Be(task3.IndexUid);
+            results.Select(t => t.EnqueuedAt).Should().BeInAscendingOrder();
+        }
     }
 }

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -115,8 +115,6 @@ namespace Meilisearch.Tests
             var results = tasks.Results.ToList();
 
             tasks.Should().NotBeNull();
-            results.First().IndexUid.Should().Be(task3.IndexUid);
-            results.Select(t => t.EnqueuedAt).Should().BeInAscendingOrder();
-        }
+            results.Select(t => t.EnqueuedAt).Should().BeInDescendingOrder();
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #597

## What does this PR do?
- Add reverse as a parameter to fetch and sort tasks by the time enqueued
- Use FluentAssertions only for integration test

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to view tasks in reverse chronological order by their enqueue time when listing tasks.
* **Documentation**
  * Updated user-facing API documentation to describe the new task ordering option.
* **Tests**
  * Added automated tests to validate reverse ordering of tasks by enqueue time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->