### PR TITLE
Expose global facetSearch and prefixSearch toggles on the Settings class

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -517,6 +517,12 @@ update_faceting_settings_1: |-
   await client.Index("books").UpdateFacetingAsync(faceting);
 reset_faceting_settings_1: |-
   await client.Index("movies").ResetFacetingAsync();
+get_facet_search_settings_1: |-
+  await client.Index("books").GetFacetSearchAsync();
+update_facet_search_settings_1: |-
+  await client.Index("books").UpdateFacetSearchAsync(false);
+reset_facet_search_settings_1: |-
+  await client.Index("books").ResetFacetSearchAsync();
 multi_search_1: |-
   await client.MultiSearchAsync(new MultiSearchQuery()
   {

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -523,6 +523,12 @@ update_facet_search_settings_1: |-
   await client.Index("books").UpdateFacetSearchAsync(false);
 reset_facet_search_settings_1: |-
   await client.Index("books").ResetFacetSearchAsync();
+get_prefix_search_settings_1: |-
+  await client.Index("books").GetPrefixSearchAsync();
+update_prefix_search_settings_1: |-
+  await client.Index("books").UpdatePrefixSearchAsync("disabled");
+reset_prefix_search_settings_1: |-
+  await client.Index("books").ResetPrefixSearchAsync();
 multi_search_1: |-
   await client.MultiSearchAsync(new MultiSearchQuery()
   {

--- a/src/Meilisearch/Index.FacetSearch.cs
+++ b/src/Meilisearch/Index.FacetSearch.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Meilisearch
+{
+    public partial class Index
+    {
+        /// <summary>
+        /// Gets whether facet search is enabled.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns whether facet search is enabled.</returns>
+        public async Task<bool> GetFacetSearchAsync(CancellationToken cancellationToken = default)
+        {
+            return await _http.GetFromJsonAsync<bool>($"indexes/{Uid}/settings/facet-search", cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Enables or disables facet search.
+        /// </summary>
+        /// <param name="facetSearch">Whether facet search is enabled.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task info of the asynchronous task.</returns>
+        public async Task<TaskInfo> UpdateFacetSearchAsync(bool facetSearch, CancellationToken cancellationToken = default)
+        {
+            var responseMessage =
+                await _http.PutAsJsonAsync($"indexes/{Uid}/settings/facet-search", facetSearch, Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+            return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Resets the facet search setting. (default: true)
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task info of the asynchronous task.</returns>
+        public async Task<TaskInfo> ResetFacetSearchAsync(CancellationToken cancellationToken = default)
+        {
+            var response = await _http.DeleteAsync($"indexes/{Uid}/settings/facet-search", cancellationToken)
+                .ConfigureAwait(false);
+
+            return await response.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Meilisearch/Index.PrefixSearch.cs
+++ b/src/Meilisearch/Index.PrefixSearch.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Meilisearch
+{
+    public partial class Index
+    {
+        /// <summary>
+        /// Gets the prefix search setting.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the prefix search setting.</returns>
+        public async Task<string> GetPrefixSearchAsync(CancellationToken cancellationToken = default)
+        {
+            return await _http.GetFromJsonAsync<string>($"indexes/{Uid}/settings/prefix-search", cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Updates the prefix search setting.
+        /// </summary>
+        /// <param name="prefixSearch">The new prefix search setting (e.g. "indexingTime" or "disabled").</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task info of the asynchronous task.</returns>
+        public async Task<TaskInfo> UpdatePrefixSearchAsync(string prefixSearch, CancellationToken cancellationToken = default)
+        {
+            var responseMessage =
+                await _http.PutAsJsonAsync($"indexes/{Uid}/settings/prefix-search", prefixSearch, Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+            return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Resets the prefix search setting. (default: "indexingTime")
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task info of the asynchronous task.</returns>
+        public async Task<TaskInfo> ResetPrefixSearchAsync(CancellationToken cancellationToken = default)
+        {
+            var response = await _http.DeleteAsync($"indexes/{Uid}/settings/prefix-search", cancellationToken)
+                .ConfigureAwait(false);
+
+            return await response.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -97,5 +97,8 @@
         <Compile Update="Index.FacetSearch.cs">
           <DependentUpon>Index.cs</DependentUpon>
         </Compile>
+        <Compile Update="Index.PrefixSearch.cs">
+          <DependentUpon>Index.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 </Project>

--- a/src/Meilisearch/Meilisearch.csproj
+++ b/src/Meilisearch/Meilisearch.csproj
@@ -94,5 +94,8 @@
         <Compile Update="DynamicSearchRule.Action.cs">
           <DependentUpon>DynamicSearchRule.cs</DependentUpon>
         </Compile>
+        <Compile Update="Index.FacetSearch.cs">
+          <DependentUpon>Index.cs</DependentUpon>
+        </Compile>
     </ItemGroup>
 </Project>

--- a/src/Meilisearch/Settings.cs
+++ b/src/Meilisearch/Settings.cs
@@ -90,6 +90,12 @@ namespace Meilisearch
         public bool? FacetSearch { get; set; }
 
         /// <summary>
+        /// Gets or sets the prefix search setting (default: "indexingTime").
+        /// </summary>
+        [JsonPropertyName("prefixSearch")]
+        public string PrefixSearch { get; set; }
+
+        /// <summary>
         /// Gets or sets the pagination attributes.
         /// </summary>
         [JsonPropertyName("pagination")]

--- a/src/Meilisearch/Settings.cs
+++ b/src/Meilisearch/Settings.cs
@@ -84,6 +84,12 @@ namespace Meilisearch
         public Faceting Faceting { get; set; }
 
         /// <summary>
+        /// Gets or sets whether facet search is enabled (default: true).
+        /// </summary>
+        [JsonPropertyName("facetSearch")]
+        public bool? FacetSearch { get; set; }
+
+        /// <summary>
         /// Gets or sets the pagination attributes.
         /// </summary>
         [JsonPropertyName("pagination")]

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -65,6 +65,7 @@ namespace Meilisearch.Tests
                     }
                 },
                 FacetSearch = true,
+                PrefixSearch = "indexingTime",
                 Pagination = new Pagination
                 {
                     MaxTotalHits = 1000
@@ -631,6 +632,29 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task GetPrefixSearch()
+        {
+            await AssertGetEquality(_index.GetPrefixSearchAsync, _defaultSettings.PrefixSearch);
+        }
+
+        [Fact]
+        public async Task UpdatePrefixSearch()
+        {
+            await AssertUpdateSuccess(_index.UpdatePrefixSearchAsync, "disabled");
+            await AssertGetEquality(_index.GetPrefixSearchAsync, "disabled");
+        }
+
+        [Fact]
+        public async Task ResetPrefixSearch()
+        {
+            await AssertUpdateSuccess(_index.UpdatePrefixSearchAsync, "disabled");
+            await AssertGetEquality(_index.GetPrefixSearchAsync, "disabled");
+
+            await AssertResetSuccess(_index.ResetPrefixSearchAsync);
+            await AssertGetEquality(_index.GetPrefixSearchAsync, _defaultSettings.PrefixSearch);
+        }
+
+        [Fact]
         public async Task GetPagination()
         {
             await AssertGetEquality(_index.GetPaginationAsync, _defaultSettings.Pagination);
@@ -810,6 +834,7 @@ namespace Meilisearch.Tests
                 TypoTolerance = inputSettings.TypoTolerance ?? defaultSettings.TypoTolerance,
                 Faceting = inputSettings.Faceting ?? defaultSettings.Faceting,
                 FacetSearch = inputSettings.FacetSearch ?? defaultSettings.FacetSearch,
+                PrefixSearch = inputSettings.PrefixSearch ?? defaultSettings.PrefixSearch,
                 Pagination = inputSettings.Pagination ?? defaultSettings.Pagination,
                 ProximityPrecision = inputSettings.ProximityPrecision ?? defaultSettings.ProximityPrecision,
                 Dictionary = inputSettings.Dictionary ?? defaultSettings.Dictionary,

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -64,6 +64,7 @@ namespace Meilisearch.Tests
                         ["*"] = SortFacetValuesByType.Alpha
                     }
                 },
+                FacetSearch = true,
                 Pagination = new Pagination
                 {
                     MaxTotalHits = 1000
@@ -607,6 +608,29 @@ namespace Meilisearch.Tests
         }
 
         [Fact]
+        public async Task GetFacetSearch()
+        {
+            await AssertGetEquality(_index.GetFacetSearchAsync, _defaultSettings.FacetSearch.Value);
+        }
+
+        [Fact]
+        public async Task UpdateFacetSearch()
+        {
+            await AssertUpdateSuccess(_index.UpdateFacetSearchAsync, false);
+            await AssertGetEquality(_index.GetFacetSearchAsync, false);
+        }
+
+        [Fact]
+        public async Task ResetFacetSearch()
+        {
+            await AssertUpdateSuccess(_index.UpdateFacetSearchAsync, false);
+            await AssertGetEquality(_index.GetFacetSearchAsync, false);
+
+            await AssertResetSuccess(_index.ResetFacetSearchAsync);
+            await AssertGetEquality(_index.GetFacetSearchAsync, _defaultSettings.FacetSearch.Value);
+        }
+
+        [Fact]
         public async Task GetPagination()
         {
             await AssertGetEquality(_index.GetPaginationAsync, _defaultSettings.Pagination);
@@ -785,6 +809,7 @@ namespace Meilisearch.Tests
                 SortableAttributes = inputSettings.SortableAttributes ?? defaultSettings.SortableAttributes,
                 TypoTolerance = inputSettings.TypoTolerance ?? defaultSettings.TypoTolerance,
                 Faceting = inputSettings.Faceting ?? defaultSettings.Faceting,
+                FacetSearch = inputSettings.FacetSearch ?? defaultSettings.FacetSearch,
                 Pagination = inputSettings.Pagination ?? defaultSettings.Pagination,
                 ProximityPrecision = inputSettings.ProximityPrecision ?? defaultSettings.ProximityPrecision,
                 Dictionary = inputSettings.Dictionary ?? defaultSettings.Dictionary,


### PR DESCRIPTION
## What

Implements [#596](https://github.com/meilisearch/meilisearch-dotnet/issues/596): the two index settings added in Meilisearch v1.12 — `facetSearch` and `prefixSearch`.

- `facetSearch` (`bool`, default `true`): when `false`, the facet-search endpoint is disabled — reduces indexing cost when facet search isn't needed.
- `prefixSearch` (`string`, default `"indexingTime"`): controls when prefix search is computed. Set `"disabled"` to turn it off.

Docs:
- https://www.meilisearch.com/docs/capabilities/filtering_sorting_faceting/how_to/filter_with_facets#toggle-facet-search-globally
- https://www.meilisearch.com/docs/reference/api/settings#prefix-search

## Changes

- `Settings.FacetSearch` (`bool?`, `facetSearch`) and `Settings.PrefixSearch` (`string`, `prefixSearch`) — nullable so they're stripped from partial PATCH updates.
- New `Index.FacetSearch.cs` with dedicated endpoint methods on `settings/facet-search`:
  - `GetFacetSearchAsync` → `GET`
  - `UpdateFacetSearchAsync(bool)` → `PUT`
  - `ResetFacetSearchAsync` → `DELETE`
- New `Index.PrefixSearch.cs` with dedicated endpoint methods on `settings/prefix-search`, mirroring `Index.ProximityPrecision.cs`:
  - `GetPrefixSearchAsync` → `GET`
  - `UpdatePrefixSearchAsync(string)` → `PUT`
  - `ResetPrefixSearchAsync` → `DELETE`
- Tests: get/update/reset for both settings, plus both added to default-settings assertions.
- `.code-samples.meilisearch.yaml` entries for both (get/update/reset).

## Testing

- `dotnet build` — 0 errors.
- Integration tests run against a local Meilisearch.

## AI disclosure

This PR was authored with assistance from Claude Code (Anthropic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public APIs to get, update, and reset per-index **facet search** settings.
  * Added public APIs to get, update, and reset per-index **prefix search** settings.
  * Extended the settings model with an optional `facetSearch` field (defaults to enabled).
* **Documentation**
  * Added code samples for facet search and prefix search settings (get, update, reset) on an example index.
* **Tests**
  * Added unit tests covering get/update/reset behavior for `facetSearch`, including default handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->