### PR TITLE
Add support for `distinct` in federated search requests

### DIFF
--- a/src/Meilisearch/MultiSearchFederationOptions.cs
+++ b/src/Meilisearch/MultiSearchFederationOptions.cs
@@ -21,5 +21,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("limit")]
         public int Limit { get; set; }
+
+        /// <summary>
+        /// Attribute whose value must be different for each returned document
+        /// </summary>
+        [JsonPropertyName("distinct")]
+        public string Distinct { get; set; }
     }
 }

--- a/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
+++ b/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
@@ -138,5 +138,24 @@ namespace Meilisearch.Tests
 
             result.Hits.Should().HaveCount(2);
         }
+
+        [Fact]
+        public async Task FederatedSearchWithDistinct()
+        {
+            var result = await _fixture.DefaultClient.FederatedMultiSearchAsync<Movie>(
+                new FederatedMultiSearchQuery()
+                {
+                    Queries = new List<FederatedSearchQuery>()
+                    {
+                        new FederatedSearchQuery() { IndexUid = _index1.Uid, Q = "" },
+                        new FederatedSearchQuery() { IndexUid = _index2.Uid, Q = "" }
+                    },
+                    FederationOptions = new MultiSearchFederationOptions() { Distinct = "genre" }
+                });
+
+            // With distinct on "genre", each genre value appears at most once
+            result.Hits.Should().NotBeEmpty();
+            result.Hits.Select(h => h.Genre).Distinct().Count().Should().Be(result.Hits.Count);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Adds `Distinct` property to `MultiSearchFederationOptions` for Meilisearch v1.40 federated search.

## Why this matters
Meilisearch v1.40 introduced `distinct` in federated search requests. The .NET SDK was missing this property. Users couldn't deduplicate federated results by attribute.

## Changes
- Added `Distinct` string property to `MultiSearchFederationOptions` in `src/Meilisearch/MultiSearchFederationOptions.cs`
- Added `FederatedSearchWithDistinct` test in `tests/Meilisearch.Tests/MultiIndexSearchTests.cs`

## Testing
- Test follows the existing `FederatedSearchWithLimitAndOffset` pattern
- The custom `MultiSearchFederationOptionsConverter` handles null strings correctly (skips serialization when null)

Closes #721

**AI disclosure:** This contribution was developed with AI assistance (Codex CLI for initial implementation, Claude Code for review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "distinct" option to federated multi-index searches, allowing you to remove duplicate results based on a specified field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->