### PR TITLE
feat: add queryVector to search responses and index renaming (v1.18)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -51,6 +51,8 @@ create_an_index_1: |-
   TaskInfo task = await client.CreateIndexAsync("movies", "id");
 update_an_index_1: |-
   TaskInfo task = await client.UpdateIndexAsync("movies", "id");
+rename_an_index_1: |-
+  TaskInfo task = await client.RenameIndexAsync("movies", "movies_new");
 delete_an_index_1: |-
   await client.DeleteIndexAsync("movies");
 get_one_document_1: |-

--- a/src/Meilisearch/Index.cs
+++ b/src/Meilisearch/Index.cs
@@ -106,6 +106,21 @@ namespace Meilisearch
         }
 
         /// <summary>
+        /// Renames the index by updating its <c>uid</c>.
+        /// </summary>
+        /// <param name="newUid">The new unique identifier to rename the index to.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the associated task.</returns>
+        public async Task<TaskInfo> RenameAsync(string newUid, CancellationToken cancellationToken = default)
+        {
+            var responseMessage =
+                await _http.PatchAsJsonAsync($"indexes/{Uid}", new { uid = newUid }, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+            return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Deletes the index.
         /// It's not a recovery delete. You will also lose the documents within the index.
         /// </summary>

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -153,6 +153,19 @@ namespace Meilisearch
         }
 
         /// <summary>
+        /// Renames an index by updating its <c>uid</c>.
+        /// </summary>
+        /// <param name="uid">Current unique identifier of the index.</param>
+        /// <param name="newUid">The new unique identifier to rename the index to.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the associated task.</returns>
+        public async Task<TaskInfo> RenameIndexAsync(string uid, string newUid,
+            CancellationToken cancellationToken = default)
+        {
+            return await Index(uid).RenameAsync(newUid, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Deletes the index.
         /// It's not a recovery delete. You will also lose the documents within the index.
         /// </summary>

--- a/src/Meilisearch/PaginatedSearchResult.cs
+++ b/src/Meilisearch/PaginatedSearchResult.cs
@@ -34,7 +34,8 @@ namespace Meilisearch
             string query,
             IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPosition,
             IReadOnlyDictionary<string, FacetStat> facetStats,
-            string indexUid
+            string indexUid,
+            IReadOnlyList<float> queryVector = null
         )
         {
             Hits = hits;
@@ -48,6 +49,7 @@ namespace Meilisearch
             MatchesPosition = matchesPosition;
             FacetStats = facetStats;
             IndexUid = indexUid;
+            QueryVector = queryVector;
         }
 
         /// <summary>
@@ -101,5 +103,12 @@ namespace Meilisearch
         /// <inheritdoc/>
         [JsonPropertyName("indexUid")]
         public string IndexUid { get; }
+
+        /// <summary>
+        /// The embedding used as the query vector for a vector/semantic search.
+        /// Only returned when the search request sets <c>retrieveVectors</c> to <c>true</c>.
+        /// </summary>
+        [JsonPropertyName("queryVector")]
+        public IReadOnlyList<float> QueryVector { get; }
     }
 }

--- a/src/Meilisearch/SearchResult.cs
+++ b/src/Meilisearch/SearchResult.cs
@@ -22,12 +22,14 @@ namespace Meilisearch
         /// <param name="matchesPosition"></param>
         /// <param name="facetStats"></param>
         /// <param name="indexUid"></param>
+        /// <param name="queryVector"></param>
         public SearchResult(IReadOnlyCollection<T> hits, int offset, int limit, int estimatedTotalHits,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> facetDistribution,
             int processingTimeMs, string query,
             IReadOnlyDictionary<string, IReadOnlyCollection<MatchPosition>> matchesPosition,
             IReadOnlyDictionary<string, FacetStat> facetStats,
-            string indexUid)
+            string indexUid,
+            IReadOnlyList<float> queryVector = null)
         {
             Hits = hits;
             Offset = offset;
@@ -39,6 +41,7 @@ namespace Meilisearch
             MatchesPosition = matchesPosition;
             FacetStats = facetStats;
             IndexUid = indexUid;
+            QueryVector = queryVector;
         }
 
         /// <inheritdoc/>
@@ -86,5 +89,12 @@ namespace Meilisearch
         /// <inheritdoc/>
         [JsonPropertyName("indexUid")]
         public string IndexUid { get; }
+
+        /// <summary>
+        /// The embedding used as the query vector for a vector/semantic search.
+        /// Only returned when the search request sets <c>retrieveVectors</c> to <c>true</c>.
+        /// </summary>
+        [JsonPropertyName("queryVector")]
+        public IReadOnlyList<float> QueryVector { get; }
     }
 }

--- a/tests/Meilisearch.Tests/IndexTests.cs
+++ b/tests/Meilisearch.Tests/IndexTests.cs
@@ -121,6 +121,24 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task RenameIndex()
+        {
+            var indexUid = "RenameIndexTest" + new Random().Next();
+            var newIndexUid = "RenamedIndexTest" + new Random().Next();
+
+            await _fixture.SetUpEmptyIndex(indexUid);
+
+            var task = await _client.RenameIndexAsync(indexUid, newIndexUid);
+            task.TaskUid.Should().BeGreaterOrEqualTo(0);
+            await _client.Index(newIndexUid).WaitForTaskAsync(task.TaskUid);
+
+            var renamed = await _client.GetIndexAsync(newIndexUid);
+            renamed.Uid.Should().Be(newIndexUid);
+
+            await Assert.ThrowsAsync<MeilisearchApiError>(() => _client.GetIndexAsync(indexUid));
+        }
+
+        [Fact]
         public async Task IndexNameWrongFormattedError()
         {
             var indexUid = "Wrong UID";

--- a/tests/Meilisearch.Tests/SearchTests.cs
+++ b/tests/Meilisearch.Tests/SearchTests.cs
@@ -601,6 +601,28 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task CustomSearchReturnsQueryVector()
+        {
+            var searchQuery = new SearchQuery
+            {
+                Hybrid = new HybridSearch
+                {
+                    Embedder = "manual",
+                    SemanticRatio = 1.0f
+                },
+                Vector = new[] { 0.1, 0.6, 0.8 },
+                RetrieveVectors = true,
+            };
+
+            var movies = await _indexForVectorSearch.SearchAsync<Movie>(string.Empty, searchQuery);
+
+            var searchResult = movies as SearchResult<Movie>;
+            searchResult.Should().NotBeNull();
+            searchResult.QueryVector.Should().NotBeNull();
+            searchResult.QueryVector.Should().Equal(0.1f, 0.6f, 0.8f);
+        }
+
+        [Fact]
         public async Task CustomSearchWithSimilarDocuments()
         {
             var query = new SimilarDocumentsQuery("143")


### PR DESCRIPTION
## Summary

Closes #677. Adds support for the [Meilisearch v1.18](https://github.com/meilisearch/meilisearch/releases/tag/v1.18.0) features.

### `queryVector` in search responses
When a search request sets `RetrieveVectors = true`, the API response now includes a top-level `queryVector` field (the embedding used for the vector/semantic search). It is exposed on both `SearchResult<T>` and `PaginatedSearchResult<T>` as `IReadOnlyList<float> QueryVector` (null when not requested).

### Index renaming
Meilisearch v1.18 supports renaming an index via the index-update endpoint (`PATCH /indexes/{uid}` with `{ "uid": "newName" }`). Added:

- `Index.RenameAsync(string newUid, ...)`
- `MeilisearchClient.RenameIndexAsync(string uid, string newUid, ...)`

Renaming via index swap (`POST /swap-indexes` with `rename: true`) was already supported by the existing `IndexSwap.Rename` property.

## Tasks (from the issue)

- [x] Update the search responses to include `queryVector` when necessary
- [x] Update the index update method to allow renaming
- [x] Update the index swapping method to allow renaming *(already present via `IndexSwap.Rename`)*
- [x] Add new test cases
- [x] Add `rename_an_index_1` example to `.code-samples.meilisearch.yaml`

## Test Plan

Added `IndexTests.RenameIndex` and `SearchTests.CustomSearchReturnsQueryVector`. Both pass against `meilisearch-enterprise` v1.45.2 locally. The `queryVector` test asserts the returned vector equals the query vector `[0.1, 0.6, 0.8]`; the rename test asserts the index resolves under its new uid and no longer under the old one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds support for Meilisearch v1.18 features to the .NET SDK. It introduces two main enhancements: query vector exposure in search responses and index renaming via the index-update endpoint.

## Changes

### QueryVector in Search Responses

- **SearchResult<T>**: Added `IReadOnlyList<float> QueryVector` property (serialized as `queryVector`) that returns the embedding used for vector/semantic search when `RetrieveVectors = true` is set in the search request. Returns null when not requested.
- **PaginatedSearchResult<T>**: Added the same `IReadOnlyList<float> QueryVector` property with matching behavior.
- Both classes updated to accept `queryVector` as an optional constructor parameter.

### Index Renaming

- **Index.RenameAsync()**: New method that renames an index by sending a PATCH request to `/indexes/{uid}` with the new uid, returning the resulting `TaskInfo`.
- **MeilisearchClient.RenameIndexAsync()**: New method that accepts the current index uid and target new uid, delegating to `Index.RenameAsync()`.

### Test Coverage

- **IndexTests.RenameIndex**: Test verifying that an index can be renamed, is accessible under the new uid, and throws `MeilisearchApiError` when accessing the old uid.
- **SearchTests.CustomSearchReturnsQueryVector**: Test confirming that when `RetrieveVectors = true` with vector search enabled, the `QueryVector` property returns the expected vector values.

### Documentation

- Added code sample entry `rename_an_index_1` to `.code-samples.meilisearch.yaml` demonstrating index renaming usage.

## Implementation Details

All new functionality has been tested against meilisearch-enterprise v1.45.2. The changes maintain backward compatibility with existing code, as all new properties and parameters are optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->