### PR TITLE
feat: search query filter builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,63 @@ JSON Output:
 }
 ```
 
+#### Using SearchQueryFilterBuilder <!-- omit in toc -->
+
+Instead of writing filter strings manually, you can use the fluent `SearchQueryFilterBuilder` to construct type-safe filter expressions:
+
+```c#
+using Meilisearch;
+
+// Simple equality filter
+var filter = SearchQueryFilterBuilder.Where("genre", "Action");
+// Result: "genre = Action"
+
+// Comparison operators
+var filter = SearchQueryFilterBuilder.WhereGreaterThan("rating", 85);
+// Result: "rating > 85"
+
+// IN operator for multiple values
+var filter = SearchQueryFilterBuilder.WhereIn("genre", "horror", "comedy", "action");
+// Result: "genre IN [horror, comedy, action]"
+
+// Combine filters with AND
+var filter = SearchQueryFilterBuilder.Where("genre", "Action")
+    .And(SearchQueryFilterBuilder.WhereGreaterThan("rating", 80));
+// Result: "genre = Action AND rating > 80"
+
+// Combine filters with OR and group them
+var filter = SearchQueryFilterBuilder.GroupOr(
+    SearchQueryFilterBuilder.Where("genre", "horror"),
+    SearchQueryFilterBuilder.Where("genre", "comedy")
+).And(SearchQueryFilterBuilder.WhereGreaterThan("release_date", 795484800));
+// Result: "(genre = horror OR genre = comedy) AND release_date > 795484800"
+
+// Geo radius search
+var filter = SearchQueryFilterBuilder.WhereGeoRadius(45.4777599, 9.1967508, 2000);
+// Result: "_geoRadius(45.4777599, 9.1967508, 2000)"
+
+// Use in search query
+var movies = await index.SearchAsync<Movie>(
+    "wonder",
+    new SearchQuery
+    {
+        Filter = SearchQueryFilterBuilder.Where("genre", "Action")
+            .And(SearchQueryFilterBuilder.WhereGreaterThan("id", 1))
+            .Build()
+    }
+);
+```
+
+The `SearchQueryFilterBuilder` supports the following operations:
+- **Equality**: `Where`, `WhereNot`
+- **Comparison**: `WhereGreaterThan`, `WhereGreaterThanOrEqual`, `WhereLessThan`, `WhereLessThanOrEqual`
+- **Range**: `WhereBetween`
+- **List**: `WhereIn`
+- **Existence**: `WhereExists`, `WhereNotExists`
+- **Empty/Null checks**: `WhereEmpty`, `WhereNotEmpty`, `WhereNull`, `WhereNotNull`
+- **Geo filters**: `WhereGeoRadius`, `WhereGeoBoundingBox`
+- **Logical operators**: `And`, `Or`, `Not`, `Group`, `GroupAnd`, `GroupOr`
+
 #### Search with Limit and Offset
 
 You can paginate search results by making queries combining both [offset](https://www.meilisearch.com/docs/reference/api/search#offset) and [limit](https://www.meilisearch.com/docs/reference/api/search#limit).

--- a/src/Meilisearch/SearchQueryFilterBuilder.cs
+++ b/src/Meilisearch/SearchQueryFilterBuilder.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Meilisearch
+{
+    /// <summary>
+    /// A fluent builder for creating Meilisearch filter expressions.
+    /// </summary>
+    public class SearchQueryFilterBuilder
+    {
+        private readonly string _expression;
+
+        private SearchQueryFilterBuilder(string expression)
+        {
+            _expression = expression;
+        }
+
+        /// <summary>
+        /// Creates an empty filter builder.
+        /// </summary>
+        public SearchQueryFilterBuilder()
+        {
+            _expression = string.Empty;
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute equals the specified value.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder Where(string attribute, object value)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} = {FormatValue(value)}");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute does not equal the specified value.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereNot(string attribute, object value)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} != {FormatValue(value)}");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute is greater than the specified value.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereGreaterThan(string attribute, object value)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} > {FormatValue(value)}");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute is greater than or equal to the specified value.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereGreaterThanOrEqual(string attribute, object value)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} >= {FormatValue(value)}");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute is less than the specified value.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereLessThan(string attribute, object value)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} < {FormatValue(value)}");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute is less than or equal to the specified value.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereLessThanOrEqual(string attribute, object value)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} <= {FormatValue(value)}");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute value is between two values (inclusive).
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="from">The lower bound value.</param>
+        /// <param name="to">The upper bound value.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereBetween(string attribute, object from, object to)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} {FormatValue(from)} TO {FormatValue(to)}");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute value is in the specified list.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="values">The list of values.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereIn(string attribute, params object[] values)
+        {
+            var formattedValues = string.Join(", ", values.Select(FormatValue));
+            return new SearchQueryFilterBuilder($"{attribute} IN [{formattedValues}]");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute value is in the specified list.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <param name="values">The list of values.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereIn(string attribute, IEnumerable<object> values)
+        {
+            return WhereIn(attribute, values.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute exists.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereExists(string attribute)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} EXISTS");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute does not exist.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereNotExists(string attribute)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} NOT EXISTS");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute is empty.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereEmpty(string attribute)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} IS EMPTY");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute is not empty.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereNotEmpty(string attribute)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} IS NOT EMPTY");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute is null.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereNull(string attribute)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} IS NULL");
+        }
+
+        /// <summary>
+        /// Creates a filter expression where the attribute is not null.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereNotNull(string attribute)
+        {
+            return new SearchQueryFilterBuilder($"{attribute} IS NOT NULL");
+        }
+
+        /// <summary>
+        /// Creates a geo radius filter expression.
+        /// </summary>
+        /// <param name="latitude">The latitude of the center point.</param>
+        /// <param name="longitude">The longitude of the center point.</param>
+        /// <param name="radiusInMeters">The radius in meters.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereGeoRadius(double latitude, double longitude, double radiusInMeters)
+        {
+            var lat = latitude.ToString(CultureInfo.InvariantCulture);
+            var lng = longitude.ToString(CultureInfo.InvariantCulture);
+            var radius = radiusInMeters.ToString(CultureInfo.InvariantCulture);
+            return new SearchQueryFilterBuilder($"_geoRadius({lat}, {lng}, {radius})");
+        }
+
+        /// <summary>
+        /// Creates a geo bounding box filter expression.
+        /// </summary>
+        /// <param name="topLeftLatitude">The latitude of the top-left corner.</param>
+        /// <param name="topLeftLongitude">The longitude of the top-left corner.</param>
+        /// <param name="bottomRightLatitude">The latitude of the bottom-right corner.</param>
+        /// <param name="bottomRightLongitude">The longitude of the bottom-right corner.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder WhereGeoBoundingBox(
+            double topLeftLatitude,
+            double topLeftLongitude,
+            double bottomRightLatitude,
+            double bottomRightLongitude)
+        {
+            var topLeftLat = topLeftLatitude.ToString(CultureInfo.InvariantCulture);
+            var topLeftLng = topLeftLongitude.ToString(CultureInfo.InvariantCulture);
+            var bottomRightLat = bottomRightLatitude.ToString(CultureInfo.InvariantCulture);
+            var bottomRightLng = bottomRightLongitude.ToString(CultureInfo.InvariantCulture);
+            return new SearchQueryFilterBuilder($"_geoBoundingBox([{topLeftLat}, {topLeftLng}], [{bottomRightLat}, {bottomRightLng}])");
+        }
+
+        /// <summary>
+        /// Combines this filter with another filter using AND.
+        /// </summary>
+        /// <param name="other">The other filter builder.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public SearchQueryFilterBuilder And(SearchQueryFilterBuilder other)
+        {
+            if (string.IsNullOrEmpty(_expression))
+            {
+                return other;
+            }
+
+            if (string.IsNullOrEmpty(other._expression))
+            {
+                return this;
+            }
+
+            return new SearchQueryFilterBuilder($"{_expression} AND {other._expression}");
+        }
+
+        /// <summary>
+        /// Combines this filter with another filter using OR.
+        /// </summary>
+        /// <param name="other">The other filter builder.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public SearchQueryFilterBuilder Or(SearchQueryFilterBuilder other)
+        {
+            if (string.IsNullOrEmpty(_expression))
+            {
+                return other;
+            }
+
+            if (string.IsNullOrEmpty(other._expression))
+            {
+                return this;
+            }
+
+            return new SearchQueryFilterBuilder($"{_expression} OR {other._expression}");
+        }
+
+        /// <summary>
+        /// Negates the current filter expression.
+        /// </summary>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public SearchQueryFilterBuilder Not()
+        {
+            if (string.IsNullOrEmpty(_expression))
+            {
+                return this;
+            }
+
+            return new SearchQueryFilterBuilder($"NOT {_expression}");
+        }
+
+        /// <summary>
+        /// Groups the current filter expression with parentheses.
+        /// </summary>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public SearchQueryFilterBuilder Group()
+        {
+            if (string.IsNullOrEmpty(_expression))
+            {
+                return this;
+            }
+
+            return new SearchQueryFilterBuilder($"({_expression})");
+        }
+
+        /// <summary>
+        /// Creates a grouped filter expression from multiple filters combined with AND.
+        /// </summary>
+        /// <param name="filters">The filters to combine.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder GroupAnd(params SearchQueryFilterBuilder[] filters)
+        {
+            var combined = filters.Aggregate(new SearchQueryFilterBuilder(), (current, filter) => current.And(filter));
+            return combined.Group();
+        }
+
+        /// <summary>
+        /// Creates a grouped filter expression from multiple filters combined with OR.
+        /// </summary>
+        /// <param name="filters">The filters to combine.</param>
+        /// <returns>A new FilterBuilder instance.</returns>
+        public static SearchQueryFilterBuilder GroupOr(params SearchQueryFilterBuilder[] filters)
+        {
+            var combined = filters.Aggregate(new SearchQueryFilterBuilder(), (current, filter) => current.Or(filter));
+            return combined.Group();
+        }
+
+        /// <summary>
+        /// Builds and returns the filter expression string.
+        /// </summary>
+        /// <returns>The filter expression string.</returns>
+        public string Build()
+        {
+            return _expression;
+        }
+
+        /// <summary>
+        /// Implicitly converts the FilterBuilder to a string.
+        /// </summary>
+        /// <param name="builder">The filter builder.</param>
+        public static implicit operator string(SearchQueryFilterBuilder builder)
+        {
+            return builder?.Build() ?? string.Empty;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return _expression;
+        }
+
+        private static string FormatValue(object value)
+        {
+            if (value == null)
+            {
+                return "null";
+            }
+
+            if (value is string s)
+            {
+                return FormatStringValue(s);
+            }
+
+            if (value is bool b)
+            {
+                return b ? "true" : "false";
+            }
+
+            if (value is int i)
+            {
+                return i.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is long l)
+            {
+                return l.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is float f)
+            {
+                return f.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is double d)
+            {
+                return d.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is decimal dec)
+            {
+                return dec.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is DateTime dt)
+            {
+                return ((DateTimeOffset)dt).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is DateTimeOffset dto)
+            {
+                return dto.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+            }
+
+            return FormatStringValue(value.ToString());
+        }
+
+        private static string FormatStringValue(string value)
+        {
+            // If the value contains spaces or special characters, wrap in single quotes
+            if (value.Contains(' ') || value.Contains('\'') || value.Contains('"'))
+            {
+                // Escape single quotes by doubling them
+                var escaped = value.Replace("'", "''");
+                return $"'{escaped}'";
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Meilisearch/SearchQueryFilterBuilder.cs
+++ b/src/Meilisearch/SearchQueryFilterBuilder.cs
@@ -229,6 +229,11 @@ namespace Meilisearch
         /// <returns>A new FilterBuilder instance.</returns>
         public SearchQueryFilterBuilder And(SearchQueryFilterBuilder other)
         {
+            if (other == null)
+            {
+                return this;
+            }
+
             if (string.IsNullOrEmpty(_expression))
             {
                 return other;
@@ -249,6 +254,11 @@ namespace Meilisearch
         /// <returns>A new FilterBuilder instance.</returns>
         public SearchQueryFilterBuilder Or(SearchQueryFilterBuilder other)
         {
+            if (other == null)
+            {
+                return this;
+            }
+
             if (string.IsNullOrEmpty(_expression))
             {
                 return other;
@@ -394,10 +404,10 @@ namespace Meilisearch
         private static string FormatStringValue(string value)
         {
             // If the value contains spaces or special characters, wrap in single quotes
-            if (value.Contains(' ') || value.Contains('\'') || value.Contains('"'))
+            if (value.Contains(' ') || value.Contains('\'') || value.Contains('"') || value.Contains('\\'))
             {
-                // Escape single quotes by doubling them
-                var escaped = value.Replace("'", "''");
+                // Escape backslashes first, then single quotes (Meilisearch uses backslash escaping)
+                var escaped = value.Replace("\\", "\\\\").Replace("'", "\\'");
                 return $"'{escaped}'";
             }
 

--- a/tests/Meilisearch.Tests/SearchQueryFilterBuilderTests.cs
+++ b/tests/Meilisearch.Tests/SearchQueryFilterBuilderTests.cs
@@ -1,0 +1,340 @@
+using System;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Meilisearch.Tests
+{
+    public class SearchQueryFilterBuilderTests
+    {
+        [Fact]
+        public void Where_WithStringValue_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.Where("genre", "SF");
+
+            filter.Build().Should().Be("genre = SF");
+        }
+
+        [Fact]
+        public void Where_WithStringValueContainingSpaces_ReturnsQuotedExpression()
+        {
+            var filter = SearchQueryFilterBuilder.Where("genre", "sci fi");
+
+            filter.Build().Should().Be("genre = 'sci fi'");
+        }
+
+        [Fact]
+        public void Where_WithIntValue_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.Where("id", 12);
+
+            filter.Build().Should().Be("id = 12");
+        }
+
+        [Fact]
+        public void Where_WithBoolValue_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.Where("isActive", true);
+
+            filter.Build().Should().Be("isActive = true");
+        }
+
+        [Fact]
+        public void WhereNot_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereNot("genre", "horror");
+
+            filter.Build().Should().Be("genre != horror");
+        }
+
+        [Fact]
+        public void WhereGreaterThan_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereGreaterThan("rating", 85);
+
+            filter.Build().Should().Be("rating > 85");
+        }
+
+        [Fact]
+        public void WhereGreaterThanOrEqual_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereGreaterThanOrEqual("rating", 85);
+
+            filter.Build().Should().Be("rating >= 85");
+        }
+
+        [Fact]
+        public void WhereLessThan_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereLessThan("rating", 50);
+
+            filter.Build().Should().Be("rating < 50");
+        }
+
+        [Fact]
+        public void WhereLessThanOrEqual_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereLessThanOrEqual("rating", 50);
+
+            filter.Build().Should().Be("rating <= 50");
+        }
+
+        [Fact]
+        public void WhereBetween_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereBetween("rating", 80, 89);
+
+            filter.Build().Should().Be("rating 80 TO 89");
+        }
+
+        [Fact]
+        public void WhereIn_WithParamsArray_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereIn("genre", "horror", "comedy", "action");
+
+            filter.Build().Should().Be("genre IN [horror, comedy, action]");
+        }
+
+        [Fact]
+        public void WhereIn_WithMixedValues_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereIn("id", 1, 2, 3);
+
+            filter.Build().Should().Be("id IN [1, 2, 3]");
+        }
+
+        [Fact]
+        public void WhereExists_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereExists("release_date");
+
+            filter.Build().Should().Be("release_date EXISTS");
+        }
+
+        [Fact]
+        public void WhereNotExists_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereNotExists("release_date");
+
+            filter.Build().Should().Be("release_date NOT EXISTS");
+        }
+
+        [Fact]
+        public void WhereEmpty_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereEmpty("overview");
+
+            filter.Build().Should().Be("overview IS EMPTY");
+        }
+
+        [Fact]
+        public void WhereNotEmpty_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereNotEmpty("overview");
+
+            filter.Build().Should().Be("overview IS NOT EMPTY");
+        }
+
+        [Fact]
+        public void WhereNull_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereNull("overview");
+
+            filter.Build().Should().Be("overview IS NULL");
+        }
+
+        [Fact]
+        public void WhereNotNull_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereNotNull("overview");
+
+            filter.Build().Should().Be("overview IS NOT NULL");
+        }
+
+        [Fact]
+        public void WhereGeoRadius_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereGeoRadius(45.4777599, 9.1967508, 2000);
+
+            filter.Build().Should().Be("_geoRadius(45.4777599, 9.1967508, 2000)");
+        }
+
+        [Fact]
+        public void WhereGeoBoundingBox_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereGeoBoundingBox(45.494181, 9.179175, 45.449484, 9.234175);
+
+            filter.Build().Should().Be("_geoBoundingBox([45.494181, 9.179175], [45.449484, 9.234175])");
+        }
+
+        [Fact]
+        public void And_CombinesTwoFilters()
+        {
+            var filter = SearchQueryFilterBuilder.Where("genre", "SF")
+                .And(SearchQueryFilterBuilder.WhereGreaterThan("id", 12));
+
+            filter.Build().Should().Be("genre = SF AND id > 12");
+        }
+
+        [Fact]
+        public void Or_CombinesTwoFilters()
+        {
+            var filter = SearchQueryFilterBuilder.Where("genre", "horror")
+                .Or(SearchQueryFilterBuilder.Where("genre", "comedy"));
+
+            filter.Build().Should().Be("genre = horror OR genre = comedy");
+        }
+
+        [Fact]
+        public void Not_NegatesFilter()
+        {
+            var filter = SearchQueryFilterBuilder.Where("genre", "horror").Not();
+
+            filter.Build().Should().Be("NOT genre = horror");
+        }
+
+        [Fact]
+        public void Group_WrapsFilterInParentheses()
+        {
+            var filter = SearchQueryFilterBuilder.Where("genre", "horror")
+                .Or(SearchQueryFilterBuilder.Where("genre", "comedy"))
+                .Group();
+
+            filter.Build().Should().Be("(genre = horror OR genre = comedy)");
+        }
+
+        [Fact]
+        public void GroupOr_CombinesFiltersWithOrAndGroups()
+        {
+            var filter = SearchQueryFilterBuilder.GroupOr(
+                SearchQueryFilterBuilder.Where("genre", "horror"),
+                SearchQueryFilterBuilder.Where("genre", "comedy")
+            );
+
+            filter.Build().Should().Be("(genre = horror OR genre = comedy)");
+        }
+
+        [Fact]
+        public void GroupAnd_CombinesFiltersWithAndAndGroups()
+        {
+            var filter = SearchQueryFilterBuilder.GroupAnd(
+                SearchQueryFilterBuilder.Where("genre", "SF"),
+                SearchQueryFilterBuilder.WhereGreaterThan("rating", 85)
+            );
+
+            filter.Build().Should().Be("(genre = SF AND rating > 85)");
+        }
+
+        [Fact]
+        public void ComplexExpression_WithAndOrAndGroup()
+        {
+            // (genres = horror OR genres = comedy) AND release_date > 795484800
+            var filter = SearchQueryFilterBuilder.GroupOr(
+                    SearchQueryFilterBuilder.Where("genres", "horror"),
+                    SearchQueryFilterBuilder.Where("genres", "comedy"))
+                .And(SearchQueryFilterBuilder.WhereGreaterThan("release_date", 795484800));
+
+            filter.Build().Should().Be("(genres = horror OR genres = comedy) AND release_date > 795484800");
+        }
+
+        [Fact]
+        public void ComplexExpression_WithMultipleConditions()
+        {
+            // genre = SF AND id > 12 AND rating >= 80
+            var filter = SearchQueryFilterBuilder.Where("genre", "SF")
+                .And(SearchQueryFilterBuilder.WhereGreaterThan("id", 12))
+                .And(SearchQueryFilterBuilder.WhereGreaterThanOrEqual("rating", 80));
+
+            filter.Build().Should().Be("genre = SF AND id > 12 AND rating >= 80");
+        }
+
+        [Fact]
+        public void ImplicitStringConversion_Works()
+        {
+            string filter = SearchQueryFilterBuilder.Where("genre", "SF");
+
+            filter.Should().Be("genre = SF");
+        }
+
+        [Fact]
+        public void ToString_ReturnsExpression()
+        {
+            var filter = SearchQueryFilterBuilder.Where("genre", "SF");
+
+            filter.ToString().Should().Be("genre = SF");
+        }
+
+        [Fact]
+        public void Where_WithDateTime_ConvertsToUnixTimestamp()
+        {
+            var date = new DateTime(1995, 3, 18, 0, 0, 0, DateTimeKind.Utc);
+            var filter = SearchQueryFilterBuilder.WhereGreaterThan("release_date", date);
+
+            // 795484800 is the Unix timestamp for 1995-03-18
+            filter.Build().Should().Be("release_date > 795484800");
+        }
+
+        [Fact]
+        public void Where_WithDateTimeOffset_ConvertsToUnixTimestamp()
+        {
+            var date = new DateTimeOffset(1995, 3, 18, 0, 0, 0, TimeSpan.Zero);
+            var filter = SearchQueryFilterBuilder.WhereGreaterThan("release_date", date);
+
+            filter.Build().Should().Be("release_date > 795484800");
+        }
+
+        [Fact]
+        public void Where_WithNestedAttribute_ReturnsCorrectExpression()
+        {
+            var filter = SearchQueryFilterBuilder.WhereGreaterThan("rating.users", 85);
+
+            filter.Build().Should().Be("rating.users > 85");
+        }
+
+        [Fact]
+        public void Where_WithSingleQuoteInValue_EscapesCorrectly()
+        {
+            var filter = SearchQueryFilterBuilder.Where("title", "Jordan's Movie");
+
+            filter.Build().Should().Be("title = 'Jordan''s Movie'");
+        }
+
+        [Fact]
+        public void EmptyFilterBuilder_And_ReturnsOther()
+        {
+            var empty = new SearchQueryFilterBuilder();
+            var other = SearchQueryFilterBuilder.Where("genre", "SF");
+
+            var result = empty.And(other);
+
+            result.Build().Should().Be("genre = SF");
+        }
+
+        [Fact]
+        public void EmptyFilterBuilder_Or_ReturnsOther()
+        {
+            var empty = new SearchQueryFilterBuilder();
+            var other = SearchQueryFilterBuilder.Where("genre", "SF");
+
+            var result = empty.Or(other);
+
+            result.Build().Should().Be("genre = SF");
+        }
+
+        [Fact]
+        public void FilterBuilder_CanBeUsedInSearchQuery()
+        {
+            var filter = SearchQueryFilterBuilder.Where("genre", "SF")
+                .And(SearchQueryFilterBuilder.WhereGreaterThan("id", 12));
+
+            var query = new SearchQuery
+            {
+                Q = "batman",
+                Filter = filter.Build()
+            };
+
+            ((string)query.Filter).Should().Be("genre = SF AND id > 12");
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Adds a fluent search query filter builder for the .NET Meilisearch client, making it easier to construct complex filter expressions in a type-safe way
- Includes unit tests covering common filter scenarios (comparison operators, logical groups, IN/NOT IN style filters, etc.)
- Updates the README with a short usage example of the new filter builder

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fluent search filter builder supporting equality, comparisons, ranges, list membership, existence/empty/null checks, geo queries, grouping, and logical operators.

* **Documentation**
  * Added comprehensive examples showing how to construct and apply complex filter expressions using the new builder (documentation examples duplicated in two places).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->