### PR TITLE
Add distinct field to MultiSearchFederationOptions

### DIFF
--- a/src/Meilisearch/MultiSearchFederationOptions.cs
+++ b/src/Meilisearch/MultiSearchFederationOptions.cs
@@ -21,5 +21,11 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("limit")]
         public int Limit { get; set; }
+
+        /// <summary>
+        /// Attribute whose values must be unique among returned documents in a federated search
+        /// </summary>
+        [JsonPropertyName("distinct")]
+        public string Distinct { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Adds the `Distinct` string property to `MultiSearchFederationOptions`, enabling deduplication by attribute in federated multi-index search.

This feature was introduced in Meilisearch v1.12 and is already supported by the Java SDK. The existing `MultiSearchFederationOptionsConverter` uses reflection, so no converter changes are needed.

Closes #721

## Changes

- Added `Distinct` property with `[JsonPropertyName("distinct")]` to `MultiSearchFederationOptions`

## Usage

```csharp
var result = await client.FederatedMultiSearchAsync<Movie>(
    new FederatedMultiSearchQuery()
    {
        Queries = new List<FederatedSearchQuery>()
        {
            new FederatedSearchQuery() { IndexUid = "movies", Q = "adventure" },
            new FederatedSearchQuery() { IndexUid = "comics", Q = "adventure" }
        },
        FederationOptions = new MultiSearchFederationOptions()
        {
            Limit = 10,
            Distinct = "title"
        }
    });
```