### PR TITLE
Support filterableAttributes opt-out syntax for Meilisearch v1.14

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -198,7 +198,23 @@ reset_searchable_attributes_1: |-
 get_filterable_attributes_1: |-
   IEnumerable<string> attributes = await client.Index("movies").GetFilterableAttributesAsync();
 update_filterable_attributes_1: |-
-  List<string> attributes = new() { "genres", "director" };
+  var attributes = new FilterableAttribute[]
+  {
+      "director",
+      new FilterableAttribute
+      {
+          AttributePatterns = new[] { "genres" },
+          Features = new FilterableAttributeFeatures
+          {
+              FacetSearch = true,
+              Filter = new FilterableAttributeFilterFeatures
+              {
+                  Equality = true,
+                  Comparison = true,
+              },
+          },
+      },
+  };
   TaskInfo result = await client.Index("movies").UpdateFilterableAttributesAsync(attributes);
 reset_filterable_attributes_1: |-
   TaskInfo result = await client.Index("movies").ResetFilterableAttributesAsync();

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -122,7 +122,7 @@ update_settings_1: |-
         { "wolverine", new string[] { "xmen", "logan" } },
         { "logan", new string[] { "wolverine" } },
     },
-    FilterableAttributes = new string[] { },
+    FilterableAttributes = new FilterableAttribute[] { },
     TypoTolerance = new TypoTolerance
     {
         DisableOnAttributes = new string[] { "title" },
@@ -196,7 +196,7 @@ update_searchable_attributes_1: |-
 reset_searchable_attributes_1: |-
   await client.Index("movies").ResetSearchableAttributesAsync();
 get_filterable_attributes_1: |-
-  IEnumerable<string> attributes = await client.Index("movies").GetFilterableAttributesAsync();
+  IEnumerable<FilterableAttribute> attributes = await client.Index("movies").GetFilterableAttributesAsync();
 update_filterable_attributes_1: |-
   var attributes = new FilterableAttribute[]
   {

--- a/src/Meilisearch/Converters/FilterableAttributeConverter.cs
+++ b/src/Meilisearch/Converters/FilterableAttributeConverter.cs
@@ -61,13 +61,16 @@ namespace Meilisearch.Converters
                 return;
             }
 
+            if (value.AttributePatterns == null)
+            {
+                throw new JsonException(
+                    "FilterableAttribute must have either Attribute or AttributePatterns set.");
+            }
+
             writer.WriteStartObject();
 
-            if (value.AttributePatterns != null)
-            {
-                writer.WritePropertyName("attributePatterns");
-                JsonSerializer.Serialize(writer, value.AttributePatterns, options);
-            }
+            writer.WritePropertyName("attributePatterns");
+            JsonSerializer.Serialize(writer, value.AttributePatterns, options);
 
             if (value.Features != null)
             {

--- a/src/Meilisearch/Converters/FilterableAttributeConverter.cs
+++ b/src/Meilisearch/Converters/FilterableAttributeConverter.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Meilisearch.Converters
+{
+    internal class FilterableAttributeConverter : JsonConverter<FilterableAttribute>
+    {
+        public override FilterableAttribute Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return new FilterableAttribute { Attribute = reader.GetString() };
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var result = new FilterableAttribute();
+
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                    {
+                        return result;
+                    }
+
+                    if (reader.TokenType != JsonTokenType.PropertyName)
+                    {
+                        throw new JsonException("Expected property name in filterable attribute object.");
+                    }
+
+                    var propertyName = reader.GetString();
+                    reader.Read();
+
+                    switch (propertyName)
+                    {
+                        case "attributePatterns":
+                            result.AttributePatterns = JsonSerializer.Deserialize<IEnumerable<string>>(ref reader, options);
+                            break;
+                        case "features":
+                            result.Features = JsonSerializer.Deserialize<FilterableAttributeFeatures>(ref reader, options);
+                            break;
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+
+                throw new JsonException("Unexpected end of JSON while reading filterable attribute object.");
+            }
+
+            throw new JsonException($"Unexpected token {reader.TokenType} when reading FilterableAttribute.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, FilterableAttribute value, JsonSerializerOptions options)
+        {
+            if (value.Attribute != null)
+            {
+                writer.WriteStringValue(value.Attribute);
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            if (value.AttributePatterns != null)
+            {
+                writer.WritePropertyName("attributePatterns");
+                JsonSerializer.Serialize(writer, value.AttributePatterns, options);
+            }
+
+            if (value.Features != null)
+            {
+                writer.WritePropertyName("features");
+                JsonSerializer.Serialize(writer, value.Features, options);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Meilisearch/FilterableAttribute.cs
+++ b/src/Meilisearch/FilterableAttribute.cs
@@ -37,11 +37,13 @@ namespace Meilisearch
         /// <summary>
         /// Implicitly wraps a plain attribute name in a <see cref="FilterableAttribute"/>.
         /// Enables passing a <see cref="string"/> wherever a <see cref="FilterableAttribute"/> is expected.
+        /// A <c>null</c> input produces a <c>null</c> result so it serializes as JSON <c>null</c>
+        /// rather than an empty object.
         /// </summary>
-        /// <param name="attribute">The attribute name.</param>
+        /// <param name="attribute">The attribute name, or <c>null</c>.</param>
         public static implicit operator FilterableAttribute(string attribute)
         {
-            return new FilterableAttribute { Attribute = attribute };
+            return attribute == null ? null : new FilterableAttribute { Attribute = attribute };
         }
     }
 

--- a/src/Meilisearch/FilterableAttribute.cs
+++ b/src/Meilisearch/FilterableAttribute.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+using Meilisearch.Converters;
+
+namespace Meilisearch
+{
+    /// <summary>
+    /// Represents a single filterable attribute entry.
+    ///
+    /// Since Meilisearch v1.14, <c>filterableAttributes</c> accepts either a plain
+    /// attribute name or a granular pattern object that opts in/out of specific features.
+    /// Use the implicit conversion from <see cref="string"/> for the legacy form, or set
+    /// <see cref="AttributePatterns"/> and <see cref="Features"/> for the granular form.
+    /// </summary>
+    [JsonConverter(typeof(FilterableAttributeConverter))]
+    public class FilterableAttribute
+    {
+        /// <summary>
+        /// Plain attribute name. When set, the entry is serialized as a JSON string
+        /// and <see cref="AttributePatterns"/> / <see cref="Features"/> are ignored.
+        /// </summary>
+        public string Attribute { get; set; }
+
+        /// <summary>
+        /// Attribute name patterns (granular syntax).
+        /// </summary>
+        [JsonPropertyName("attributePatterns")]
+        public IEnumerable<string> AttributePatterns { get; set; }
+
+        /// <summary>
+        /// Per-feature opt-in flags (granular syntax).
+        /// </summary>
+        [JsonPropertyName("features")]
+        public FilterableAttributeFeatures Features { get; set; }
+
+        /// <summary>
+        /// Implicitly wraps a plain attribute name in a <see cref="FilterableAttribute"/>.
+        /// Enables passing a <see cref="string"/> wherever a <see cref="FilterableAttribute"/> is expected.
+        /// </summary>
+        /// <param name="attribute">The attribute name.</param>
+        public static implicit operator FilterableAttribute(string attribute)
+        {
+            return new FilterableAttribute { Attribute = attribute };
+        }
+    }
+
+    /// <summary>
+    /// Feature opt-in flags for a granular <see cref="FilterableAttribute"/>.
+    /// </summary>
+    public class FilterableAttributeFeatures
+    {
+        /// <summary>
+        /// Gets or sets whether facet search is enabled for the matched attributes.
+        /// </summary>
+        [JsonPropertyName("facetSearch")]
+        public bool FacetSearch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the filter-related feature opt-ins for the matched attributes.
+        /// </summary>
+        [JsonPropertyName("filter")]
+        public FilterableAttributeFilterFeatures Filter { get; set; }
+    }
+
+    /// <summary>
+    /// Filter-related feature opt-ins inside <see cref="FilterableAttributeFeatures"/>.
+    /// </summary>
+    public class FilterableAttributeFilterFeatures
+    {
+        /// <summary>
+        /// Gets or sets whether equality filtering (e.g. <c>genre = comedy</c>) is enabled.
+        /// </summary>
+        [JsonPropertyName("equality")]
+        public bool Equality { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether comparison filtering (e.g. <c>price &gt; 10</c>) is enabled.
+        /// </summary>
+        [JsonPropertyName("comparison")]
+        public bool Comparison { get; set; }
+    }
+}

--- a/src/Meilisearch/Index.Attributes.cs
+++ b/src/Meilisearch/Index.Attributes.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -84,27 +85,41 @@ namespace Meilisearch
 
         /// <summary>
         /// Gets the filterable attributes setting.
+        ///
+        /// Each entry is either a plain attribute name (legacy syntax) or a granular
+        /// pattern that opts in/out of specific features (Meilisearch v1.14+).
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the filterable attributes setting.</returns>
-        public async Task<IEnumerable<string>> GetFilterableAttributesAsync(CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<FilterableAttribute>> GetFilterableAttributesAsync(CancellationToken cancellationToken = default)
         {
-            return await _http.GetFromJsonAsync<IEnumerable<string>>($"indexes/{Uid}/settings/filterable-attributes", cancellationToken: cancellationToken)
+            return await _http.GetFromJsonAsync<IEnumerable<FilterableAttribute>>($"indexes/{Uid}/settings/filterable-attributes", cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
 
         /// <summary>
         /// Updates the filterable attributes setting.
         /// </summary>
-        /// <param name="filterableAttributes">Collection of filterable attributes.</param>
+        /// <param name="filterableAttributes">Collection of filterable attributes. Each entry may be a plain attribute name or a granular <see cref="FilterableAttribute"/>.</param>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Returns the task info of the asynchronous task.</returns>
-        public async Task<TaskInfo> UpdateFilterableAttributesAsync(IEnumerable<string> filterableAttributes, CancellationToken cancellationToken = default)
+        public async Task<TaskInfo> UpdateFilterableAttributesAsync(IEnumerable<FilterableAttribute> filterableAttributes, CancellationToken cancellationToken = default)
         {
             var responseMessage =
                 await _http.PutAsJsonAsync($"indexes/{Uid}/settings/filterable-attributes", filterableAttributes, Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Updates the filterable attributes setting using the legacy string-only syntax.
+        /// </summary>
+        /// <param name="filterableAttributes">Collection of attribute names.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task info of the asynchronous task.</returns>
+        public Task<TaskInfo> UpdateFilterableAttributesAsync(IEnumerable<string> filterableAttributes, CancellationToken cancellationToken = default)
+        {
+            return UpdateFilterableAttributesAsync(filterableAttributes.Select(a => (FilterableAttribute)a), cancellationToken);
         }
 
         /// <summary>

--- a/src/Meilisearch/Index.Attributes.cs
+++ b/src/Meilisearch/Index.Attributes.cs
@@ -119,7 +119,9 @@ namespace Meilisearch
         /// <returns>Returns the task info of the asynchronous task.</returns>
         public Task<TaskInfo> UpdateFilterableAttributesAsync(IEnumerable<string> filterableAttributes, CancellationToken cancellationToken = default)
         {
-            return UpdateFilterableAttributesAsync(filterableAttributes.Select(a => (FilterableAttribute)a), cancellationToken);
+            return filterableAttributes == null
+                ? throw new System.ArgumentNullException(nameof(filterableAttributes))
+                : UpdateFilterableAttributesAsync(filterableAttributes.Select(a => (FilterableAttribute)a), cancellationToken);
         }
 
         /// <summary>

--- a/src/Meilisearch/Settings.cs
+++ b/src/Meilisearch/Settings.cs
@@ -58,9 +58,12 @@ namespace Meilisearch
 
         /// <summary>
         /// Gets or sets the filterable attributes.
+        ///
+        /// Each entry is either a plain attribute name (legacy syntax) or a granular
+        /// pattern that opts in/out of specific features (Meilisearch v1.14+).
         /// </summary>
         [JsonPropertyName("filterableAttributes")]
-        public IEnumerable<string> FilterableAttributes { get; set; }
+        public IEnumerable<FilterableAttribute> FilterableAttributes { get; set; }
 
         /// <summary>
         /// Gets or sets the sortable attributes.

--- a/tests/Meilisearch.Tests/FacetSearchTests.cs
+++ b/tests/Meilisearch.Tests/FacetSearchTests.cs
@@ -101,7 +101,7 @@ namespace Meilisearch.Tests
         {
             var newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "genre", "id" },
+                FilterableAttributes = new FilterableAttribute[] { "genre", "id" },
             };
             var task = await _indexForFaceting.UpdateSettingsAsync(newFilters);
             task.TaskUid.Should().BeGreaterOrEqualTo(0);

--- a/tests/Meilisearch.Tests/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/IndexFixture.cs
@@ -97,7 +97,7 @@ namespace Meilisearch.Tests
             // task settings
             var settings = new Settings
             {
-                FilterableAttributes = new string[] { "genre" },
+                FilterableAttributes = new FilterableAttribute[] { "genre" },
             };
             task = await index.UpdateSettingsAsync(settings);
 
@@ -174,7 +174,7 @@ namespace Meilisearch.Tests
 
             var settings = new Settings
             {
-                FilterableAttributes = new string[] { "product_id" },
+                FilterableAttributes = new FilterableAttribute[] { "product_id" },
             };
             task = await index.UpdateSettingsAsync(settings);
 

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -131,7 +131,7 @@ namespace Meilisearch.Tests
         {
             var newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "name" },
+                FilterableAttributes = new FilterableAttribute[] { "name" },
             };
             var task = await _basicIndex.UpdateSettingsAsync(newFilters);
             task.TaskUid.Should().BeGreaterOrEqualTo(0);
@@ -303,7 +303,7 @@ namespace Meilisearch.Tests
         {
             var newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "id" },
+                FilterableAttributes = new FilterableAttribute[] { "id" },
             };
             var task = await _indexWithIntId.UpdateSettingsAsync(newFilters);
             task.TaskUid.Should().BeGreaterOrEqualTo(0);
@@ -328,7 +328,7 @@ namespace Meilisearch.Tests
         {
             var newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "genre", "id" },
+                FilterableAttributes = new FilterableAttribute[] { "genre", "id" },
             };
             var task = await _indexWithIntId.UpdateSettingsAsync(newFilters);
             task.TaskUid.Should().BeGreaterOrEqualTo(0);
@@ -382,7 +382,7 @@ namespace Meilisearch.Tests
         {
             var newFilters = new Settings
             {
-                FilterableAttributes = new string[] { "id" },
+                FilterableAttributes = new FilterableAttribute[] { "id" },
             };
             var task = await _indexWithIntId.UpdateSettingsAsync(newFilters);
             await _indexWithIntId.WaitForTaskAsync(task.TaskUid);

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -39,7 +39,7 @@ namespace Meilisearch.Tests
                 SeparatorTokens = new List<string> { },
                 NonSeparatorTokens = new List<string> { },
                 Synonyms = new Dictionary<string, IEnumerable<string>> { },
-                FilterableAttributes = Array.Empty<string>(),
+                FilterableAttributes = Array.Empty<FilterableAttribute>(),
                 SortableAttributes = Array.Empty<string>(),
                 ProximityPrecision = "byWord",
                 TypoTolerance = new TypoTolerance
@@ -149,7 +149,7 @@ namespace Meilisearch.Tests
                 DistinctAttribute = "name",
                 DisplayedAttributes = new string[] { "name" },
                 RankingRules = new string[] { "typo" },
-                FilterableAttributes = new string[] { "genre" },
+                FilterableAttributes = new FilterableAttribute[] { "genre" },
                 Dictionary = new string[] { "dictionary" }
             };
             await AssertUpdateSuccess(_index.UpdateSettingsAsync, newSettings);
@@ -219,7 +219,31 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task UpdateFilterableAttributes()
         {
-            var newFilterableAttributes = new string[] { "name", "genre" };
+            IEnumerable<FilterableAttribute> newFilterableAttributes = new FilterableAttribute[] { "name", "genre" };
+            await AssertUpdateSuccess(_index.UpdateFilterableAttributesAsync, newFilterableAttributes);
+            await AssertGetEquality(_index.GetFilterableAttributesAsync, newFilterableAttributes);
+        }
+
+        [Fact]
+        public async Task UpdateFilterableAttributesWithGranularSyntax()
+        {
+            IEnumerable<FilterableAttribute> newFilterableAttributes = new FilterableAttribute[]
+            {
+                "author",
+                new FilterableAttribute
+                {
+                    AttributePatterns = new[] { "genre" },
+                    Features = new FilterableAttributeFeatures
+                    {
+                        FacetSearch = true,
+                        Filter = new FilterableAttributeFilterFeatures
+                        {
+                            Equality = true,
+                            Comparison = false,
+                        },
+                    },
+                },
+            };
             await AssertUpdateSuccess(_index.UpdateFilterableAttributesAsync, newFilterableAttributes);
             await AssertGetEquality(_index.GetFilterableAttributesAsync, newFilterableAttributes);
         }
@@ -227,7 +251,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task ResetFilterableAttributes()
         {
-            var newFilterableAttributes = new string[] { "name", "genre" };
+            IEnumerable<FilterableAttribute> newFilterableAttributes = new FilterableAttribute[] { "name", "genre" };
             await AssertUpdateSuccess(_index.UpdateFilterableAttributesAsync, newFilterableAttributes);
             await AssertGetEquality(_index.GetFilterableAttributesAsync, newFilterableAttributes);
 


### PR DESCRIPTION
Closes #644.

## Summary
- Add `FilterableAttribute` model (string or `{ attributePatterns, features }`) with implicit conversion from `string` so callers can mix legacy and granular entries.
- New `FilterableAttributeConverter` serializes each entry as a JSON string when only `Attribute` is set, otherwise as a JSON object — symmetric on read.
- `Settings.FilterableAttributes`, `Index.GetFilterableAttributesAsync` and `Index.UpdateFilterableAttributesAsync` switch to the new type. An `IEnumerable<string>` overload of the update method is kept for source compatibility with existing callers.
- Update `.code-samples.meilisearch.yaml` `update_filterable_attributes_1` to use the granular syntax.
- Add `UpdateFilterableAttributesWithGranularSyntax` integration test covering the mixed-syntax round trip.

## Test plan
- `dotnet build` clean
- `dotnet format --verify-no-changes Meilisearch.sln` clean
- Filterable-attribute integration tests pass against `getmeili/meilisearch:v1.16` (`GetFilterableAttributes`, `UpdateFilterableAttributes`, `UpdateFilterableAttributesWithGranularSyntax`, `ResetFilterableAttributes`)
- Full CI to confirm

## AI disclosure
Authored with Claude Code (Claude Opus 4.7). Scope: design of the `FilterableAttribute` / `FilterableAttributeFeatures` types, the JsonConverter, the updated `Index.Attributes`/`Settings` signatures, the granular-syntax integration test, the updated code sample, and this PR description. All generated code reviewed by the author and verified against the linked Meilisearch v1.14 issue and the JS SDK reference implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Filterable attributes API updated to accept structured configuration objects instead of plain strings.

* **New Features**
  * Configure facet search and filter behaviors (equality/comparison) on a per-attribute basis.

* **Documentation**
  * Updated code samples to demonstrate the new structured filterable attributes configuration format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->