### PR TITLE
Add showPerformanceDetails option to search endpoints

### DIFF
--- a/src/Meilisearch/ISearchable.cs
+++ b/src/Meilisearch/ISearchable.cs
@@ -51,5 +51,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("facetStats")]
         IReadOnlyDictionary<string, FacetStat> FacetStats { get; }
+
+        /// <summary>
+        /// Gets the performance details.
+        /// </summary>
+        [JsonPropertyName("performanceDetails")]
+        IReadOnlyDictionary<string, string> PerformanceDetails { get; }
     }
 }

--- a/src/Meilisearch/MultiSearchFederationOptions.cs
+++ b/src/Meilisearch/MultiSearchFederationOptions.cs
@@ -1,7 +1,4 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
-
-using Meilisearch.Converters;
 
 namespace Meilisearch
 {
@@ -21,5 +18,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("limit")]
         public int Limit { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to retrieve performance details.
+        /// </summary>
+        [JsonPropertyName("showPerformanceDetails")]
+        public bool ShowPerformanceDetails { get; set; }
     }
 }

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -23,7 +23,7 @@ namespace Meilisearch
         /// <param name="matchesPosition"></param>
         /// <param name="facetStats"></param>
         /// <param name="indexUid"></param>
-        /// <param name="performanceDetails"></param>"
+        /// <param name="performanceDetails"></param>
         public PaginatedSearchResult(
             IReadOnlyCollection<T> hits,
             int hitsPerPage,

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -23,6 +23,7 @@ namespace Meilisearch
         /// <param name="matchesPosition"></param>
         /// <param name="facetStats"></param>
         /// <param name="indexUid"></param>
+        /// <param name="performanceDetails"></param>"
         public PaginatedSearchResult(
             IReadOnlyCollection<T> hits,
             int hitsPerPage,
@@ -34,7 +35,8 @@ namespace Meilisearch
             string query,
             IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPosition,
             IReadOnlyDictionary<string, FacetStat> facetStats,
-            string indexUid
+            string indexUid,
+            IReadOnlyDictionary<string, string> performanceDetails
         )
         {
             Hits = hits;
@@ -48,6 +50,7 @@ namespace Meilisearch
             MatchesPosition = matchesPosition;
             FacetStats = facetStats;
             IndexUid = indexUid;
+            PerformanceDetails = performanceDetails;
         }
 
         /// <summary>
@@ -101,5 +104,9 @@ namespace Meilisearch
         /// <inheritdoc/>
         [JsonPropertyName("indexUid")]
         public string IndexUid { get; }
+
+        /// <inheritdoc/>
+        [JsonPropertyName("performanceDetails")]
+        public IReadOnlyDictionary<string, string> PerformanceDetails { get; }
     }
 }

--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -62,5 +62,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("retrieveVectors")]
         public bool RetrieveVectors { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to retrieve performance details.
+        /// </summary>
+        [JsonPropertyName("showPerformanceDetails")]
+        public bool ShowPerformanceDetails { get; set; }
     }
 }

--- a/src/Meilisearch/SearchQuery.cs
+++ b/src/Meilisearch/SearchQuery.cs
@@ -62,11 +62,5 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("retrieveVectors")]
         public bool RetrieveVectors { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether to retrieve performance details.
-        /// </summary>
-        [JsonPropertyName("showPerformanceDetails")]
-        public bool ShowPerformanceDetails { get; set; }
     }
 }

--- a/src/Meilisearch/SearchQueryBase.cs
+++ b/src/Meilisearch/SearchQueryBase.cs
@@ -109,5 +109,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("showRankingScoreDetails")]
         public bool? ShowRankingScoreDetails { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to retrieve performance details.
+        /// </summary>
+        [JsonPropertyName("showPerformanceDetails")]
+        public bool? ShowPerformanceDetails { get; set; }
     }
 }

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -22,12 +22,14 @@ namespace Meilisearch
         /// <param name="matchesPosition"></param>
         /// <param name="facetStats"></param>
         /// <param name="indexUid"></param>
+        /// <param name="performanceDetails"></param>
         public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int estimatedTotalHits,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
             int processingTimeMs, string query,
             IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPosition,
             IReadOnlyDictionary<string, FacetStat> facetStats,
-            string indexUid)
+            string indexUid,
+            IReadOnlyDictionary<string, string> performanceDetails)
         {
             Hits = hits;
             Offset = offset;
@@ -39,6 +41,7 @@ namespace Meilisearch
             MatchesPosition = matchesPosition;
             FacetStats = facetStats;
             IndexUid = indexUid;
+            PerformanceDetails = performanceDetails;
         }
 
         /// <inheritdoc/>
@@ -86,5 +89,9 @@ namespace Meilisearch
         /// <inheritdoc/>
         [JsonPropertyName("indexUid")]
         public string IndexUid { get; }
+
+        /// <inheritdoc/>
+        [JsonPropertyName("performanceDetails")]
+        public IReadOnlyDictionary<string, string> PerformanceDetails { get; }
     }
 }

--- a/src/Meilisearch/SimilarDocumentsQuery.cs
+++ b/src/Meilisearch/SimilarDocumentsQuery.cs
@@ -81,5 +81,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("retrieveVectors")]
         public bool RetrieveVectors { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to retrieve performance details.
+        /// </summary>
+        [JsonPropertyName("showPerformanceDetails")]
+        public bool ShowPerformanceDetails { get; set; }
     }
 }

--- a/src/Meilisearch/SimilarDocumentsResult.cs
+++ b/src/Meilisearch/SimilarDocumentsResult.cs
@@ -17,13 +17,15 @@ namespace Meilisearch
         /// <param name="offset"></param>
         /// <param name="limit"></param>
         /// <param name="estimatedTotalHits"></param>
+        /// <param name="performanceDetails"></param>
         public SimilarDocumentsResult(
             IReadOnlyCollection<T> hits,
             string id,
             int processingTimeMs,
             int offset,
             int limit,
-            int estimatedTotalHits)
+            int estimatedTotalHits,
+            IReadOnlyDictionary<string, string> performanceDetails)
         {
             Hits = hits;
             Id = id;
@@ -31,6 +33,7 @@ namespace Meilisearch
             Offset = offset;
             Limit = limit;
             EstimatedTotalHits = estimatedTotalHits;
+            PerformanceDetails = performanceDetails;
         }
 
         /// <summary>
@@ -68,5 +71,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("estimatedTotalHits")]
         public int EstimatedTotalHits { get; }
+
+        /// <summary>
+        /// Gets the performance details.
+        /// </summary>
+        [JsonPropertyName("performanceDetails")]
+        public IReadOnlyDictionary<string, string> PerformanceDetails { get; }
     }
 }

--- a/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
+++ b/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
@@ -119,7 +119,6 @@ namespace Meilisearch.Tests
             res2.PerformanceDetails.Should().BeNull();
         }
 
-
         [Fact]
         public async Task FederatedSearchWithNoFederationOptions()
         {
@@ -177,6 +176,48 @@ namespace Meilisearch.Tests
             var testJson = JsonSerializer.Serialize(federatedquer);
 
             result.Hits.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task FederatedSearchWithPerformanceDetails()
+        {
+            var result = await _fixture.DefaultClient.FederatedMultiSearchAsync<Movie>(
+                new FederatedMultiSearchQuery()
+                {
+                    Queries = new List<FederatedSearchQuery>()
+                    {
+                        new FederatedSearchQuery() { IndexUid = _index1.Uid, Q = "", Filter = "genre = 'SF'" },
+                        new FederatedSearchQuery()
+                        {
+                            IndexUid = _index2.Uid, Q = "", Filter = "genre = 'Action'"
+                        }
+                    },
+                    FederationOptions = new MultiSearchFederationOptions() { Limit = 1, ShowPerformanceDetails = true }
+                });
+
+            result.PerformanceDetails.Should().NotBeNullOrEmpty();
+            result.Hits.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task FederatedSearchWithoutPerformanceDetails()
+        {
+            var result = await _fixture.DefaultClient.FederatedMultiSearchAsync<Movie>(
+                new FederatedMultiSearchQuery()
+                {
+                    Queries = new List<FederatedSearchQuery>()
+                    {
+                        new FederatedSearchQuery() { IndexUid = _index1.Uid, Q = "", Filter = "genre = 'SF'" },
+                        new FederatedSearchQuery()
+                        {
+                            IndexUid = _index2.Uid, Q = "", Filter = "genre = 'Action'"
+                        }
+                    },
+                    FederationOptions = new MultiSearchFederationOptions() { }
+                });
+
+            result.PerformanceDetails.Should().BeNull();
+            result.Hits.Should().HaveCount(4);
         }
     }
 }

--- a/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
+++ b/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
@@ -79,6 +79,46 @@ namespace Meilisearch.Tests
             }).Should().BeTrue();
         }
 
+        [Fact]
+        public async Task BasicSearchWithPerformanceDetails()
+        {
+            var result = await _fixture.DefaultClient.MultiSearchAsync(new MultiSearchQuery()
+            {
+                Queries = new System.Collections.Generic.List<SearchQuery>()
+                {
+                    new SearchQuery() { IndexUid = _index1.Uid, Q = "", Filter = "genre = 'SF'", ShowPerformanceDetails = true },
+                    new SearchQuery() { IndexUid = _index2.Uid, Q = "", Filter = "genre = 'Action'", ShowPerformanceDetails = true }
+                }
+            });
+
+            result.Results.Should().HaveCount(2);
+            var res1 = result.Results[0];
+            res1.PerformanceDetails.Should().NotBeNullOrEmpty();
+
+            var res2 = result.Results[1];
+            res2.PerformanceDetails.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task BasicSearchWithoutPerformanceDetails()
+        {
+            var result = await _fixture.DefaultClient.MultiSearchAsync(new MultiSearchQuery()
+            {
+                Queries = new System.Collections.Generic.List<SearchQuery>()
+                {
+                    new SearchQuery() { IndexUid = _index1.Uid, Q = "", Filter = "genre = 'SF'" },
+                    new SearchQuery() { IndexUid = _index2.Uid, Q = "", Filter = "genre = 'Action'" }
+                }
+            });
+
+            result.Results.Should().HaveCount(2);
+            var res1 = result.Results[0];
+            res1.PerformanceDetails.Should().BeNull();
+
+            var res2 = result.Results[1];
+            res2.PerformanceDetails.Should().BeNull();
+        }
+
 
         [Fact]
         public async Task FederatedSearchWithNoFederationOptions()

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -90,6 +90,25 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task BasicSearchWithPerformanceDetails()
+        {
+            var movies = await _basicIndex.SearchAsync<Movie>("man", new SearchQuery()
+            {
+                ShowPerformanceDetails = true
+            });
+
+            movies.PerformanceDetails.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task BasicSearchWithoutPerformanceDetails()
+        {
+            var movies = await _basicIndex.SearchAsync<Movie>("man");
+
+            movies.PerformanceDetails.Should().BeNull();
+        }
+
+        [Fact]
         public async Task CustomSearchWithLimit()
         {
             var movies = await _basicIndex.SearchAsync<Movie>(
@@ -100,6 +119,26 @@ namespace Meilisearch.Tests
             movies.Hits.First().Id.Should().NotBeEmpty();
             movies.Hits.First().Name.Should().NotBeEmpty();
             movies.Hits.First().Genre.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public async Task CustomSearchWithPageAndPerformanceDetails()
+        {
+            var movies = (PaginatedSearchResult<Movie>)await _basicIndex.SearchAsync<Movie>(
+                "man",
+                new SearchQuery { Page = 1, HitsPerPage = 1, ShowPerformanceDetails = true });
+
+            movies.PerformanceDetails.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task CustomSearchWithPageAndWithoutPerformanceDetails()
+        {
+            var movies = (PaginatedSearchResult<Movie>)await _basicIndex.SearchAsync<Movie>(
+                "man",
+                new SearchQuery { Page = 1, HitsPerPage = 1 });
+
+            movies.PerformanceDetails.Should().BeNull();
         }
 
         [Fact]
@@ -616,6 +655,34 @@ namespace Meilisearch.Tests
                 m => Assert.Equal("How to Train Your Dragon: The Hidden World", m.Title),
                 m => Assert.Equal("Shazam!", m.Title)
             );
+        }
+
+        [Fact]
+        public async Task CustomSearchWithSimilarDocumentsAndPerformanceDetails()
+        {
+            var query = new SimilarDocumentsQuery("143")
+            {
+                Embedder = "manual",
+                ShowPerformanceDetails = true
+            };
+
+            var movies = await _indexForVectorSearch.SearchSimilarDocumentsAsync<VectorMovie>(query);
+
+            movies.PerformanceDetails.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task CustomSearchWithSimilarDocumentsAndWithoutPerformanceDetails()
+        {
+            var query = new SimilarDocumentsQuery("143")
+            {
+                Embedder = "manual",
+                ShowPerformanceDetails = false
+            };
+
+            var movies = await _indexForVectorSearch.SearchSimilarDocumentsAsync<VectorMovie>(query);
+
+            movies.PerformanceDetails.Should().BeNull();
         }
     }
 }

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -98,6 +98,9 @@ namespace Meilisearch.Tests
             });
 
             movies.PerformanceDetails.Should().NotBeNullOrEmpty();
+            movies.Hits.Should().NotBeEmpty();
+            movies.Hits.First().Name.Should().NotBeEmpty();
+            movies.Hits.ElementAt(1).Name.Should().NotBeEmpty();
         }
 
         [Fact]
@@ -106,6 +109,9 @@ namespace Meilisearch.Tests
             var movies = await _basicIndex.SearchAsync<Movie>("man");
 
             movies.PerformanceDetails.Should().BeNull();
+            movies.Hits.Should().NotBeEmpty();
+            movies.Hits.First().Name.Should().NotBeEmpty();
+            movies.Hits.ElementAt(1).Name.Should().NotBeEmpty();
         }
 
         [Fact]
@@ -129,6 +135,8 @@ namespace Meilisearch.Tests
                 new SearchQuery { Page = 1, HitsPerPage = 1, ShowPerformanceDetails = true });
 
             movies.PerformanceDetails.Should().NotBeNullOrEmpty();
+            movies.Hits.Should().NotBeEmpty();
+            movies.Hits.First().Name.Should().NotBeEmpty();
         }
 
         [Fact]
@@ -139,6 +147,8 @@ namespace Meilisearch.Tests
                 new SearchQuery { Page = 1, HitsPerPage = 1 });
 
             movies.PerformanceDetails.Should().BeNull();
+            movies.Hits.Should().NotBeEmpty();
+            movies.Hits.First().Name.Should().NotBeEmpty();
         }
 
         [Fact]
@@ -669,6 +679,13 @@ namespace Meilisearch.Tests
             var movies = await _indexForVectorSearch.SearchSimilarDocumentsAsync<VectorMovie>(query);
 
             movies.PerformanceDetails.Should().NotBeNullOrEmpty();
+
+            Assert.Collection(movies.Hits,
+                m => Assert.Equal("Escape Room", m.Title),
+                m => Assert.Equal("Captain Marvel", m.Title),
+                m => Assert.Equal("How to Train Your Dragon: The Hidden World", m.Title),
+                m => Assert.Equal("Shazam!", m.Title)
+            );
         }
 
         [Fact]
@@ -683,6 +700,13 @@ namespace Meilisearch.Tests
             var movies = await _indexForVectorSearch.SearchSimilarDocumentsAsync<VectorMovie>(query);
 
             movies.PerformanceDetails.Should().BeNull();
+
+            Assert.Collection(movies.Hits,
+                m => Assert.Equal("Escape Room", m.Title),
+                m => Assert.Equal("Captain Marvel", m.Title),
+                m => Assert.Equal("How to Train Your Dragon: The Hidden World", m.Title),
+                m => Assert.Equal("Shazam!", m.Title)
+            );
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #706

## What does this PR do?
This PR adds a new `showPerformanceDetails` option to search endpoints (search, multi-search and similar documents). I've written needed tests to make sure everything works smoothly.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional performance details to search results. Users can now request performance metrics by enabling ShowPerformanceDetails in their search queries. Performance information is included in results across all search types including basic, paginated, similar documents, and federated multi-search operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->