### PR TITLE
Fix index swap tests

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1,0 +1,6 @@
+---
+alwaysApply: true
+---
+
+- Use Docker for local development
+- Run tests with `docker-compose run --rm package bash -c "dotnet test && dotnet format --verbosity normal --verify-no-changes"`

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
       - name: Meilisearch (latest version) setup with Docker
+        env:
+          # Any docker tag is actually accepted as a valid version
+          MEILISEARCH_VERSION: latest
         run: docker compose up -d
       - name: Run tests
         run: dotnet test --no-restore --verbosity normal

--- a/src/Meilisearch/IndexSwap.cs
+++ b/src/Meilisearch/IndexSwap.cs
@@ -11,9 +11,13 @@ namespace Meilisearch
         [JsonPropertyName("indexes")]
         public List<string> Indexes { get; private set; }
 
-        public IndexSwap(string indexA, string indexB)
+        [JsonPropertyName("rename")]
+        public bool Rename { get; set; } = false;
+
+        public IndexSwap(string indexA, string indexB, bool rename = false)
         {
             this.Indexes = new List<string> { indexA, indexB };
+            this.Rename = rename;
         }
     }
 }

--- a/tests/Meilisearch.Tests/IndexSwapTest.cs
+++ b/tests/Meilisearch.Tests/IndexSwapTest.cs
@@ -22,6 +22,17 @@ namespace Meilisearch.Tests
 
             var json = JsonSerializer.Serialize(swap);
             Assert.Contains("\"indexes\":[\"indexA\",\"indexB\"]", json);
+            Assert.Contains("\"rename\":false", json);
+        }
+
+        [Fact]
+        public void CreateExpectedJSONFormatWithRenameTrue()
+        {
+            var swap = new IndexSwap("indexA", "indexB", rename: true);
+
+            var json = JsonSerializer.Serialize(swap);
+            Assert.Contains("\"indexes\":[\"indexA\",\"indexB\"]", json);
+            Assert.Contains("\"rename\":true", json);
         }
     }
 }


### PR DESCRIPTION
Fixes #668 

## how

- update CI tests to use `meilisearch:latest` Docker image
- update index swap/renames tests to pass with the latest version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an optional “rename” parameter to index-swap operations, enabling swaps that also rename the destination.

- Documentation
  - Added local development guidance using Docker, including commands to run tests and formatting checks.

- Tests
  - Added unit tests verifying JSON output and behavior for the “rename” option.

- Chores
  - CI updated to standardize the Meilisearch Docker version used in integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->