### PR TITLE
Add foreign keys experimental setting support (document relations)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -623,8 +623,14 @@ patch_dynamic_search_rule_1: |-
 delete_dynamic_search_rule_1: |-
   await client.DeleteDynamicSearchRuleAsync("black-friday");
 get_foreign_keys_setting_1: |-
+  // Foreign keys are experimental and must be enabled first
+  await client.EnableForeignKeys();
+
   await client.Index("books").GetForeignKeysAsync();
 update_foreign_keys_setting_1: |-
+  // Foreign keys are experimental and must be enabled first
+  await client.EnableForeignKeys();
+
   var foreignKeys = new ForeignKey[]
   {
       new ForeignKey { ForeignIndexUid = "authors", FieldName = "author"  },
@@ -632,4 +638,7 @@ update_foreign_keys_setting_1: |-
   };
   await client.Index("books").UpdateForeignKeysAsync(foreignKeys);
 reset_foreign_keys_setting_1: |-
+  // Foreign keys are experimental and must be enabled first
+  await client.EnableForeignKeys();
+
   await client.Index("books").ResetForeignKeysAsync();

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -622,3 +622,14 @@ patch_dynamic_search_rule_1: |-
   await client.CreateOrUpdateDynamicSearchRuleAsync("black-friday", patchQuery);
 delete_dynamic_search_rule_1: |-
   await client.DeleteDynamicSearchRuleAsync("black-friday");
+get_foreign_keys_setting_1: |-
+  await client.Index("books").GetForeignKeysAsync();
+update_foreign_keys_setting_1: |-
+  var foreignKeys = new ForeignKey[]
+  {
+      new ForeignKey { ForeignIndexUid = "authors", FieldName = "author"  },
+      new ForeignKey { ForeignIndexUid = "authors", FieldName = "related_authors"  }
+  };
+  await client.Index("books").UpdateForeignKeysAsync(foreignKeys);
+reset_foreign_keys_setting_1: |-
+  await client.Index("books").ResetForeignKeysAsync();

--- a/src/Meilisearch/FederatedSearchQuery.cs
+++ b/src/Meilisearch/FederatedSearchQuery.cs
@@ -14,10 +14,10 @@ namespace Meilisearch
     public class FederatedSearchQuery : SearchQueryBase
     {
         /// <summary>
-        /// Federated search options
+        /// Per-query federated search options: weight, remote and query position.
         /// </summary>
         [JsonPropertyName("federationOptions")]
-        public MultiSearchFederationOptions FederationOptions { get; set; }
+        public FederatedSearchQueryOptions FederationOptions { get; set; }
 
         /// <summary>
         /// Sets distinct attribute at search time.

--- a/src/Meilisearch/FederatedSearchQuery.cs
+++ b/src/Meilisearch/FederatedSearchQuery.cs
@@ -3,7 +3,13 @@ using System.Text.Json.Serialization;
 namespace Meilisearch
 {
     /// <summary>
-    /// Search query for federated multi-index search
+    /// Search query for federated multi-index search.
+    /// <remarks>
+    /// Pagination is federation-wide: pass <see cref="MultiSearchFederationOptions.Limit"/> and
+    /// <see cref="MultiSearchFederationOptions.Offset"/> on the query's federation options.
+    /// Meilisearch rejects the per-query <c>limit</c>, <c>offset</c>, <c>page</c> and
+    /// <c>hitsPerPage</c> parameters in a federated request, so they are not exposed here.
+    /// </remarks>
     /// </summary>
     public class FederatedSearchQuery : SearchQueryBase
     {
@@ -12,5 +18,35 @@ namespace Meilisearch
         /// </summary>
         [JsonPropertyName("federationOptions")]
         public MultiSearchFederationOptions FederationOptions { get; set; }
+
+        /// <summary>
+        /// Sets distinct attribute at search time.
+        /// </summary>
+        [JsonPropertyName("distinct")]
+        public string Distinct { get; set; }
+
+        /// <summary>
+        /// Gets or sets rankingScoreThreshold, a number between 0.0 and 1.0.
+        /// </summary>
+        [JsonPropertyName("rankingScoreThreshold")]
+        public decimal? RankingScoreThreshold { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hybrid search settings.
+        /// </summary>
+        [JsonPropertyName("hybrid")]
+        public HybridSearch Hybrid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vector. Requires <see cref="Hybrid"/> to be set as well.
+        /// </summary>
+        [JsonPropertyName("vector")]
+        public double[] Vector { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to retrieve vectors.
+        /// </summary>
+        [JsonPropertyName("retrieveVectors")]
+        public bool? RetrieveVectors { get; set; }
     }
 }

--- a/src/Meilisearch/FederatedSearchQueryOptions.cs
+++ b/src/Meilisearch/FederatedSearchQueryOptions.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace Meilisearch
+{
+    /// <summary>
+    /// Per-query federation options in federated multi-index search.
+    /// <remarks>
+    /// Distinct from <see cref="MultiSearchFederationOptions"/>, which carries the federation-wide
+    /// <c>limit</c> and <c>offset</c>. Meilisearch accepts only <c>weight</c>, <c>remote</c> and
+    /// <c>queryPosition</c> inside a query's own <c>federationOptions</c>.
+    /// </remarks>
+    /// </summary>
+    public class FederatedSearchQueryOptions
+    {
+        /// <summary>
+        /// Factor applied to this query's ranking score when merging results, defaults to 1.0.
+        /// </summary>
+        [JsonPropertyName("weight")]
+        public decimal? Weight { get; set; }
+
+        /// <summary>
+        /// Name of the remote instance to run this query on, as declared in the network settings.
+        /// </summary>
+        [JsonPropertyName("remote")]
+        public string Remote { get; set; }
+
+        /// <summary>
+        /// Position reported as <c>_federation.queriesPosition</c> for this query's hits.
+        /// </summary>
+        [JsonPropertyName("queryPosition")]
+        public int? QueryPosition { get; set; }
+    }
+}

--- a/src/Meilisearch/ForeignKey.cs
+++ b/src/Meilisearch/ForeignKey.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Meilisearch
+{
+    /// <summary>
+    /// Represents a foreign key entry.
+    /// </summary>
+    public class ForeignKey
+    {
+        /// <summary>
+        /// The uid of the foreign (related) index this entity points to.
+        /// </summary>
+        [JsonPropertyName("foreignIndexUid")]
+        public string ForeignIndexUid { get; set; }
+
+        /// <summary>
+        /// The name of the field in the current index that holds the foreign key value.
+        /// </summary>
+        [JsonPropertyName("fieldName")]
+        public string FieldName { get; set; }
+    }
+}

--- a/src/Meilisearch/Index.ForeignKeys.cs
+++ b/src/Meilisearch/Index.ForeignKeys.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Meilisearch
+{
+    public partial class Index
+    {
+        /// <summary>
+        /// Gets the foreign keys setting.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the foreign keys setting.</returns>
+        public async Task<IEnumerable<ForeignKey>> GetForeignKeysAsync(CancellationToken cancellationToken = default)
+        {
+            return await _http.GetFromJsonAsync<IEnumerable<ForeignKey>>($"indexes/{Uid}/settings/foreign-keys", cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Updates the foreign keys setting.
+        /// </summary>
+        /// <param name="foreignKeys">Collection of foreign keys.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task info of the asynchronous task.</returns>
+        public async Task<TaskInfo> UpdateForeignKeysAsync(IEnumerable<ForeignKey> foreignKeys, CancellationToken cancellationToken = default)
+        {
+            var responseMessage =
+                await _http.PutAsJsonAsync($"indexes/{Uid}/settings/foreign-keys", foreignKeys,
+                        Constants.JsonSerializerOptionsRemoveNulls, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            return await responseMessage.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Resets the foreign keys setting.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Returns the task info of the asynchronous task.</returns>
+        public async Task<TaskInfo> ResetForeignKeysAsync(CancellationToken cancellationToken = default)
+        {
+            var httpresponse = await _http.DeleteAsync($"indexes/{Uid}/settings/foreign-keys", cancellationToken)
+                .ConfigureAwait(false);
+            return await httpresponse.Content.ReadFromJsonAsync<TaskInfo>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Meilisearch/MeilisearchClient.cs
+++ b/src/Meilisearch/MeilisearchClient.cs
@@ -382,21 +382,29 @@ namespace Meilisearch
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for this call.</param>
         /// <returns>Successfulness of enabling as experimental feature.</returns>
-        public async Task<bool> EnableDynamicSearchRules(CancellationToken cancellationToken = default)
+        public Task<bool> EnableDynamicSearchRules(CancellationToken cancellationToken = default) => SetExperimentalFeature("dynamicSearchRules", true, cancellationToken);
+
+        /// <summary>
+        /// Toggles an experimental feature by its name.
+        /// </summary>
+        /// <param name="featureName">Name of the experimental feature, as returned by the experimental-features route.</param>
+        /// <param name="enabled">Whether the feature should be enabled.</param>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Successfulness of the toggle as experimental feature.</returns>
+        private async Task<bool> SetExperimentalFeature(string featureName, bool enabled, CancellationToken cancellationToken = default)
         {
             var responseMessage =
-                await _http.PatchAsJsonAsync("experimental-features", new
-                {
-                    dynamicSearchRules = true
-                }, cancellationToken: cancellationToken)
+                await _http.PatchAsJsonAsync("experimental-features",
+                    new Dictionary<string, bool> { [featureName] = enabled },
+                    cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
 
             var result = await responseMessage.Content
                 .ReadFromJsonAsync<JsonDocument>(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
-            return result.RootElement.TryGetProperty("dynamicSearchRules", out var dsrElement) &&
-                   dsrElement.GetBoolean();
+            return result.RootElement.TryGetProperty(featureName, out var featureElement) &&
+                   featureElement.GetBoolean() == enabled;
         }
 
         /// <summary>
@@ -469,6 +477,20 @@ namespace Meilisearch
 
             return responseMessage.StatusCode == HttpStatusCode.NoContent;
         }
+
+        /// <summary>
+        /// Enables foreign keys experimental feature.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Successfulness of enabling as experimental feature.</returns>
+        public Task<bool> EnableForeignKeys(CancellationToken cancellationToken = default) => SetExperimentalFeature("foreignKeys", true, cancellationToken);
+
+        /// <summary>
+        /// Disables foreign keys experimental feature.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token for this call.</param>
+        /// <returns>Successfulness of enabling as experimental feature.</returns>
+        public Task<bool> DisableForeignKeys(CancellationToken cancellationToken = default) => SetExperimentalFeature("foreignKeys", false, cancellationToken);
 
         /// <summary>
         /// Cancel tasks given a specific query.

--- a/src/Meilisearch/Settings.cs
+++ b/src/Meilisearch/Settings.cs
@@ -32,6 +32,14 @@ namespace Meilisearch
         [JsonPropertyName("displayedAttributes")]
         public IEnumerable<string> DisplayedAttributes { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets the foreign keys.
+        /// <remarks>This is an experimental Meilisearch feature (v1.39+).</remarks>
+        /// </summary>
+        [JsonPropertyName("foreignKeys")]
+        public IEnumerable<ForeignKey> ForeignKeys { get; set; }
+
         /// <summary>
         /// Gets or sets the stop-words list.
         /// </summary>

--- a/tests/Meilisearch.Tests/Models/VectorMovie.cs
+++ b/tests/Meilisearch.Tests/Models/VectorMovie.cs
@@ -17,4 +17,33 @@ namespace Meilisearch.Tests.Models
         [JsonPropertyName("_vectors")]
         public Dictionary<string, double[]> Vectors { get; set; }
     }
+
+    /// <summary>
+    /// Same documents as <see cref="VectorMovie"/>, shaped for a search made with
+    /// <c>retrieveVectors</c>: Meilisearch returns <c>_vectors</c> as an embedder object rather than
+    /// the bare array the documents were indexed with.
+    /// </summary>
+    public class VectorMovieWithEmbeddings
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("release_year")]
+        public int ReleaseYear { get; set; }
+
+        [JsonPropertyName("_vectors")]
+        public Dictionary<string, RetrievedEmbedder> Vectors { get; set; }
+    }
+
+    public class RetrievedEmbedder
+    {
+        [JsonPropertyName("embeddings")]
+        public double[][] Embeddings { get; set; }
+
+        [JsonPropertyName("regenerate")]
+        public bool Regenerate { get; set; }
+    }
 }

--- a/tests/Meilisearch.Tests/Movie.cs
+++ b/tests/Meilisearch.Tests/Movie.cs
@@ -81,4 +81,32 @@ namespace Meilisearch.Tests
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Naming convention used to match meilisearch.")]
         public IDictionary<string, JsonElement> _RankingScoreDetails { get; set; }
     }
+
+    /// <summary>
+    /// A movie hit from a federated multi-search, carrying the `_federation` metadata Meilisearch
+    /// adds to every hit.
+    /// </summary>
+    public class FederatedMovie
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Genre { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("_federation")]
+        public FederationMetadata Federation { get; set; }
+    }
+
+    public class FederationMetadata
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("indexUid")]
+        public string IndexUid { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("queriesPosition")]
+        public int QueriesPosition { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("weightedRankingScore")]
+        public double WeightedRankingScore { get; set; }
+    }
 }

--- a/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
+++ b/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 
 using Meilisearch.Tests.Fixtures;
+using Meilisearch.Tests.Models;
 
 using Xunit;
 
@@ -187,6 +188,77 @@ namespace Meilisearch.Tests
             // One hit per distinct genre value, per query.
             var distinct = await _fixture.DefaultClient.FederatedMultiSearchAsync<Movie>(query);
             distinct.Hits.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task FederatedSearchWithPerQueryFederationOptions()
+        {
+            // Both queries match the same two movies; the weights decide which index wins the merge.
+            var query = new FederatedMultiSearchQuery
+            {
+                Queries = new List<FederatedSearchQuery>
+                {
+                    new FederatedSearchQuery
+                    {
+                        IndexUid = _index1.Uid,
+                        Q = "Star Wars",
+                        FederationOptions = new FederatedSearchQueryOptions { Weight = 0.1M }
+                    },
+                    new FederatedSearchQuery
+                    {
+                        IndexUid = _index2.Uid,
+                        Q = "Star Wars",
+                        FederationOptions = new FederatedSearchQueryOptions { Weight = 1.0M }
+                    }
+                },
+                FederationOptions = new MultiSearchFederationOptions { Limit = 1 }
+            };
+
+            var result = await _fixture.DefaultClient.FederatedMultiSearchAsync<FederatedMovie>(query);
+
+            // Identical matches in both indexes, so the heavier query's hit is the one kept.
+            var hit = result.Hits.Should().ContainSingle().Subject;
+            hit.Name.Should().Be("Star Wars");
+            hit.Federation.IndexUid.Should().Be(_index2.Uid);
+            hit.Federation.WeightedRankingScore.Should().BeApproximately(1.0, 1e-6);
+        }
+
+        [Fact]
+        public async Task FederatedSearchWithHybridAndVector()
+        {
+            var vectorIndex1 = await _fixture.SetUpIndexForVectorSearch("VectorIndex-MultiSearch-Index1");
+            var vectorIndex2 = await _fixture.SetUpIndexForVectorSearch("VectorIndex-MultiSearch-Index2");
+
+            FederatedSearchQuery VectorQuery(string indexUid) => new FederatedSearchQuery
+            {
+                IndexUid = indexUid,
+                Q = string.Empty,
+                Hybrid = new HybridSearch { Embedder = "manual", SemanticRatio = 1.0f },
+                Vector = new[] { 0.1, 0.6, 0.8 },
+                RetrieveVectors = true
+            };
+
+            var query = new FederatedMultiSearchQuery
+            {
+                Queries = new List<FederatedSearchQuery>
+                {
+                    VectorQuery(vectorIndex1.Uid),
+                    VectorQuery(vectorIndex2.Uid)
+                },
+                FederationOptions = new MultiSearchFederationOptions { Limit = 2 }
+            };
+
+            var result = await _fixture.DefaultClient.FederatedMultiSearchAsync<VectorMovieWithEmbeddings>(query);
+
+            // The vector queried for is "Escape Room"'s own, so it ranks first in both indexes.
+            result.Hits.Should().HaveCount(2);
+            result.Hits.Should().OnlyContain(movie => movie.Title == "Escape Room");
+            // Meilisearch stores embeddings as f32, so the values come back slightly rounded.
+            result.Hits.First().Vectors["manual"].Embeddings.Should()
+                .ContainSingle().Which.Should().BeEquivalentTo(
+                    new[] { 0.1, 0.6, 0.8 },
+                    options => options.Using<double>(
+                        ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 1e-6)).WhenTypeIs<double>());
         }
     }
 }

--- a/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
+++ b/tests/Meilisearch.Tests/MultiIndexSearchTests.cs
@@ -140,5 +140,53 @@ namespace Meilisearch.Tests
 
             result.Hits.Should().HaveCount(2);
         }
+
+        [Fact]
+        public async Task FederatedSearchWithRankingScoreThreshold()
+        {
+            // "Iron Spider" matches "Iron Man" loosely, "Star Wars Harry" matches "Star Wars" well.
+            var query = new FederatedMultiSearchQuery
+            {
+                Queries = new List<FederatedSearchQuery>()
+                {
+                    new FederatedSearchQuery { IndexUid = _index1.Uid, Q = "Iron Spider" },
+                    new FederatedSearchQuery { IndexUid = _index2.Uid, Q = "Star Wars Harry" }
+                }
+            };
+
+            var unfiltered = await _fixture.DefaultClient.FederatedMultiSearchAsync<Movie>(query);
+            unfiltered.Hits.Should().HaveCount(2);
+
+            // The threshold is per query: only the loose match is dropped.
+            query.Queries[0].RankingScoreThreshold = 0.5M;
+
+            var filtered = await _fixture.DefaultClient.FederatedMultiSearchAsync<Movie>(query);
+            filtered.Hits.Should().ContainSingle().Which.Name.Should().Be("Star Wars");
+        }
+
+        [Fact]
+        public async Task FederatedSearchWithDistinct()
+        {
+            var query = new FederatedMultiSearchQuery
+            {
+                Queries = new List<FederatedSearchQuery>
+                {
+                    new FederatedSearchQuery { IndexUid = _index1.Uid, Q = "", Filter = "genre = 'SF'" },
+                    new FederatedSearchQuery { IndexUid = _index2.Uid, Q = "", Filter = "genre = 'SF'" }
+                }
+            };
+
+            var unfiltered = await _fixture.DefaultClient.FederatedMultiSearchAsync<Movie>(query);
+            unfiltered.Hits.Should().HaveCount(4);
+
+            foreach (var federatedQuery in query.Queries)
+            {
+                federatedQuery.Distinct = "genre";
+            }
+
+            // One hit per distinct genre value, per query.
+            var distinct = await _fixture.DefaultClient.FederatedMultiSearchAsync<Movie>(query);
+            distinct.Hits.Should().HaveCount(2);
+        }
     }
 }

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -157,7 +157,7 @@ namespace Meilisearch.Tests
                 DisplayedAttributes = new string[] { "name" },
                 RankingRules = new string[] { "typo" },
                 FilterableAttributes = new FilterableAttribute[] { "genre" },
-                ForeignKeys = new[]{ new ForeignKey { ForeignIndexUid = "index_1", FieldName = "index_1_id"}},
+                ForeignKeys = new[] { new ForeignKey { ForeignIndexUid = "index_1", FieldName = "index_1_id" } },
                 Dictionary = new string[] { "dictionary" }
             };
             await AssertUpdateSuccess(_index.UpdateSettingsAsync, newSettings);

--- a/tests/Meilisearch.Tests/SettingsTests.cs
+++ b/tests/Meilisearch.Tests/SettingsTests.cs
@@ -36,6 +36,7 @@ namespace Meilisearch.Tests
                 DistinctAttribute = null,
                 SearchableAttributes = new string[] { "*" },
                 DisplayedAttributes = new string[] { "*" },
+                ForeignKeys = new List<ForeignKey>(),
                 Dictionary = Array.Empty<string>(),
                 StopWords = Array.Empty<string>(),
                 SeparatorTokens = new List<string> { },
@@ -80,6 +81,10 @@ namespace Meilisearch.Tests
 
         public async Task InitializeAsync()
         {
+            // foreignKeys is an experimental feature, disabled by default: without this opt-in the
+            // server omits the setting entirely and every foreignKeys assertion sees null.
+            Assert.True(await _fixture.DefaultClient.EnableForeignKeys());
+
             await _fixture.DeleteAllIndexes(); // Test context cleaned for each [Fact]
             _index = await _fixture.SetUpBasicIndex("BasicIndex-SettingsTests");
         }
@@ -152,6 +157,7 @@ namespace Meilisearch.Tests
                 DisplayedAttributes = new string[] { "name" },
                 RankingRules = new string[] { "typo" },
                 FilterableAttributes = new FilterableAttribute[] { "genre" },
+                ForeignKeys = new[]{ new ForeignKey { ForeignIndexUid = "index_1", FieldName = "index_1_id"}},
                 Dictionary = new string[] { "dictionary" }
             };
             await AssertUpdateSuccess(_index.UpdateSettingsAsync, newSettings);
@@ -259,6 +265,35 @@ namespace Meilisearch.Tests
 
             await AssertResetSuccess(_index.ResetFilterableAttributesAsync);
             await AssertGetEquality(_index.GetFilterableAttributesAsync, _defaultSettings.FilterableAttributes);
+        }
+
+        [Fact]
+        public async Task GetForeignKeys()
+        {
+            await AssertGetEquality(_index.GetForeignKeysAsync, _defaultSettings.ForeignKeys);
+        }
+
+        [Fact]
+        public async Task UpdateForeignKeys()
+        {
+            IEnumerable<ForeignKey> newForeignKeys = new[]
+            {
+                new ForeignKey { ForeignIndexUid = "index_2", FieldName = "index_2_id" },
+                new ForeignKey { ForeignIndexUid = "index_3", FieldName = "index_3_id" }
+            };
+            await AssertUpdateSuccess(_index.UpdateForeignKeysAsync, newForeignKeys);
+            await AssertGetEquality(_index.GetForeignKeysAsync, newForeignKeys);
+        }
+
+        [Fact]
+        public async Task ResetForeignKeys()
+        {
+            IEnumerable<ForeignKey> newForeignKeys = new[] { new ForeignKey { ForeignIndexUid = "index_4", FieldName = "index_4_id" } };
+            await AssertUpdateSuccess(_index.UpdateForeignKeysAsync, newForeignKeys);
+            await AssertGetEquality(_index.GetForeignKeysAsync, newForeignKeys);
+
+            await AssertResetSuccess(_index.ResetForeignKeysAsync);
+            await AssertGetEquality(_index.GetForeignKeysAsync, _defaultSettings.ForeignKeys);
         }
 
         [Fact]
@@ -777,6 +812,7 @@ namespace Meilisearch.Tests
                 DistinctAttribute = inputSettings.DistinctAttribute ?? defaultSettings.DistinctAttribute,
                 SearchableAttributes = inputSettings.SearchableAttributes ?? defaultSettings.SearchableAttributes,
                 DisplayedAttributes = inputSettings.DisplayedAttributes ?? defaultSettings.DisplayedAttributes,
+                ForeignKeys = inputSettings.ForeignKeys ?? defaultSettings.ForeignKeys,
                 StopWords = inputSettings.StopWords ?? defaultSettings.StopWords,
                 SeparatorTokens = inputSettings.SeparatorTokens ?? defaultSettings.SeparatorTokens,
                 NonSeparatorTokens = inputSettings.NonSeparatorTokens ?? defaultSettings.NonSeparatorTokens,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #746 

## What does this PR do?
- Adds support for the experimental setting foreign keys.

## AI disclosure
I used Claude for writing tests and running end-to-end tests against a live Meilisearch container, as well as reviewing the PR and code changes.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing experimental foreign key settings, including retrieval, updates, resets, and feature toggling.
  * Included foreign key settings in index settings responses.
  * Expanded federated search with distinct filtering, ranking score thresholds, per-query options, hybrid search, vector search, and vector retrieval.

* **Documentation**
  * Added usage examples for foreign key settings.

* **Tests**
  * Added coverage for foreign key management and enhanced federated search capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->