### PR TITLE
Update outdated documentation links

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -292,7 +292,7 @@ getting_started_add_documents: |-
 getting_started_check_task_status: |-
   TaskInfo task = await client.GetTaskAsync(0);
 getting_started_search: |-
-  MeilisearchClient client = new MeilisearchClient("MEILISEARCH_URL", "masterKey");
+  MeilisearchClient client = new MeilisearchClient("MEILISEARCH_URL", "MEILISEARCH_KEY");
   var index = client.Index("movies");
 
   var movies = await index.SearchAsync<Movie>("botman");
@@ -405,7 +405,7 @@ primary_field_guide_add_document_primary_key: |-
     },
     "reference_number");
 authorization_header_1: |-
-  MeilisearchClient client = new MeilisearchClient("MEILISEARCH_URL", "masterKey");
+  MeilisearchClient client = new MeilisearchClient("MEILISEARCH_URL", "MEILISEARCH_KEY");
   var keys = await client.GetKeysAsync();
 get_one_key_1: |-
   Key key = await client.GetKeyAsync("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4");

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://discord.meilisearch.com">Discord</a> |
   <a href="https://roadmap.meilisearch.com/tabs/1-under-consideration">Roadmap</a> |
   <a href="https://www.meilisearch.com">Website</a> |
-  <a href="https://www.meilisearch.com/docs/faq">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq">FAQ</a>
 </h4>
 
 <p align="center">
@@ -111,7 +111,7 @@ namespace GettingStarted
 }
 ```
 
-With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/tasks).
+With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks).
 
 #### Basic Search <!-- omit in toc -->
 
@@ -142,7 +142,7 @@ JSON Output:
 
 #### Custom Search <!-- omit in toc -->
 
-All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters) section of the documentation.
+All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-parameters) section of the documentation.
 
 ```c#
 var movies = await index.SearchAsync<Movie>(
@@ -191,7 +191,7 @@ TaskInfo task = await index.UpdateFilterableAttributesAsync(
 
 You only need to perform this operation once.
 
-Note that MeiliSearch will rebuild your index whenever you update `FilterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [update status](https://www.meilisearch.com/docs/reference/api/tasks#status).
+Note that MeiliSearch will rebuild your index whenever you update `FilterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [update status](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#status).
 
 Then, you can perform the search:
 
@@ -226,7 +226,7 @@ JSON Output:
 
 #### Search with Limit and Offset
 
-You can paginate search results by making queries combining both [offset](https://www.meilisearch.com/docs/reference/api/search#offset) and [limit](https://www.meilisearch.com/docs/reference/api/search#limit).
+You can paginate search results by making queries combining both [offset](https://www.meilisearch.com/docs/reference/api/search/search-with-post#offset) and [limit](https://www.meilisearch.com/docs/reference/api/search/search-with-post#limit).
 
 ```c#
 var results = await index.SearchAsync<T>(query, new SearchQuery()
@@ -243,7 +243,7 @@ if (results is SearchResult<T> limitedResults)
 
 #### Search with defined number of results per page
 
-To get paginated results with page numbers, the [HitsPerPage](https://www.meilisearch.com/docs/reference/api/search#number-of-results-per-page) and [Page](https://www.meilisearch.com/docs/reference/api/search#page) properties must be defined.
+To get paginated results with page numbers, the [HitsPerPage](https://www.meilisearch.com/docs/reference/api/search/search-with-post#number-of-results-per-page) and [Page](https://www.meilisearch.com/docs/reference/api/search/search-with-post#page) properties must be defined.
 
 ```c#
 var results = await index.SearchAsync<T>(query, new SearchQuery()
@@ -261,7 +261,7 @@ if (results is PaginatedSearchResult<T> paginatedResults)
 
 #### Search with sort
 
-To get results sorted by attributes and preferred sorting order, the [Sort](https://www.meilisearch.com/docs/reference/api/search#sort) property must be defined.
+To get results sorted by attributes and preferred sorting order, the [Sort](https://www.meilisearch.com/docs/reference/api/search/search-with-post#sort) property must be defined.
 
 ```c#
 var results = await index.SearchAsync<T>(query, new SearchQuery()

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -51,7 +51,7 @@ namespace Meilisearch
 
         /// <summary>
         /// Gets the current Meilisearch version. For more details on response.
-        /// https://www.meilisearch.com/docs/reference/api/version#get-version-of-meilisearch.
+        /// https://www.meilisearch.com/docs/reference/api/version/get-version#get-version-of-meilisearch.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the Meilisearch version with commit and build version.</returns>


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation links throughout the project to align with the current Meilisearch documentation structure. Changes include redirecting FAQ resources, async task management endpoints, and search parameter configuration guides to their latest documentation paths, ensuring users access current, accurate, and properly organized information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->