### PR TITLE
Add GetTaskDocumentsAsync method (Meilisearch v1.13)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -94,6 +94,8 @@ search_post_1: |-
   await client.Index("movies").SearchAsync<Movie>("American ninja");
 get_task_1: |
   TaskInfo task = await client.GetTaskAsync(1);
+get_task_documents_1: |
+  string documents = await client.GetTaskDocumentsAsync(1);
 get_all_tasks_1: |
   ResourceResults<Task> taskResult = await client.GetTasksAsync();
 get_settings_1: |-

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -251,6 +251,17 @@ namespace Meilisearch
         }
 
         /// <summary>
+        /// Gets the documents associated with a task.
+        /// </summary>
+        /// <param name="taskUid">Unique identifier of the task.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task documents as a JSON string.</returns>
+        public async Task<string> GetTaskDocumentsAsync(int taskUid, CancellationToken cancellationToken = default)
+        {
+            return await TaskEndpoint().GetTaskDocumentsAsync(taskUid, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Waits until the asynchronous task was done.
         /// </summary>
         /// <param name="taskUid">Unique identifier of the asynchronous task.</param>

--- a/src/Meilisearch/TaskEndpoint.cs
+++ b/src/Meilisearch/TaskEndpoint.cs
@@ -74,6 +74,19 @@ namespace Meilisearch
         }
 
         /// <summary>
+        /// Gets the documents associated with a task.
+        /// </summary>
+        /// <param name="taskUid">Uid of the task.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task documents as a JSON string.</returns>
+        public async Task<string> GetTaskDocumentsAsync(int taskUid, CancellationToken cancellationToken = default)
+        {
+            var response = await _http.GetAsync($"tasks/{taskUid}/documents", cancellationToken)
+                .ConfigureAwait(false);
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Gets the tasks from an index.
         /// </summary>
         /// <param name="indexUid">Uid of the index.</param>


### PR DESCRIPTION
## Summary

Adds `GetTaskDocumentsAsync` to retrieve documents associated with a task, corresponding to `GET /tasks/{taskUid}/documents` introduced in Meilisearch 1.13.

## Changes

- `src/Meilisearch/TaskEndpoint.cs`: Added `GetTaskDocumentsAsync(int taskUid, CancellationToken)` method
- `src/Meilisearch/MeilisearchClient.cs`: Added public `GetTaskDocumentsAsync` wrapper with XML documentation
- `.code-samples.meilisearch.yaml`: Added `get_task_documents_1` code sample

## Testing

Follows the same async pattern as `GetTaskAsync`. Uses `HttpClient.GetAsync` with the `/tasks/{taskUid}/documents` endpoint and returns the response body as a string for maximum flexibility with document types.

Closes #720

This contribution was developed with AI assistance (Claude Code).