### PR TITLE
Add support for Dynamic Search Rules

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -576,9 +576,9 @@ facet_search_3: |-
   };
   await client.Index("books").FacetSearchAsync("genres", query);
 list_dynamic_search_rules_1: |-
-  await _client.ListDynamicSearchRulesAsync();
+  await client.ListDynamicSearchRulesAsync();
 get_dynamic_search_rule_1: |-
-  await _client.GetDynamicSearchRuleAsync("black-friday");
+  await client.GetDynamicSearchRuleAsync("black-friday");
 patch_dynamic_search_rule_1: |-
   var patchQuery = new PatchDynamicSearchRule
   {
@@ -603,6 +603,6 @@ patch_dynamic_search_rule_1: |-
       }
     }
   };
-  await _client.CreateOrUpdateDynamicSearchRuleAsync("black-friday", patchQuery);
+  await client.CreateOrUpdateDynamicSearchRuleAsync("black-friday", patchQuery);
 delete_dynamic_search_rule_1: |-
-  await _client.DeleteDynamicSearchRuleAsync("black-friday");
+  await client.DeleteDynamicSearchRuleAsync("black-friday");

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -575,3 +575,34 @@ facet_search_3: |-
     ExhaustiveFacetCount: true
   };
   await client.Index("books").FacetSearchAsync("genres", query);
+list_dynamic_search_rules_1: |-
+  await _client.ListDynamicSearchRulesAsync();
+get_dynamic_search_rule_1: |-
+  await _client.GetDynamicSearchRuleAsync("black-friday");
+patch_dynamic_search_rule_1: |-
+  var patchQuery = new PatchDynamicSearchRule
+  {
+    Description = "Black Friday 2025 rules",
+    Priority = 10,
+    Active = true,
+    Conditions = new BaseCondition[]
+    {
+      new QueryCondition { IsEmpty = true },
+      new TimeCondition
+      {
+        Start = new DateTimeOffset(2025, 11, 28, 0, 0, 0, TimeSpan.Zero),
+        End = new DateTimeOffset(2025, 11, 28, 23, 59, 59, TimeSpan.Zero)
+      },
+    },
+    Actions = new[]
+    {
+      new DSRAction
+      {
+        Selector = new DSRASelector { IndexUid = "products", Id = "123" },
+        Action = new PinAction { Position = 1 }
+      }
+    }
+  };
+  await _client.CreateOrUpdateDynamicSearchRuleAsync("black-friday", patchQuery);
+delete_dynamic_search_rule_1: |-
+  await _client.DeleteDynamicSearchRuleAsync("black-friday");

--- a/src/Meilisearch/Constants.cs
+++ b/src/Meilisearch/Constants.cs
@@ -17,6 +17,7 @@ namespace Meilisearch
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new OptionalJsonConverterFactory() },
         };
 
         /// <summary>

--- a/src/Meilisearch/Converters/BaseObjectWithTypesConverter.cs
+++ b/src/Meilisearch/Converters/BaseObjectWithTypesConverter.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Meilisearch.Converters
+{
+    public class BaseObjectWithTypesConverter<TBase, TType>: JsonConverter<TBase> where TType : struct, Enum
+    {
+        private readonly string _typePropertyName;
+        private readonly Dictionary<TType, Type> _mapper;
+
+        public BaseObjectWithTypesConverter(string typePropertyName, Dictionary<TType, Type> mapper)
+        {
+            _typePropertyName = typePropertyName;
+            _mapper = mapper;
+        }
+
+        public override TBase Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using (var doc = JsonDocument.ParseValue(ref reader))
+            {
+                var root = doc.RootElement;
+                if (!root.TryGetProperty(_typePropertyName, out var typeElement))
+                    throw new JsonException($"Expected {_typePropertyName} property");
+
+                var typeStr = typeElement.GetString();
+                if (!Enum.TryParse(typeStr, true, out TType type))
+                    throw new JsonException($"Unexpected value for {_typePropertyName} property found: {typeStr}");
+
+                if (!_mapper.TryGetValue(type, out var resultType))
+                    throw new JsonException($"Unimplemented {_typePropertyName} type: {type}");
+
+                return (TBase) JsonSerializer.Deserialize(root.GetRawText(), resultType, options);
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, TBase value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value, value.GetType(), options);
+        }
+    }
+
+
+    public class DynamicSearchRuleActionConverter : BaseObjectWithTypesConverter<BaseAction, ActionType>
+    {
+        public DynamicSearchRuleActionConverter() : base(BaseAction.TypePropertyName,
+            new Dictionary<ActionType, Type> { [ActionType.Pin] = typeof(PinAction) })
+        {
+        }
+    }
+
+    public class DynamicSearchRuleConditionConverter : BaseObjectWithTypesConverter<BaseCondition, ConditionType>
+    {
+        public DynamicSearchRuleConditionConverter() : base(BaseCondition.ScopePropertyName,
+            new Dictionary<ConditionType, Type>
+            {
+                [ConditionType.Query] = typeof(QueryCondition),
+                [ConditionType.Time] = typeof(TimeCondition)
+            })
+        {
+        }
+    }
+}

--- a/src/Meilisearch/Converters/BaseObjectWithTypesConverter.cs
+++ b/src/Meilisearch/Converters/BaseObjectWithTypesConverter.cs
@@ -6,10 +6,10 @@ using System.Text.Json.Serialization;
 namespace Meilisearch.Converters
 {
     /// <summary>
-    /// Base converter for classes that have property which can define other properties according to provided value
+    /// Base JSON converter for polymorphic objects identified by a discriminator property
     /// </summary>
-    /// <typeparam name="TBase">Abstract class with type defining property</typeparam>
-    /// <typeparam name="TType">Enum type which defines other fields of inheritor</typeparam>
+    /// <typeparam name="TBase">Base type that contains the discriminator property</typeparam>
+    /// <typeparam name="TType">Enum used to determine the concrete derived type</typeparam>
     public abstract class BaseObjectWithTypesConverter<TBase, TType>: JsonConverter<TBase> where TType : struct, Enum
     {
         private readonly string _typePropertyName;
@@ -18,8 +18,8 @@ namespace Meilisearch.Converters
         /// <summary>
         /// Default constructor to define converter behavior
         /// </summary>
-        /// <param name="typePropertyName">Name of property which defines type</param>
-        /// <param name="mapper">Dictionary defines mapping between Enum value and inheritor type</param>
+        /// <param name="typePropertyName">Name of the discriminator property</param>
+        /// <param name="mapper">Mapping between discriminator values and their corresponding derived types</param>
         protected BaseObjectWithTypesConverter(string typePropertyName, Dictionary<TType, Type> mapper)
         {
             _typePropertyName = typePropertyName;
@@ -54,16 +54,16 @@ namespace Meilisearch.Converters
     }
 
     /// <summary>
-    /// Defines converter for BaseAction implementations
+    /// JSON converter for <see cref="BaseAction"/> implementations.
     /// </summary>
     public class DynamicSearchRuleActionConverter : BaseObjectWithTypesConverter<BaseAction, ActionType>
     {
         /// <summary>
         /// <inheritdoc/>
-        /// Provides next mappings:
+        /// Supports the following mappings:
         /// <list type="bullet">
         /// <item>
-        /// <description>ActionType.Pin -&gt; PinAction</description>
+        /// <description><see cref="ActionType.Pin"/> -&gt; <see cref="PinAction"/></description>
         /// </item>
         /// </list>
         /// </summary>
@@ -80,13 +80,13 @@ namespace Meilisearch.Converters
     {
         /// <summary>
         /// <inheritdoc/>
-        /// Provides next mappings:
+        /// Supports the following mappings:
         /// <list type="bullet">
         /// <item>
-        /// <description>ConditionType.Query -&gt; QueryCondition</description>
+        /// <description><see cref="ConditionType.Query"/> -&gt; <see cref="QueryCondition"/></description>
         /// </item>
         /// <item>
-        /// <description>ConditionType.Time -&gt; TimeCondition</description>
+        /// <description><see cref="ConditionType.Time"/> -&gt; <see cref="TimeCondition"/></description>
         /// </item>
         /// </list>
         /// </summary>

--- a/src/Meilisearch/Converters/BaseObjectWithTypesConverter.cs
+++ b/src/Meilisearch/Converters/BaseObjectWithTypesConverter.cs
@@ -5,17 +5,28 @@ using System.Text.Json.Serialization;
 
 namespace Meilisearch.Converters
 {
-    public class BaseObjectWithTypesConverter<TBase, TType>: JsonConverter<TBase> where TType : struct, Enum
+    /// <summary>
+    /// Base converter for classes that have property which can define other properties according to provided value
+    /// </summary>
+    /// <typeparam name="TBase">Abstract class with type defining property</typeparam>
+    /// <typeparam name="TType">Enum type which defines other fields of inheritor</typeparam>
+    public abstract class BaseObjectWithTypesConverter<TBase, TType>: JsonConverter<TBase> where TType : struct, Enum
     {
         private readonly string _typePropertyName;
         private readonly Dictionary<TType, Type> _mapper;
 
-        public BaseObjectWithTypesConverter(string typePropertyName, Dictionary<TType, Type> mapper)
+        /// <summary>
+        /// Default constructor to define converter behavior
+        /// </summary>
+        /// <param name="typePropertyName">Name of property which defines type</param>
+        /// <param name="mapper">Dictionary defines mapping between Enum value and inheritor type</param>
+        protected BaseObjectWithTypesConverter(string typePropertyName, Dictionary<TType, Type> mapper)
         {
             _typePropertyName = typePropertyName;
             _mapper = mapper;
         }
 
+        /// <inheritdoc/>
         public override TBase Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             using (var doc = JsonDocument.ParseValue(ref reader))
@@ -35,23 +46,50 @@ namespace Meilisearch.Converters
             }
         }
 
+        /// <inheritdoc/>
         public override void Write(Utf8JsonWriter writer, TBase value, JsonSerializerOptions options)
         {
             JsonSerializer.Serialize(writer, value, value.GetType(), options);
         }
     }
 
-
+    /// <summary>
+    /// Defines converter for BaseAction implementations
+    /// </summary>
     public class DynamicSearchRuleActionConverter : BaseObjectWithTypesConverter<BaseAction, ActionType>
     {
+        /// <summary>
+        /// <inheritdoc/>
+        /// Provides next mappings:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>ActionType.Pin -&gt; PinAction</description>
+        /// </item>
+        /// </list>
+        /// </summary>
         public DynamicSearchRuleActionConverter() : base(BaseAction.TypePropertyName,
             new Dictionary<ActionType, Type> { [ActionType.Pin] = typeof(PinAction) })
         {
         }
     }
 
+    /// <summary>
+    /// Defines converter for BaseCondition implementations
+    /// </summary>
     public class DynamicSearchRuleConditionConverter : BaseObjectWithTypesConverter<BaseCondition, ConditionType>
     {
+        /// <summary>
+        /// <inheritdoc/>
+        /// Provides next mappings:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>ConditionType.Query -&gt; QueryCondition</description>
+        /// </item>
+        /// <item>
+        /// <description>ConditionType.Time -&gt; TimeCondition</description>
+        /// </item>
+        /// </list>
+        /// </summary>
         public DynamicSearchRuleConditionConverter() : base(BaseCondition.ScopePropertyName,
             new Dictionary<ConditionType, Type>
             {

--- a/src/Meilisearch/Converters/BaseObjectWithTypesConverter.cs
+++ b/src/Meilisearch/Converters/BaseObjectWithTypesConverter.cs
@@ -10,7 +10,7 @@ namespace Meilisearch.Converters
     /// </summary>
     /// <typeparam name="TBase">Base type that contains the discriminator property</typeparam>
     /// <typeparam name="TType">Enum used to determine the concrete derived type</typeparam>
-    public abstract class BaseObjectWithTypesConverter<TBase, TType>: JsonConverter<TBase> where TType : struct, Enum
+    public abstract class BaseObjectWithTypesConverter<TBase, TType> : JsonConverter<TBase> where TType : struct, Enum
     {
         private readonly string _typePropertyName;
         private readonly Dictionary<TType, Type> _mapper;
@@ -42,7 +42,7 @@ namespace Meilisearch.Converters
                 if (!_mapper.TryGetValue(type, out var resultType))
                     throw new JsonException($"Unimplemented {_typePropertyName} type: {type}");
 
-                return (TBase) JsonSerializer.Deserialize(root.GetRawText(), resultType, options);
+                return (TBase)JsonSerializer.Deserialize(root.GetRawText(), resultType, options);
             }
         }
 

--- a/src/Meilisearch/Converters/EnumToCamelCaseConverter.cs
+++ b/src/Meilisearch/Converters/EnumToCamelCaseConverter.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 namespace Meilisearch.Converters
 {
     /// <summary>
-    /// Converts enum values of <typeparamref name="TEnum"/> into CamelCase string laterals
+    /// Converts enum values of <typeparamref name="TEnum"/> into CamelCase JSON strings
     /// </summary>
     /// <typeparam name="TEnum">Type of enum to convert</typeparam>
     public class EnumToCamelCaseConverter<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum

--- a/src/Meilisearch/Converters/EnumToCamelCaseConverter.cs
+++ b/src/Meilisearch/Converters/EnumToCamelCaseConverter.cs
@@ -4,8 +4,13 @@ using System.Text.Json.Serialization;
 
 namespace Meilisearch.Converters
 {
+    /// <summary>
+    /// Converts enum values of <typeparamref name="TEnum"/> into CamelCase string laterals
+    /// </summary>
+    /// <typeparam name="TEnum">Type of enum to convert</typeparam>
     public class EnumToCamelCaseConverter<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
     {
+        /// <inheritdoc/>
         public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType != JsonTokenType.String)
@@ -17,6 +22,7 @@ namespace Meilisearch.Converters
                 : throw new JsonException($"Invalid {typeof(TEnum).Name} value: '{enumString}'.");
         }
 
+        /// <inheritdoc/>
         public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
         {
             var valueStr = JsonNamingPolicy.CamelCase.ConvertName(value.ToString());

--- a/src/Meilisearch/Converters/EnumToCamelCaseConverter.cs
+++ b/src/Meilisearch/Converters/EnumToCamelCaseConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Meilisearch.Converters
+{
+    public class EnumToCamelCaseConverter<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
+    {
+        public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected string for ConditionType, but found {reader.TokenType}.");
+
+            var enumString = reader.GetString();
+            return Enum.TryParse<TEnum>(enumString, true, out var enumValue)
+                ? enumValue
+                : throw new JsonException($"Invalid {typeof(TEnum)} value: '{enumValue}'.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+        {
+            var valueStr = JsonNamingPolicy.CamelCase.ConvertName(value.ToString());
+            writer.WriteStringValue(valueStr);
+        }
+    }
+}

--- a/src/Meilisearch/Converters/EnumToCamelCaseConverter.cs
+++ b/src/Meilisearch/Converters/EnumToCamelCaseConverter.cs
@@ -9,12 +9,12 @@ namespace Meilisearch.Converters
         public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType != JsonTokenType.String)
-                throw new JsonException($"Expected string for ConditionType, but found {reader.TokenType}.");
+                throw new JsonException($"Expected string for {typeof(TEnum).Name}, but found {reader.TokenType}.");
 
             var enumString = reader.GetString();
             return Enum.TryParse<TEnum>(enumString, true, out var enumValue)
                 ? enumValue
-                : throw new JsonException($"Invalid {typeof(TEnum)} value: '{enumValue}'.");
+                : throw new JsonException($"Invalid {typeof(TEnum).Name} value: '{enumString}'.");
         }
 
         public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)

--- a/src/Meilisearch/Converters/OptionalJsonConverter.cs
+++ b/src/Meilisearch/Converters/OptionalJsonConverter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Meilisearch.Converters
+{
+    public struct Optional<T>
+    {
+        public bool HasValue { get; private set; }
+
+        private T _value;
+
+        public T Value
+        {
+            get =>
+                HasValue
+                    ? _value
+                    : throw new InvalidOperationException("Value is not set");
+            set
+            {
+                HasValue = true;
+                _value = value;
+            }
+        }
+
+        public static Optional<T> None => default;
+        public static implicit operator Optional<T>(T value) => new Optional<T> { Value = value };
+    }
+
+    public class OptionalJsonConverter<T> : JsonConverter<Optional<T>>
+    {
+        public override Optional<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => JsonSerializer.Deserialize<T>(ref reader, options);
+
+        public override void Write(Utf8JsonWriter writer, Optional<T> value, JsonSerializerOptions options)
+        {
+            if (!value.HasValue)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            JsonSerializer.Serialize(writer, value.Value, options);
+        }
+    }
+
+    public class OptionalJsonConverterFactory : JsonConverterFactory
+    {
+        public override bool CanConvert(Type typeToConvert)
+            => typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(Optional<>);
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            var converterType = typeof(OptionalJsonConverter<>)
+                .MakeGenericType(typeToConvert.GetGenericArguments()[0]);
+            return (JsonConverter)Activator.CreateInstance(converterType);
+        }
+    }
+}

--- a/src/Meilisearch/Converters/OptionalJsonConverter.cs
+++ b/src/Meilisearch/Converters/OptionalJsonConverter.cs
@@ -11,7 +11,7 @@ namespace Meilisearch.Converters
     public struct Optional<T>
     {
         /// <summary>
-        /// Indicates whether value was provided or not
+        /// Indicates whether a value was explicitly provided
         /// </summary>
         public bool HasValue { get; private set; }
 
@@ -20,7 +20,7 @@ namespace Meilisearch.Converters
         /// <summary>
         /// Provided value
         /// </summary>
-        /// <exception cref="InvalidOperationException">Throws when value was not provided</exception>
+        /// <exception cref="InvalidOperationException">Throws when no value has been provided</exception>
         public T Value
         {
             get =>
@@ -35,20 +35,20 @@ namespace Meilisearch.Converters
         }
 
         /// <summary>
-        /// Default value of Optional&lt;<typeparamref name="T"/>&gt;
+        /// Instance with no value provided
         /// </summary>
         public static Optional<T> None => default;
 
         /// <summary>
-        /// Implicit converter of provided <typeparamref name="T"/> type value into Optional&lt;<typeparamref name="T"/>&gt;
+        /// Implicitly converts a value into an <see cref="Optional{T}"/> instance
         /// </summary>
         /// <param name="value">Provided value</param>
-        /// <returns></returns>
+        /// <returns>An <see cref="Optional{T}"/> containing the specified value</returns>
         public static implicit operator Optional<T>(T value) => new Optional<T> { Value = value };
     }
 
     /// <summary>
-    /// Converter for Optional&lt;<typeparamref name="T"/>&gt;
+    /// Converter for <see cref="Optional{T}"/>
     /// </summary>
     /// <typeparam name="T">Possible type of provided value</typeparam>
     public class OptionalJsonConverter<T> : JsonConverter<Optional<T>>
@@ -59,7 +59,7 @@ namespace Meilisearch.Converters
 
         /// <inheritdoc/>
         /// <summary>
-        /// Writes given <paramref name="value"/> as JSON into <paramref name="writer"/>. Writes null, when value wasn't provided.
+        /// Writes given <paramref name="value"/> as JSON into <paramref name="writer"/>. If the value was not provided, writes <c>null</c>.
         /// Recommended to use with JsonIgnoreAttribute with ignoring when value is default:
         /// <code>[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]</code>
         /// </summary>
@@ -76,7 +76,7 @@ namespace Meilisearch.Converters
     }
 
     /// <summary>
-    /// Factory for automatic creation of OptionalJsonConverter&lt;T&gt; for all incoming types of Optional&lt;T&gt; implicitly
+    /// Factory that automatically creates converters for all <see cref="Optional{T}"/>
     /// </summary>
     public class OptionalJsonConverterFactory : JsonConverterFactory
     {

--- a/src/Meilisearch/Converters/OptionalJsonConverter.cs
+++ b/src/Meilisearch/Converters/OptionalJsonConverter.cs
@@ -4,12 +4,23 @@ using System.Text.Json.Serialization;
 
 namespace Meilisearch.Converters
 {
+    /// <summary>
+    /// Class that helps to differ nullable and not provided values
+    /// </summary>
+    /// <typeparam name="T">Possible type of provided value</typeparam>
     public struct Optional<T>
     {
+        /// <summary>
+        /// Indicates whether value was provided or not
+        /// </summary>
         public bool HasValue { get; private set; }
 
         private T _value;
 
+        /// <summary>
+        /// Provided value
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Throws when value was not provided</exception>
         public T Value
         {
             get =>
@@ -23,15 +34,35 @@ namespace Meilisearch.Converters
             }
         }
 
+        /// <summary>
+        /// Default value of Optional&lt;<typeparamref name="T"/>&gt;
+        /// </summary>
         public static Optional<T> None => default;
+
+        /// <summary>
+        /// Implicit converter of provided <typeparamref name="T"/> type value into Optional&lt;<typeparamref name="T"/>&gt;
+        /// </summary>
+        /// <param name="value">Provided value</param>
+        /// <returns></returns>
         public static implicit operator Optional<T>(T value) => new Optional<T> { Value = value };
     }
 
+    /// <summary>
+    /// Converter for Optional&lt;<typeparamref name="T"/>&gt;
+    /// </summary>
+    /// <typeparam name="T">Possible type of provided value</typeparam>
     public class OptionalJsonConverter<T> : JsonConverter<Optional<T>>
     {
+        /// <inheritdoc/>
         public override Optional<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             => JsonSerializer.Deserialize<T>(ref reader, options);
 
+        /// <inheritdoc/>
+        /// <summary>
+        /// Writes given <paramref name="value"/> as JSON into <paramref name="writer"/>. Writes null, when value wasn't provided.
+        /// Recommended to use with JsonIgnoreAttribute with ignoring when value is default:
+        /// <code>[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]</code>
+        /// </summary>
         public override void Write(Utf8JsonWriter writer, Optional<T> value, JsonSerializerOptions options)
         {
             if (!value.HasValue)
@@ -44,11 +75,16 @@ namespace Meilisearch.Converters
         }
     }
 
+    /// <summary>
+    /// Factory for automatic creation of OptionalJsonConverter&lt;T&gt; for all incoming types of Optional&lt;T&gt; implicitly
+    /// </summary>
     public class OptionalJsonConverterFactory : JsonConverterFactory
     {
+        /// <inheritdoc/>
         public override bool CanConvert(Type typeToConvert)
             => typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(Optional<>);
 
+        /// <inheritdoc/>
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             var converterType = typeof(OptionalJsonConverter<>)

--- a/src/Meilisearch/DynamicSearchRule.Action.cs
+++ b/src/Meilisearch/DynamicSearchRule.Action.cs
@@ -5,7 +5,7 @@ using Meilisearch.Converters;
 namespace Meilisearch
 {
     /// <summary>
-    /// Enum that indicates action type for BaseAction objects
+    /// Enum that indicates action type for <see cref="BaseAction"/> objects
     /// </summary>
     [JsonConverter(typeof(EnumToCamelCaseConverter<ActionType>))]
     public enum ActionType
@@ -72,7 +72,7 @@ namespace Meilisearch
     }
 
     /// <summary>
-    /// Pin action for found documents using Dynamic Search Rules
+    /// Action that pins matching documents to a specific position
     /// </summary>
     public class PinAction : BaseAction
     {

--- a/src/Meilisearch/DynamicSearchRule.Action.cs
+++ b/src/Meilisearch/DynamicSearchRule.Action.cs
@@ -1,16 +1,24 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 using Meilisearch.Converters;
 
 namespace Meilisearch
 {
+    /// <summary>
+    /// Enum that indicates action type for BaseAction objects
+    /// </summary>
     [JsonConverter(typeof(EnumToCamelCaseConverter<ActionType>))]
     public enum ActionType
     {
+        /// <summary>
+        /// Pin action
+        /// </summary>
         Pin
     }
 
+    /// <summary>
+    /// Wrapper for Selector - Action pairs
+    /// </summary>
     public class DSRAction
     {
         /// <summary>
@@ -26,6 +34,9 @@ namespace Meilisearch
         public BaseAction Action { get; set; }
     }
 
+    /// <summary>
+    /// Target document selector descriptor
+    /// </summary>
     public class DSRASelector
     {
         /// <summary>
@@ -35,16 +46,22 @@ namespace Meilisearch
         public string IndexUid { get; set; }
 
         /// <summary>
-        /// Gets ir sets id
+        /// Gets or sets id
         /// </summary>
         [JsonPropertyName("id")]
         public string Id { get; set; }
     }
 
 
+    /// <summary>
+    /// Base class of Actions for Dynamic Search Rules
+    /// </summary>
     [JsonConverter(typeof(DynamicSearchRuleActionConverter))]
     public abstract class BaseAction
     {
+        /// <summary>
+        /// Property name that defines type of BaseAction object
+        /// </summary>
         public const string TypePropertyName = "type";
 
         /// <summary>
@@ -54,8 +71,13 @@ namespace Meilisearch
         public abstract ActionType Type { get; }
     }
 
+    /// <summary>
+    /// Pin action for found documents using Dynamic Search Rules
+    /// </summary>
     public class PinAction : BaseAction
     {
+        /// <inheritdoc/>
+        /// <value>ActionType.Pin</value>
         public override ActionType Type => ActionType.Pin;
 
         /// <summary>

--- a/src/Meilisearch/DynamicSearchRule.Action.cs
+++ b/src/Meilisearch/DynamicSearchRule.Action.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+using Meilisearch.Converters;
+
+namespace Meilisearch
+{
+    [JsonConverter(typeof(EnumToCamelCaseConverter<ActionType>))]
+    public enum ActionType
+    {
+        Pin
+    }
+
+    public class DSRAction
+    {
+        /// <summary>
+        /// Target document selector for this action
+        /// </summary>
+        [JsonPropertyName("selector")]
+        public DSRASelector Selector { get; set; }
+
+        /// <summary>
+        /// Action payload to apply to the selected document
+        /// </summary>
+        [JsonPropertyName("action")]
+        public BaseAction Action { get; set; }
+    }
+
+    public class DSRASelector
+    {
+        /// <summary>
+        /// Gets or sets indexUid
+        /// </summary>
+        [JsonPropertyName("indexUid")]
+        public string IndexUid { get; set; }
+
+        /// <summary>
+        /// Gets ir sets id
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+    }
+
+
+    [JsonConverter(typeof(DynamicSearchRuleActionConverter))]
+    public abstract class BaseAction
+    {
+        public const string TypePropertyName = "type";
+
+        /// <summary>
+        /// Describes action type
+        /// </summary>
+        [JsonPropertyName(TypePropertyName)]
+        public abstract ActionType Type { get; }
+    }
+
+    public class PinAction : BaseAction
+    {
+        public override ActionType Type => ActionType.Pin;
+
+        /// <summary>
+        /// Gets or sets position
+        /// </summary>
+        [JsonPropertyName("position")]
+        public int Position { get; set; }
+    }
+}

--- a/src/Meilisearch/DynamicSearchRule.Condition.cs
+++ b/src/Meilisearch/DynamicSearchRule.Condition.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Text.Json.Serialization;
+
+using Meilisearch.Converters;
+
+namespace Meilisearch
+{
+    [JsonConverter(typeof(EnumToCamelCaseConverter<ConditionType>))]
+    public enum ConditionType
+    {
+        Query,
+        Time
+    }
+
+    [JsonConverter(typeof(DynamicSearchRuleConditionConverter))]
+    public abstract class BaseCondition
+    {
+        public const string ScopePropertyName = "scope";
+
+        /// <summary>
+        /// Describes condition type
+        /// </summary>
+        [JsonPropertyName(ScopePropertyName)]
+        public abstract ConditionType Scope { get; }
+    }
+
+    public class QueryCondition : BaseCondition
+    {
+        public override ConditionType Scope => ConditionType.Query;
+
+        /// <summary>
+        /// Gets or sets isEmpty
+        /// </summary>
+        [JsonPropertyName("isEmpty")]
+        public bool? IsEmpty { get; set; }
+
+        /// <summary>
+        /// Gets or sets contains
+        /// </summary>
+        [JsonPropertyName("contains")]
+        public string Contains { get; set; }
+    }
+
+    public class TimeCondition : BaseCondition
+    {
+        public override ConditionType Scope => ConditionType.Time;
+
+        /// <summary>
+        /// Gets or sets start
+        /// </summary>
+        [JsonPropertyName("start")]
+        public DateTimeOffset? Start { get; set; }
+
+        /// <summary>
+        /// Gets or sets end
+        /// </summary>
+        [JsonPropertyName("end")]
+        public DateTimeOffset? End { get; set; }
+    }
+}

--- a/src/Meilisearch/DynamicSearchRule.Condition.cs
+++ b/src/Meilisearch/DynamicSearchRule.Condition.cs
@@ -5,16 +5,31 @@ using Meilisearch.Converters;
 
 namespace Meilisearch
 {
+    /// <summary>
+    /// Enum that indicates action type for BaseAction objects
+    /// </summary>
     [JsonConverter(typeof(EnumToCamelCaseConverter<ConditionType>))]
     public enum ConditionType
     {
+        /// <summary>
+        /// Condition as query
+        /// </summary>
         Query,
+        /// <summary>
+        /// Condition as time interval
+        /// </summary>
         Time
     }
 
+    /// <summary>
+    /// Base class of Conditions for Dynamic Search Rules
+    /// </summary>
     [JsonConverter(typeof(DynamicSearchRuleConditionConverter))]
     public abstract class BaseCondition
     {
+        /// <summary>
+        /// Property name that defines type of BaseCondition object
+        /// </summary>
         public const string ScopePropertyName = "scope";
 
         /// <summary>
@@ -24,8 +39,12 @@ namespace Meilisearch
         public abstract ConditionType Scope { get; }
     }
 
+    /// <summary>
+    /// Condition for searching the documents by the query using Dynamic Search Rules
+    /// </summary>
     public class QueryCondition : BaseCondition
     {
+        /// <inheritdoc/>
         public override ConditionType Scope => ConditionType.Query;
 
         /// <summary>
@@ -41,8 +60,12 @@ namespace Meilisearch
         public string Contains { get; set; }
     }
 
+    /// <summary>
+    /// Condition for searching the documents by the time interval using Dynamic Search Rules
+    /// </summary>
     public class TimeCondition : BaseCondition
     {
+        /// <inheritdoc/>
         public override ConditionType Scope => ConditionType.Time;
 
         /// <summary>

--- a/src/Meilisearch/DynamicSearchRule.Condition.cs
+++ b/src/Meilisearch/DynamicSearchRule.Condition.cs
@@ -6,7 +6,7 @@ using Meilisearch.Converters;
 namespace Meilisearch
 {
     /// <summary>
-    /// Enum that indicates action type for BaseAction objects
+    /// Enum that indicates condition type for <see cref="BaseCondition"/> objects
     /// </summary>
     [JsonConverter(typeof(EnumToCamelCaseConverter<ConditionType>))]
     public enum ConditionType

--- a/src/Meilisearch/DynamicSearchRule.cs
+++ b/src/Meilisearch/DynamicSearchRule.cs
@@ -3,6 +3,9 @@ using System.Text.Json.Serialization;
 
 namespace Meilisearch
 {
+    /// <summary>
+    /// Meilisearch API dynamic search rule wrapper
+    /// </summary>
     public class DynamicSearchRule
     {
         /// <summary>

--- a/src/Meilisearch/DynamicSearchRule.cs
+++ b/src/Meilisearch/DynamicSearchRule.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Meilisearch
+{
+    public class DynamicSearchRule
+    {
+        /// <summary>
+        /// Gets or sets the uid.
+        /// </summary>
+        [JsonPropertyName("uid")]
+        public string Uid { get; set; }
+
+        /// <summary>
+        /// Actions to apply when dynamic search rule matches
+        /// </summary>
+        [JsonPropertyName("actions")]
+        public IEnumerable<DSRAction> Actions { get; set; }
+
+        /// <summary>
+        /// Optional field. Gets or sets the description
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Precedence of the dynamic search rule.
+        /// Lower numeric values take precedence over higher ones.
+        /// <list type="bullets">
+        ///     <item> If the same document is selected by multiple rules, the smallest <i>priority</i> number wins  </item>
+        ///     <item> If different documents are pinned to the same position, they are ordered by ascending <i>priority</i> </item>
+        /// </list>
+        /// </summary>
+        [JsonPropertyName("priority")]
+        public ulong? Priority { get; set; }
+
+        /// <summary>
+        /// Whether the dynamic search rule is active
+        /// </summary>
+        [JsonPropertyName("active")]
+        public bool Active { get; set; }
+
+        /// <summary>
+        /// Conditions that must match before the dynamic search rule applies
+        /// </summary>
+        [JsonPropertyName("conditions")]
+        public IEnumerable<BaseCondition> Conditions { get; set; }
+    }
+}

--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -88,5 +88,11 @@
         <Compile Update="Index.SimilarDocuments.cs">
           <DependentUpon>Index.cs</DependentUpon>
         </Compile>
+        <Compile Update="DynamicSearchRule.Condition.cs">
+          <DependentUpon>DynamicSearchRule.cs</DependentUpon>
+        </Compile>
+        <Compile Update="DynamicSearchRule.Action.cs">
+          <DependentUpon>DynamicSearchRule.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 </Project>

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -378,6 +378,99 @@ namespace Meilisearch
         }
 
         /// <summary>
+        /// Enables dynamic search rules experimental feature.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Successfulness of enabling as experimental feature.</returns>
+        public async Task<bool> EnableDynamicSearchRules(CancellationToken cancellationToken = default)
+        {
+            var responseMessage =
+                await _http.PatchAsJsonAsync("experimental-features", new
+                    {
+                        dynamicSearchRules = true
+                    }, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+            var result = await responseMessage.Content
+                .ReadFromJsonAsync<JsonDocument>(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            return result.RootElement.TryGetProperty("dynamicSearchRules", out var dsrElement) &&
+                   dsrElement.GetBoolean();
+        }
+
+        /// <summary>
+        /// Updates dynamic search rule with given uid or creates new one if it doesn't exist.
+        /// </summary>
+        /// <param name="uid">Unique identifier of dynamic search rule.</param>
+        /// <param name="dynamicSearchRule">Content of dynamic search rule.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Created or updated dynamic search rule.</returns>
+        public async Task<DynamicSearchRule> CreateOrUpdateDynamicSearchRuleAsync(string uid, PatchDynamicSearchRule dynamicSearchRule, CancellationToken cancellationToken = default)
+        {
+            var responseMessage =
+                await _http.PatchAsJsonAsync($"dynamic-search-rules/{uid}", dynamicSearchRule, Constants.JsonSerializerOptionsRemoveNulls,
+                    cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+            return await responseMessage.Content
+                .ReadFromJsonAsync<DynamicSearchRule>(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets list of dynamic search rules according to query.
+        /// </summary>
+        /// <param name="query">Query for listing dynamic search rules.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>List of dynamic search rules.</returns>
+        public async Task<ResourceResults<IEnumerable<DynamicSearchRule>>> ListDynamicSearchRulesAsync(DynamicSearchRulesQuery query = default, CancellationToken cancellationToken = default)
+        {
+            if (query == default) query =  new DynamicSearchRulesQuery();
+
+            var responseMessage =
+                await _http.PostAsJsonAsync("dynamic-search-rules", query, Constants.JsonSerializerOptionsRemoveNulls,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            return await responseMessage.Content
+                .ReadFromJsonAsync<ResourceResults<IEnumerable<DynamicSearchRule>>>(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets dynamic search rule with given identifier.
+        /// </summary>
+        /// <param name="uid">Unique identifier of dynamic search rule.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Dynamic search rule with given identifier.</returns>
+        public async Task<DynamicSearchRule> GetDynamicSearchRuleAsync(string uid, CancellationToken cancellationToken = default)
+        {
+            var responseMessage =
+                await _http.GetAsync($"dynamic-search-rules/{uid}", cancellationToken)
+                    .ConfigureAwait(false);
+
+            return await responseMessage.Content
+                .ReadFromJsonAsync<DynamicSearchRule>(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Deletes dynamic search rule with given identifier.
+        /// </summary>
+        /// <param name="uid">Unique identifier of dynamic search rule.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Successfulness of deletion.</returns>
+        public async Task<bool> DeleteDynamicSearchRuleAsync(string uid, CancellationToken cancellationToken = default)
+        {
+            var responseMessage =
+                await _http.DeleteAsync($"dynamic-search-rules/{uid}", cancellationToken)
+                    .ConfigureAwait(false);
+
+            return responseMessage.StatusCode == HttpStatusCode.NoContent;
+        }
+
+        /// <summary>
         /// Cancel tasks given a specific query.
         /// </summary>
         /// <param name="query">Query parameters supports by the method.</param>

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -386,9 +386,9 @@ namespace Meilisearch
         {
             var responseMessage =
                 await _http.PatchAsJsonAsync("experimental-features", new
-                    {
-                        dynamicSearchRules = true
-                    }, cancellationToken: cancellationToken)
+                {
+                    dynamicSearchRules = true
+                }, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
 
             var result = await responseMessage.Content
@@ -426,7 +426,7 @@ namespace Meilisearch
         /// <returns>List of dynamic search rules.</returns>
         public async Task<ResourceResults<IEnumerable<DynamicSearchRule>>> ListDynamicSearchRulesAsync(DynamicSearchRulesQuery query = default, CancellationToken cancellationToken = default)
         {
-            if (query == default) query =  new DynamicSearchRulesQuery();
+            if (query == default) query = new DynamicSearchRulesQuery();
 
             var responseMessage =
                 await _http.PostAsJsonAsync("dynamic-search-rules", query, Constants.JsonSerializerOptionsRemoveNulls,

--- a/src/Meilisearch/PatchDynamicSearchRule.cs
+++ b/src/Meilisearch/PatchDynamicSearchRule.cs
@@ -5,6 +5,9 @@ using Meilisearch.Converters;
 
 namespace Meilisearch
 {
+    /// <summary>
+    /// Helper to call Meilisearch API for updating or creating dynamic search rule
+    /// </summary>
     public class PatchDynamicSearchRule
     {
         /// <summary>

--- a/src/Meilisearch/PatchDynamicSearchRule.cs
+++ b/src/Meilisearch/PatchDynamicSearchRule.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+using Meilisearch.Converters;
+
+namespace Meilisearch
+{
+    public class PatchDynamicSearchRule
+    {
+        /// <summary>
+        /// Actions to apply when dynamic search rule matches
+        /// </summary>
+        [JsonPropertyName("actions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public Optional<IEnumerable<DSRAction>> Actions { get; set; }
+
+        /// <summary>
+        /// Optional field. Gets or sets the description
+        /// </summary>
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public Optional<string> Description { get; set; }
+
+        /// <summary>
+        /// Precedence of the dynamic search rule.
+        /// Lower numeric values take precedence over higher ones.
+        /// <list type="bullets">
+        ///     <item> If the same document is selected by multiple rules, the smallest <i>priority</i> number wins  </item>
+        ///     <item> If different documents are pinned to the same position, they are ordered by ascending <i>priority</i> </item>
+        /// </list>
+        /// </summary>
+        [JsonPropertyName("priority")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public Optional<ulong?> Priority { get; set; }
+
+        /// <summary>
+        /// Whether the dynamic search rule is active
+        /// </summary>
+        [JsonPropertyName("active")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public Optional<bool?> Active { get; set; }
+
+        /// <summary>
+        /// Conditions that must match before the dynamic search rule applies
+        /// </summary>
+        [JsonPropertyName("conditions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public Optional<IEnumerable<BaseCondition>> Conditions { get; set; }
+    }
+}

--- a/src/Meilisearch/QueryParameters/DynamicSearchRulesQuery.cs
+++ b/src/Meilisearch/QueryParameters/DynamicSearchRulesQuery.cs
@@ -29,7 +29,8 @@ namespace Meilisearch.QueryParameters
         /// <summary>
         /// A class that handles the creation of a filter parameter for query string for DynamicSearchRules.
         /// </summary>
-        public class DSRQFilter {
+        public class DSRQFilter
+        {
             /// <summary>
             /// Only includes rules whose attribute names match these patterns.
             /// </summary>

--- a/src/Meilisearch/QueryParameters/DynamicSearchRulesQuery.cs
+++ b/src/Meilisearch/QueryParameters/DynamicSearchRulesQuery.cs
@@ -31,7 +31,7 @@ namespace Meilisearch.QueryParameters
         /// </summary>
         public class DSRQFilter {
             /// <summary>
-            /// Only includes whose names match these patterns.
+            /// Only includes rules whose attribute names match these patterns.
             /// </summary>
             [JsonPropertyName("attribute_patterns")]
             public DSRQFilterPatterns AttributePatterns { get; set; }

--- a/src/Meilisearch/QueryParameters/DynamicSearchRulesQuery.cs
+++ b/src/Meilisearch/QueryParameters/DynamicSearchRulesQuery.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Meilisearch.QueryParameters
+{
+    /// <summary>
+    /// A class that handles the creation of a query body for DynamicSearchRules.
+    /// </summary>
+    public class DynamicSearchRulesQuery
+    {
+        /// <summary>
+        /// Gets or sets the offset.
+        /// </summary>
+        [JsonPropertyName("offset")]
+        public int? Offset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the limit.
+        /// </summary>
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// An optional filter to restrict which rules are returned
+        /// </summary>
+        [JsonPropertyName("filter")]
+        public DSRQFilter Filter { get; set; }
+
+        /// <summary>
+        /// A class that handles the creation of a filter parameter for query string for DynamicSearchRules.
+        /// </summary>
+        public class DSRQFilter {
+            /// <summary>
+            /// Only includes whose names match these patterns.
+            /// </summary>
+            [JsonPropertyName("attribute_patterns")]
+            public DSRQFilterPatterns AttributePatterns { get; set; }
+
+            /// <summary>
+            /// An option to include only active or not active rules.
+            /// </summary>
+            [JsonPropertyName("active")]
+            public bool? Active { get; set; }
+
+            /// <summary>
+            /// A class that handles creation of list of patterns wrapped into object for filter class
+            /// </summary>
+            public class DSRQFilterPatterns
+            {
+                /// <summary>
+                /// Patterns list
+                /// </summary>
+                [JsonPropertyName("patterns")]
+                public IEnumerable<string> Patterns { get; set; }
+            }
+        }
+    }
+}

--- a/tests/Meilisearch.Tests/Datasets.cs
+++ b/tests/Meilisearch.Tests/Datasets.cs
@@ -20,6 +20,10 @@ namespace Meilisearch.Tests
         public static readonly string MoviesWithInfoJsonPath = Path.Combine(BasePath, "movies_with_info.json");
 
         public static readonly string ProductsForDistinctJsonPath = Path.Combine(BasePath, "products_for_distinct_search.json");
+
+        public const string DynamicSearchRuleJsonPath = "dynamic_search_rule.json";
+        public const string DynamicSearchRuleWithOptionalValuesJsonPath = "dynamic_search_rule_with_optional_values.json";
+        public static string GetDynamicSearchRuleJsonPath(string file) => Path.Combine(BasePath, file);
     }
 
     public class DatasetSmallMovie

--- a/tests/Meilisearch.Tests/Datasets/dynamic_search_rule.json
+++ b/tests/Meilisearch.Tests/Datasets/dynamic_search_rule.json
@@ -1,0 +1,15 @@
+{
+  "description": "Black Friday 2025 rules",
+  "priority": 10,
+  "active": true,
+  "conditions": [
+    { "scope": "query", "isEmpty": true },
+    { "scope": "time", "start": "2025-11-28T00:00:00Z", "end": "2025-11-28T23:59:59Z" }
+  ],
+  "actions": [
+    {
+      "selector": { "indexUid": "products", "id": "123" },
+      "action": { "type": "pin", "position": 1 }
+    }
+  ]
+}

--- a/tests/Meilisearch.Tests/Datasets/dynamic_search_rule_with_optional_values.json
+++ b/tests/Meilisearch.Tests/Datasets/dynamic_search_rule_with_optional_values.json
@@ -1,0 +1,14 @@
+{
+  "description": "Black Friday 2025 rules",
+  "priority": null,
+  "conditions": [
+    { "scope": "query", "isEmpty": true },
+    { "scope": "time", "start": "2025-11-28T00:00:00Z", "end": "2025-11-28T23:59:59Z" }
+  ],
+  "actions": [
+    {
+      "selector": { "indexUid": "products",  "id": "123" },
+      "action": { "type": "pin", "position": 1 }
+    }
+  ]
+}

--- a/tests/Meilisearch.Tests/DocumentTests.cs
+++ b/tests/Meilisearch.Tests/DocumentTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 
 using Meilisearch.QueryParameters;
+using Meilisearch.Tests.Fixtures;
 
 using Xunit;
 

--- a/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
+++ b/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
@@ -1,13 +1,9 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 using Meilisearch.QueryParameters;
+using Meilisearch.Tests.Fixtures;
 
 using Xunit;
 

--- a/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
+++ b/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+using Meilisearch.QueryParameters;
+
+using Xunit;
+
+namespace Meilisearch.Tests
+{
+    public class DynamicSearchRuleTests<TFixture> : IAsyncLifetime where TFixture : DynamicSearchRuleFixture
+    {
+        private readonly MeilisearchClient _client;
+
+        private readonly TFixture _fixture;
+
+        public DynamicSearchRuleTests(TFixture fixture)
+        {
+            _fixture = fixture;
+            _client = fixture.DefaultClient;
+        }
+
+        public Task InitializeAsync() => _fixture.InitializeAsync();
+
+        public Task DisposeAsync() => _fixture.DisposeAsync();
+
+        [Fact]
+        public async Task CreateDynamicSearchRuleAsync()
+        {
+            const string dynamicSearchRuleUid = nameof(CreateDynamicSearchRuleAsync);
+            var dynamicSearchRule = new PatchDynamicSearchRule
+            {
+                Description = "Black Friday 2025 rules",
+                Priority = 10,
+                Active = true,
+                Conditions = new BaseCondition[]
+                {
+                    new QueryCondition { IsEmpty = true },
+                    new TimeCondition
+                    {
+                        Start = new DateTimeOffset(2025, 11, 28, 0, 0, 0, TimeSpan.Zero),
+                        End = new DateTimeOffset(2025, 11, 28, 23, 59, 59, TimeSpan.FromHours(3))
+                    },
+                },
+                Actions = new[]
+                {
+                    new DSRAction
+                    {
+                        Selector = new DSRASelector { IndexUid = "products", Id = "123" },
+                        Action = new PinAction { Position = 1 }
+                    }
+                }
+            };
+
+            var result = await _client.CreateOrUpdateDynamicSearchRuleAsync(dynamicSearchRuleUid, dynamicSearchRule);
+
+            AssertDynamicSearchRule(dynamicSearchRule.ToDynamicSearchRule(dynamicSearchRuleUid), result);
+        }
+
+        [Fact]
+        public async Task CreateDynamicSearchRuleWithoutActionsAsync()
+        {
+            const string dynamicSearchRuleUid = nameof(CreateDynamicSearchRuleWithoutActionsAsync);
+            var dynamicSearchRule = new PatchDynamicSearchRule();
+
+            var exception = await Assert.ThrowsAsync<MeilisearchApiError>(() => _client.CreateOrUpdateDynamicSearchRuleAsync(dynamicSearchRuleUid, dynamicSearchRule));
+            Assert.Equal("invalid_dynamic_search_rule_actions", exception.Code);
+        }
+
+        [Fact]
+        public async Task CreateDynamicSearchRuleWithEmptyActionsAsync()
+        {
+            const string dynamicSearchRuleUid = nameof(CreateDynamicSearchRuleWithoutActionsAsync);
+            var dynamicSearchRule = new PatchDynamicSearchRule
+            {
+                Actions = Array.Empty<DSRAction>(),
+            };
+
+            var exception = await Assert.ThrowsAsync<MeilisearchApiError>(() => _client.CreateOrUpdateDynamicSearchRuleAsync(dynamicSearchRuleUid, dynamicSearchRule));
+            Assert.Equal("invalid_dynamic_search_rule_actions", exception.Code);
+        }
+
+        [Fact]
+        public async Task UpdateDynamicSearchRuleAsync()
+        {
+            const string dynamicSearchRuleUid = nameof(UpdateDynamicSearchRuleAsync);
+            var (patchRule, _) = await _fixture.SetUpDynamicSearchRuleExampleAsync(dynamicSearchRuleUid);
+
+            // modify dynamic-search-rule
+            patchRule.Active = false;
+            patchRule.Description = "Some updated description";
+
+            var result = await _client.CreateOrUpdateDynamicSearchRuleAsync(dynamicSearchRuleUid, patchRule);
+            AssertDynamicSearchRule(patchRule.ToDynamicSearchRule(dynamicSearchRuleUid), result);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetExistingDynamicSearchRuleCases))]
+        public async Task GetExistingDynamicSearchRuleAsync(string dynamicSearchRuleJsonPath)
+        {
+            const string dynamicSearchRuleUid = nameof(GetExistingDynamicSearchRuleAsync);
+            var (_, dynamicSearchRule) = await _fixture.SetUpDynamicSearchRuleAsync(dynamicSearchRuleUid, dynamicSearchRuleJsonPath);
+
+            var result = await _client.GetDynamicSearchRuleAsync(dynamicSearchRuleUid);
+            AssertDynamicSearchRule(dynamicSearchRule, result);
+        }
+
+        [Fact]
+        public async Task GetNotExistingDynamicSearchRuleAsync()
+        {
+            var exception = await Assert.ThrowsAsync<MeilisearchApiError>(() =>
+                _client.GetDynamicSearchRuleAsync(nameof(GetNotExistingDynamicSearchRuleAsync)));
+
+            Assert.Equal("dynamic_search_rule_not_found", exception.Code);
+        }
+
+        [Fact]
+        public async Task ListDynamicSearchRulesWithEmptyQuery()
+        {
+            const string dynamicSearchRuleUid = nameof(ListDynamicSearchRulesWithEmptyQuery);
+            var (_, dynamicSearchRule) = await _fixture.SetUpDynamicSearchRuleExampleAsync(dynamicSearchRuleUid);
+
+            var resourceResults = await _client.ListDynamicSearchRulesAsync();
+
+            var results = resourceResults.Results.ToList();
+            Assert.Equal(0, resourceResults.Offset);
+            Assert.Equal(1, resourceResults.Total);
+            Assert.Single(results);
+            AssertDynamicSearchRule(dynamicSearchRule, results.First());
+        }
+
+        [Fact]
+        public async Task ListDynamicSearchRulesWithOffset()
+        {
+            const string dynamicSearchRuleUid = nameof(ListDynamicSearchRulesWithOffset);
+            await _fixture.SetUpDynamicSearchRuleExampleAsync(dynamicSearchRuleUid);
+
+            var resourceResults = await _client.ListDynamicSearchRulesAsync(new DynamicSearchRulesQuery { Offset = 1 });
+
+            Assert.Equal(1, resourceResults.Offset);
+            Assert.Equal(1, resourceResults.Total);
+            Assert.Empty(resourceResults.Results);
+        }
+
+        [Fact]
+        public async Task ListDynamicSearchRulesWithLimit()
+        {
+            const string dynamicSearchRuleUid = nameof(ListDynamicSearchRulesWithOffset);
+            var (_, dynamicSearchRule) = await _fixture.SetUpDynamicSearchRuleExampleAsync(dynamicSearchRuleUid);
+
+            var resourceResults = await _client.ListDynamicSearchRulesAsync(new DynamicSearchRulesQuery { Limit = 1 });
+
+            var results = resourceResults.Results.ToList();
+            Assert.Equal(1, resourceResults.Limit);
+            Assert.Equal(0, resourceResults.Offset);
+            Assert.Equal(1, resourceResults.Total);
+            Assert.Single(results);
+            AssertDynamicSearchRule(dynamicSearchRule, results.First());
+        }
+
+        [Fact]
+        public async Task DeleteExistingDynamicSearchRuleAsync()
+        {
+            const string dynamicSearchRuleUid = nameof(DeleteExistingDynamicSearchRuleAsync);
+            await _fixture.SetUpDynamicSearchRuleExampleAsync(dynamicSearchRuleUid);
+
+            var result = await _client.DeleteDynamicSearchRuleAsync(dynamicSearchRuleUid);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task DeleteNotExistingDynamicSearchRuleAsync()
+        {
+            var exception = await Assert.ThrowsAsync<MeilisearchApiError>(() => _client.DeleteDynamicSearchRuleAsync(nameof(DeleteNotExistingDynamicSearchRuleAsync)));
+
+            Assert.Equal("dynamic_search_rule_not_found", exception.Code);
+        }
+
+        private static void AssertDynamicSearchRule(DynamicSearchRule expected, DynamicSearchRule actual)
+        {
+            Assert.Equal(expected.Uid, actual.Uid);
+            Assert.Equal(expected.Description, actual.Description);
+            Assert.Equal(expected.Priority, actual.Priority);
+            Assert.Equal(expected.Active, actual.Active);
+            if (expected.Conditions != null)
+            {
+                Assert.Equal(expected.Conditions.Count(), actual.Conditions.Count());
+                Assert.Equivalent(expected.Conditions, actual.Conditions);
+            } else Assert.Null(actual.Conditions);
+
+            if (expected.Actions != null)
+            {
+                Assert.Equal(expected.Actions.Count(), actual.Actions.Count());
+
+                foreach (var (expectedAction, actualAction) in expected.Actions.Zip(actual.Actions))
+                {
+                    Assert.Equivalent(expectedAction.Selector, actualAction.Selector);
+                    Assert.Equivalent(expectedAction.Action, actualAction.Action);
+                }
+            } else Assert.Null(actual.Actions);
+        }
+
+        public static TheoryData<string> GetExistingDynamicSearchRuleCases() =>
+            new TheoryData<string>(
+                Datasets.DynamicSearchRuleJsonPath,
+                Datasets.DynamicSearchRuleWithOptionalValuesJsonPath
+            );
+    }
+
+    internal static class DynamicSearchRuleExtensions
+    {
+        public static DynamicSearchRule ToDynamicSearchRule(this PatchDynamicSearchRule patchRule, string uid)
+        {
+            var result = new DynamicSearchRule { Uid = uid };
+            if (patchRule.Priority.HasValue)
+                result.Priority = patchRule.Priority.Value;
+            if (patchRule.Active.HasValue)
+                result.Active = patchRule.Active.Value ?? true;
+            if (patchRule.Description.HasValue)
+                result.Description = patchRule.Description.Value;
+            if (patchRule.Actions.HasValue)
+                result.Actions = patchRule.Actions.Value;
+            if (patchRule.Conditions.HasValue)
+                result.Conditions = patchRule.Conditions.Value;
+            return result;
+        }
+    }
+}

--- a/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
+++ b/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
@@ -188,7 +188,8 @@ namespace Meilisearch.Tests
                 Assert.NotNull(actual.Conditions);
                 Assert.Equal(expected.Conditions.Count(), actual.Conditions.Count());
                 Assert.Equivalent(expected.Conditions, actual.Conditions);
-            } else Assert.Null(actual.Conditions);
+            }
+            else Assert.Null(actual.Conditions);
 
             if (expected.Actions != null)
             {
@@ -200,7 +201,8 @@ namespace Meilisearch.Tests
                     Assert.Equivalent(expectedAction.Selector, actualAction.Selector);
                     Assert.Equivalent(expectedAction.Action, actualAction.Action);
                 }
-            } else Assert.Null(actual.Actions);
+            }
+            else Assert.Null(actual.Actions);
         }
 
         public static TheoryData<string> GetExistingDynamicSearchRuleCases() =>

--- a/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
+++ b/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
@@ -75,7 +75,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task CreateDynamicSearchRuleWithEmptyActionsAsync()
         {
-            const string dynamicSearchRuleUid = nameof(CreateDynamicSearchRuleWithoutActionsAsync);
+            const string dynamicSearchRuleUid = nameof(CreateDynamicSearchRuleWithEmptyActionsAsync);
             var dynamicSearchRule = new PatchDynamicSearchRule
             {
                 Actions = Array.Empty<DSRAction>(),
@@ -150,7 +150,7 @@ namespace Meilisearch.Tests
         [Fact]
         public async Task ListDynamicSearchRulesWithLimit()
         {
-            const string dynamicSearchRuleUid = nameof(ListDynamicSearchRulesWithOffset);
+            const string dynamicSearchRuleUid = nameof(ListDynamicSearchRulesWithLimit);
             var (_, dynamicSearchRule) = await _fixture.SetUpDynamicSearchRuleExampleAsync(dynamicSearchRuleUid);
 
             var resourceResults = await _client.ListDynamicSearchRulesAsync(new DynamicSearchRulesQuery { Limit = 1 });
@@ -189,12 +189,14 @@ namespace Meilisearch.Tests
             Assert.Equal(expected.Active, actual.Active);
             if (expected.Conditions != null)
             {
+                Assert.NotNull(actual.Conditions);
                 Assert.Equal(expected.Conditions.Count(), actual.Conditions.Count());
                 Assert.Equivalent(expected.Conditions, actual.Conditions);
             } else Assert.Null(actual.Conditions);
 
             if (expected.Actions != null)
             {
+                Assert.NotNull(actual.Actions);
                 Assert.Equal(expected.Actions.Count(), actual.Actions.Count());
 
                 foreach (var (expectedAction, actualAction) in expected.Actions.Zip(actual.Actions))

--- a/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
+++ b/tests/Meilisearch.Tests/DynamicSearchRuleTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Meilisearch.Tests
 {
-    public class DynamicSearchRuleTests<TFixture> : IAsyncLifetime where TFixture : DynamicSearchRuleFixture
+    public abstract class DynamicSearchRuleTests<TFixture> : IAsyncLifetime where TFixture : DynamicSearchRuleFixture
     {
         private readonly MeilisearchClient _client;
 

--- a/tests/Meilisearch.Tests/FacetSearchTests.cs
+++ b/tests/Meilisearch.Tests/FacetSearchTests.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
+using Meilisearch.Tests.Fixtures;
+
 using Xunit;
 
 namespace Meilisearch.Tests

--- a/tests/Meilisearch.Tests/Fixtures/DynamicSearchRuleFixture.cs
+++ b/tests/Meilisearch.Tests/Fixtures/DynamicSearchRuleFixture.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Meilisearch.QueryParameters;
+
+using Xunit;
+
+namespace Meilisearch.Tests
+{
+    public abstract class DynamicSearchRuleFixture : MeilisearchClientFixture
+    {
+        public override async Task InitializeAsync() =>
+            Assert.True(await DefaultClient.EnableDynamicSearchRules());
+
+        public override async Task DisposeAsync() => await DeleteAllDynamicSearchRule();
+
+        public Task<(PatchDynamicSearchRule, DynamicSearchRule)> SetUpDynamicSearchRuleExampleAsync(string uid) =>
+            SetUpDynamicSearchRuleAsync(uid, Datasets.DynamicSearchRuleJsonPath);
+
+        public async Task<(PatchDynamicSearchRule, DynamicSearchRule)> SetUpDynamicSearchRuleAsync(string uid, string jsonPath)
+        {
+            var dsrJson = await File.ReadAllTextAsync(Datasets.GetDynamicSearchRuleJsonPath(jsonPath));
+            var dynamicSearchRule = JsonSerializer.Deserialize<PatchDynamicSearchRule>(dsrJson, Constants.JsonSerializerOptionsRemoveNulls);
+            return (dynamicSearchRule, await DefaultClient.CreateOrUpdateDynamicSearchRuleAsync(uid, dynamicSearchRule));
+        }
+
+        public async Task DeleteAllDynamicSearchRule()
+        {
+            const int pageSize = 100;
+
+            while (true)
+            {
+                var allDynamicSearchRules = await DefaultClient.ListDynamicSearchRulesAsync(new DynamicSearchRulesQuery{ Limit = pageSize });
+                if (!allDynamicSearchRules.Results.Any()) break;
+
+                foreach (var dynamicSearchRule in allDynamicSearchRules.Results)
+                    await DefaultClient.DeleteDynamicSearchRuleAsync(dynamicSearchRule.Uid);
+
+            }
+        }
+    }
+}

--- a/tests/Meilisearch.Tests/Fixtures/DynamicSearchRuleFixture.cs
+++ b/tests/Meilisearch.Tests/Fixtures/DynamicSearchRuleFixture.cs
@@ -32,7 +32,7 @@ namespace Meilisearch.Tests.Fixtures
 
             while (true)
             {
-                var allDynamicSearchRules = await DefaultClient.ListDynamicSearchRulesAsync(new DynamicSearchRulesQuery{ Limit = pageSize });
+                var allDynamicSearchRules = await DefaultClient.ListDynamicSearchRulesAsync(new DynamicSearchRulesQuery { Limit = pageSize });
                 if (!allDynamicSearchRules.Results.Any()) break;
 
                 foreach (var dynamicSearchRule in allDynamicSearchRules.Results)

--- a/tests/Meilisearch.Tests/Fixtures/DynamicSearchRuleFixture.cs
+++ b/tests/Meilisearch.Tests/Fixtures/DynamicSearchRuleFixture.cs
@@ -7,7 +7,7 @@ using Meilisearch.QueryParameters;
 
 using Xunit;
 
-namespace Meilisearch.Tests
+namespace Meilisearch.Tests.Fixtures
 {
     public abstract class DynamicSearchRuleFixture : MeilisearchClientFixture
     {

--- a/tests/Meilisearch.Tests/Fixtures/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/Fixtures/IndexFixture.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 using Meilisearch.Tests.Models;
 
-namespace Meilisearch.Tests
+namespace Meilisearch.Tests.Fixtures
 {
     public abstract class IndexFixture : MeilisearchClientFixture
     {

--- a/tests/Meilisearch.Tests/Fixtures/IndexFixture.cs
+++ b/tests/Meilisearch.Tests/Fixtures/IndexFixture.cs
@@ -1,37 +1,17 @@
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 
 using Meilisearch.Tests.Models;
 
-using Xunit;
-
 namespace Meilisearch.Tests
 {
-    public abstract class IndexFixture : IAsyncLifetime
+    public abstract class IndexFixture : MeilisearchClientFixture
     {
-        public IndexFixture()
-        {
-            DefaultClient = new MeilisearchClient(MeilisearchAddress(), ApiKey);
-            var httpClient = new HttpClient(new MeilisearchMessageHandler(new HttpClientHandler())) { BaseAddress = new Uri(MeilisearchAddress()) };
-            ClientWithCustomHttpClient = new MeilisearchClient(httpClient, ApiKey);
-        }
+        public override Task InitializeAsync() => Task.CompletedTask;
 
-        private const string ApiKey = "masterKey";
-
-        public virtual string MeilisearchAddress()
-        {
-            throw new InvalidOperationException("Please override the MeilisearchAddress property in inhereted class.");
-        }
-
-        public MeilisearchClient DefaultClient { get; private set; }
-        public MeilisearchClient ClientWithCustomHttpClient { get; private set; }
-
-        public Task InitializeAsync() => Task.CompletedTask;
-
-        public async Task DisposeAsync() => await DeleteAllIndexes(); // Let a clean Meilisearch instance, for maintainers convenience only.
+        public override async Task DisposeAsync() => await DeleteAllIndexes(); // Let a clean Meilisearch instance, for maintainers convenience only.
 
         public async Task<Index> SetUpEmptyIndex(string indexUid, string primaryKey = default)
         {

--- a/tests/Meilisearch.Tests/Fixtures/MeilisearchClientFixture.cs
+++ b/tests/Meilisearch.Tests/Fixtures/MeilisearchClientFixture.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Meilisearch.Tests
+{
+    public abstract class MeilisearchClientFixture : IAsyncLifetime
+    {
+        public MeilisearchClientFixture()
+        {
+            DefaultClient = new MeilisearchClient(MeilisearchAddress(), ApiKey);
+            var httpClient = new HttpClient(new MeilisearchMessageHandler(new HttpClientHandler())) { BaseAddress = new Uri(MeilisearchAddress()) };
+            ClientWithCustomHttpClient = new MeilisearchClient(httpClient, ApiKey);
+        }
+
+        private const string ApiKey = "masterKey";
+
+        public virtual string MeilisearchAddress()
+        {
+            throw new InvalidOperationException("Please override the MeilisearchAddress property in inhereted class.");
+        }
+
+        public MeilisearchClient DefaultClient { get; private set; }
+        public MeilisearchClient ClientWithCustomHttpClient { get; private set; }
+
+        public virtual Task InitializeAsync() => Task.CompletedTask;
+
+        public abstract Task DisposeAsync();
+    }
+}

--- a/tests/Meilisearch.Tests/Fixtures/MeilisearchClientFixture.cs
+++ b/tests/Meilisearch.Tests/Fixtures/MeilisearchClientFixture.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 using Xunit;
 
-namespace Meilisearch.Tests
+namespace Meilisearch.Tests.Fixtures
 {
     public abstract class MeilisearchClientFixture : IAsyncLifetime
     {

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 
 using Meilisearch.QueryParameters;
+using Meilisearch.Tests.Fixtures;
 
 using Xunit;
 

--- a/tests/Meilisearch.Tests/KeyTests.cs
+++ b/tests/Meilisearch.Tests/KeyTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 
 using Meilisearch.QueryParameters;
+using Meilisearch.Tests.Fixtures;
 
 using Xunit;
 

--- a/tests/Meilisearch.Tests/MeilisearchClientTests.cs
+++ b/tests/Meilisearch.Tests/MeilisearchClientTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using Meilisearch.Converters;
 using Meilisearch.Extensions;
 using Meilisearch.QueryParameters;
+using Meilisearch.Tests.Fixtures;
 
 using Xunit;
 

--- a/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
+++ b/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
+using Meilisearch.Tests.Fixtures;
+
 using Xunit;
 
 namespace Meilisearch.Tests

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
+using Meilisearch.Tests.Fixtures;
 using Meilisearch.Tests.Models;
 
 using Xunit;

--- a/tests/Meilisearch.Tests/ServerConfigs/BaseUriServer.cs
+++ b/tests/Meilisearch.Tests/ServerConfigs/BaseUriServer.cs
@@ -9,96 +9,127 @@ namespace Meilisearch.Tests.ServerConfigs
         const string CollectionFixtureName = nameof(BaseUriServer);
         private const string MeilisearchTestAddress = "http://localhost:7700/";
 
-        public class ConfigFixture : IndexFixture
+        public class IndexCollectionTests
         {
-            public override string MeilisearchAddress()
+            const string IndexCollectionFixtureName = CollectionFixtureName + "Index";
+
+            public class ConfigFixture : IndexFixture
             {
-                return Environment.GetEnvironmentVariable("MEILISEARCH_URL") ?? MeilisearchTestAddress;
+                public override string MeilisearchAddress()
+                {
+                    return Environment.GetEnvironmentVariable("MEILISEARCH_URL") ?? MeilisearchTestAddress;
+                }
+            }
+
+            [CollectionDefinition(IndexCollectionFixtureName)]
+            public class IndexCollection : ICollectionFixture<ConfigFixture>
+            {
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class DocumentTests : DocumentTests<ConfigFixture>
+            {
+                public DocumentTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class IndexTests : IndexTests<ConfigFixture>
+            {
+                public IndexTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class KeyTests : KeyTests<ConfigFixture>
+            {
+                public KeyTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class MeilisearchClientTests : MeilisearchClientTests<ConfigFixture>
+            {
+                public MeilisearchClientTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class SearchTests : SearchTests<ConfigFixture>
+            {
+                public SearchTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class MultiIndexSearchTests : MultiIndexSearchTests<ConfigFixture>
+            {
+                public MultiIndexSearchTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class FacetingSearchTests : FacetSearchTests<ConfigFixture>
+            {
+                public FacetingSearchTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class SettingsTests : SettingsTests<ConfigFixture>
+            {
+                public SettingsTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class TaskInfoTests : TaskInfoTests<ConfigFixture>
+            {
+                public TaskInfoTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class TenantTokenTests : TenantTokenTests<ConfigFixture>
+            {
+                public TenantTokenTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
             }
         }
 
-        [CollectionDefinition(CollectionFixtureName)]
-        public class IndexCollection : ICollectionFixture<ConfigFixture>
+        public class DynamicSearchRuleCollectionTests
         {
-        }
+            const string DsrCollectionFixtureName = CollectionFixtureName + "DynamicSearchReule";
 
-        [Collection(CollectionFixtureName)]
-        public class DocumentTests : DocumentTests<ConfigFixture>
-        {
-            public DocumentTests(ConfigFixture fixture) : base(fixture)
+            public class ConfigFixture : DynamicSearchRuleFixture
+            {
+                public override string MeilisearchAddress()
+                {
+                    return Environment.GetEnvironmentVariable("MEILISEARCH_URL") ?? MeilisearchTestAddress;
+                }
+            }
+
+            [CollectionDefinition(DsrCollectionFixtureName)]
+            public class DynamicSearchRuleCollection : ICollectionFixture<ConfigFixture>
             {
             }
-        }
 
-        [Collection(CollectionFixtureName)]
-        public class IndexTests : IndexTests<ConfigFixture>
-        {
-            public IndexTests(ConfigFixture fixture) : base(fixture)
+            [Collection(DsrCollectionFixtureName)]
+            public class DynamicSearchRuleTests : DynamicSearchRuleTests<ConfigFixture>
             {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class KeyTests : KeyTests<ConfigFixture>
-        {
-            public KeyTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class MeilisearchClientTests : MeilisearchClientTests<ConfigFixture>
-        {
-            public MeilisearchClientTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class SearchTests : SearchTests<ConfigFixture>
-        {
-            public SearchTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class MultiIndexSearchTests : MultiIndexSearchTests<ConfigFixture>
-        {
-            public MultiIndexSearchTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class FacetingSearchTests : FacetSearchTests<ConfigFixture>
-        {
-            public FacetingSearchTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class SettingsTests : SettingsTests<ConfigFixture>
-        {
-            public SettingsTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class TaskInfoTests : TaskInfoTests<ConfigFixture>
-        {
-            public TaskInfoTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class TenantTokenTests : TenantTokenTests<ConfigFixture>
-        {
-            public TenantTokenTests(ConfigFixture fixture) : base(fixture)
-            {
+                public DynamicSearchRuleTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
             }
         }
     }

--- a/tests/Meilisearch.Tests/ServerConfigs/BaseUriServer.cs
+++ b/tests/Meilisearch.Tests/ServerConfigs/BaseUriServer.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Meilisearch.Tests.Fixtures;
+
 using Xunit;
 
 namespace Meilisearch.Tests.ServerConfigs

--- a/tests/Meilisearch.Tests/ServerConfigs/ProxiedUriServer.cs
+++ b/tests/Meilisearch.Tests/ServerConfigs/ProxiedUriServer.cs
@@ -9,96 +9,128 @@ namespace Meilisearch.Tests.ServerConfigs
         const string CollectionFixtureName = nameof(ProxiedUriServer);
         private const string MeilisearchTestAddress = "http://localhost:8080/api/";
 
-        public class ConfigFixture : IndexFixture
+        public class IndexCollectionTests
         {
-            public override string MeilisearchAddress()
+            const string IndexCollectionFixtureName = CollectionFixtureName + "Index";
+
+            public class ConfigFixture : IndexFixture
             {
-                return Environment.GetEnvironmentVariable("PROXIED_MEILISEARCH") ?? MeilisearchTestAddress;
+                public override string MeilisearchAddress()
+                {
+                    return Environment.GetEnvironmentVariable("PROXIED_MEILISEARCH") ?? MeilisearchTestAddress;
+                }
+            }
+
+
+            [CollectionDefinition(IndexCollectionFixtureName)]
+            public class IndexCollection : ICollectionFixture<ConfigFixture>
+            {
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class DocumentTests : DocumentTests<ConfigFixture>
+            {
+                public DocumentTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class IndexTests : IndexTests<ConfigFixture>
+            {
+                public IndexTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class KeyTests : KeyTests<ConfigFixture>
+            {
+                public KeyTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class MeilisearchClientTests : MeilisearchClientTests<ConfigFixture>
+            {
+                public MeilisearchClientTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class SearchTests : SearchTests<ConfigFixture>
+            {
+                public SearchTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class MultiIndexSearchTests : MultiIndexSearchTests<ConfigFixture>
+            {
+                public MultiIndexSearchTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class FacetingSearchTests : FacetSearchTests<ConfigFixture>
+            {
+                public FacetingSearchTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class SettingsTests : SettingsTests<ConfigFixture>
+            {
+                public SettingsTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class TaskInfoTests : TaskInfoTests<ConfigFixture>
+            {
+                public TaskInfoTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
+            }
+
+            [Collection(IndexCollectionFixtureName)]
+            public class TenantTokenTests : TenantTokenTests<ConfigFixture>
+            {
+                public TenantTokenTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
             }
         }
 
-        [CollectionDefinition(CollectionFixtureName)]
-        public class IndexCollection : ICollectionFixture<ConfigFixture>
+        public class DynamicSearchRuleCollectionTests
         {
-        }
+            const string DsrCollectionFixtureName = CollectionFixtureName + "DynamicSearchReule";
 
-        [Collection(CollectionFixtureName)]
-        public class DocumentTests : DocumentTests<ConfigFixture>
-        {
-            public DocumentTests(ConfigFixture fixture) : base(fixture)
+            public class ConfigFixture : DynamicSearchRuleFixture
+            {
+                public override string MeilisearchAddress()
+                {
+                    return Environment.GetEnvironmentVariable("MEILISEARCH_URL") ?? MeilisearchTestAddress;
+                }
+            }
+
+            [CollectionDefinition(DsrCollectionFixtureName)]
+            public class DynamicSearchRuleCollection : ICollectionFixture<ConfigFixture>
             {
             }
-        }
 
-        [Collection(CollectionFixtureName)]
-        public class IndexTests : IndexTests<ConfigFixture>
-        {
-            public IndexTests(ConfigFixture fixture) : base(fixture)
+            [Collection(DsrCollectionFixtureName)]
+            public class DynamicSearchRuleTests : DynamicSearchRuleTests<ConfigFixture>
             {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class KeyTests : KeyTests<ConfigFixture>
-        {
-            public KeyTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class MeilisearchClientTests : MeilisearchClientTests<ConfigFixture>
-        {
-            public MeilisearchClientTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class SearchTests : SearchTests<ConfigFixture>
-        {
-            public SearchTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class MultiIndexSearchTests : MultiIndexSearchTests<ConfigFixture>
-        {
-            public MultiIndexSearchTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class FacetingSearchTests : FacetSearchTests<ConfigFixture>
-        {
-            public FacetingSearchTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class SettingsTests : SettingsTests<ConfigFixture>
-        {
-            public SettingsTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class TaskInfoTests : TaskInfoTests<ConfigFixture>
-        {
-            public TaskInfoTests(ConfigFixture fixture) : base(fixture)
-            {
-            }
-        }
-
-        [Collection(CollectionFixtureName)]
-        public class TenantTokenTests : TenantTokenTests<ConfigFixture>
-        {
-            public TenantTokenTests(ConfigFixture fixture) : base(fixture)
-            {
+                public DynamicSearchRuleTests(ConfigFixture fixture) : base(fixture)
+                {
+                }
             }
         }
     }

--- a/tests/Meilisearch.Tests/ServerConfigs/ProxiedUriServer.cs
+++ b/tests/Meilisearch.Tests/ServerConfigs/ProxiedUriServer.cs
@@ -116,7 +116,7 @@ namespace Meilisearch.Tests.ServerConfigs
             {
                 public override string MeilisearchAddress()
                 {
-                    return Environment.GetEnvironmentVariable("MEILISEARCH_URL") ?? MeilisearchTestAddress;
+                    return Environment.GetEnvironmentVariable("PROXIED_MEILISEARCH") ?? MeilisearchTestAddress;
                 }
             }
 

--- a/tests/Meilisearch.Tests/ServerConfigs/ProxiedUriServer.cs
+++ b/tests/Meilisearch.Tests/ServerConfigs/ProxiedUriServer.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Meilisearch.Tests.Fixtures;
+
 using Xunit;
 
 namespace Meilisearch.Tests.ServerConfigs

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 using FluentAssertions;
 
+using Meilisearch.Tests.Fixtures;
+
 using Xunit;
 
 namespace Meilisearch.Tests

--- a/tests/Meilisearch.Tests/TaskInfoTests.cs
+++ b/tests/Meilisearch.Tests/TaskInfoTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 
 using Meilisearch.QueryParameters;
+using Meilisearch.Tests.Fixtures;
 
 using Xunit;
 

--- a/tests/Meilisearch.Tests/TenantTokenTests.cs
+++ b/tests/Meilisearch.Tests/TenantTokenTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Meilisearch.Tests.Fixtures;
+
 using Xunit;
 
 namespace Meilisearch.Tests


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #728 

## What does this PR do?
- Adds ListDynamicSearchRulesAsync method for listing rules
- Adds GetDynamicSearchRuleAsync method for retrieving a rule
- Adds CreateOrUpdateDynamicSearchRuleAsync method for creating or updating a rule
- Adds DeleteDynamicSearchRuleAsync method for deleting a rule
- Adds tests
- Adds examples of usage into .code-samples.meilisearch.yaml

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds Meilisearch v1.41 Dynamic Search Rules support to the .NET SDK, including new client APIs, request/response models, JSON serialization for polymorphic rule actions/conditions and PATCH “optionality”, documentation samples, and full test coverage (datasets, fixtures, and server-config wiring).

## Changes overview

### Client API
- Added `MeilisearchClient.EnableDynamicSearchRules(...)` to enable the experimental feature via `PATCH experimental-features` and return whether `dynamicSearchRules` is enabled.
- Added CRUD/list methods:
  - `ListDynamicSearchRulesAsync(DynamicSearchRulesQuery query = default, ...)` — `POST /dynamic-search-rules` (supports pagination/filter in body)
  - `GetDynamicSearchRuleAsync(string uid, ...)` — `GET /dynamic-search-rules/{uid}`
  - `CreateOrUpdateDynamicSearchRuleAsync(string uid, PatchDynamicSearchRule dynamicSearchRule, ...)` — `PATCH /dynamic-search-rules/{uid}`
  - `DeleteDynamicSearchRuleAsync(string uid, ...)` — `DELETE /dynamic-search-rules/{uid}` returning `true` on `204 NoContent`

### Models
- Added `DynamicSearchRule` (`uid`, `actions`, `description`, `priority`, `active`, `conditions`).
- Added `PatchDynamicSearchRule` using PATCH semantics via optional fields (`Optional<T>`):
  - `Optional<IEnumerable<DSRAction>> Actions`
  - `Optional<string> Description`
  - `Optional<ulong?> Priority`
  - `Optional<bool?> Active`
  - `Optional<IEnumerable<BaseCondition>> Conditions`
- Added request query model `DynamicSearchRulesQuery` with optional `offset`, `limit`, and `filter` (including `attribute_patterns.patterns` and `active`).

### Dynamic Search Rule action/condition types + converters
- Added:
  - `ActionType` (e.g. `Pin`), `DSRAction` (selector + action), `BaseAction` with JSON discriminator `type`, and `PinAction` (`position`)
  - `ConditionType` (`Query`, `Time`), `BaseCondition` with JSON discriminator `scope`, `QueryCondition` (`isEmpty`, `contains`), and `TimeCondition` (`start`, `end`)
- Implemented serialization support:
  - `EnumToCamelCaseConverter<TEnum>` (camelCase JSON strings for enums)
  - `BaseObjectWithTypesConverter<TBase, TType>` for discriminator-driven polymorphic (de)serialization
  - `DynamicSearchRuleActionConverter` and `DynamicSearchRuleConditionConverter` to wire discriminators to concrete action/condition types
  - Introduced `Optional<T>` + `OptionalJsonConverter<T>` + `OptionalJsonConverterFactory` and registered the factory in `JsonSerializerOptionsRemoveNulls` so PATCH payloads can omit vs send `null` correctly.

### Tests, fixtures, datasets
- Added `DynamicSearchRuleTests<TFixture>` covering create/upsert, validation failures for missing/empty actions, update, get (including not-found), list (default/offset/limit), and delete (including not-found), with JSON-driven theory inputs.
- Added `DynamicSearchRuleFixture`:
  - enables dynamic search rules on init
  - cleans up by listing rules (limit 100) and deleting all returned UIDs
  - loads PATCH payloads from JSON datasets using `JsonSerializerOptionsRemoveNulls`
- Added datasets:
  - `dynamic_search_rule.json`
  - `dynamic_search_rule_with_optional_values.json`
- Refactored test fixtures for reusability:
  - introduced `MeilisearchClientFixture`
  - moved/refactored `IndexFixture` to inherit from `MeilisearchClientFixture`
- Updated server-config test scaffolding to add dynamic-search-rule collection wrappers and wire fixtures under both `BaseUriServer` and `ProxiedUriServer`, plus minor `using` adjustments in existing tests.

### Documentation
- Updated `.code-samples.meilisearch.yaml` with Dynamic Search Rules examples:
  - `list_dynamic_search_rules_1`
  - `get_dynamic_search_rule_1`
  - `patch_dynamic_search_rule_1`
  - `delete_dynamic_search_rule_1`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->